### PR TITLE
Fixes #12.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+	
+3.2.10  - Cmake fix (#12) -- spaces in COMMAND
+	- moved to GitHub
 3.2.9   October 29, 2017
 	- bug fix for #62 -- stalled test in some environments
 	

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -8,7 +8,7 @@ set(srcs Assert.F90)
 
 # Generate AssertArray files:  AssertArrays.fh, generated.inc, and AssertXYZ?.F90
 execute_process(
-   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/GenerateAssertsOnArrays.py --maxRank ${MAX_RANK}
+   COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/GenerateAssertsOnArrays.py" "--maxRank" "${MAX_RANK}"
    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
    RESULT_VARIABLE generated_result
    OUTPUT_VARIABLE generated_output


### PR DESCRIPTION
Not clear why exactly this COMMAND case needs quotes when others apparently do not.