### PR TITLE
Fixes #19 - improved build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
    - make -j4 
    # Test
    - make -j4 tests
+   - ctest
    # install
    - make install
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,9 @@ enable_testing()
 #---------------------------
 # Main configuration options
 #---------------------------
-OPTION(USE_MPI "Use MPI for parallel runs" NO)
 OPTION(USE_OPENMP "Use OPENMP for parallel runs" NO)
+set(MPI OFF CACHE BOOL "Build with MPI support.")
+set(OPENMP OFF CACHE BOOL "Build with OpenMP support.")
 set(MAX_ASSERT_RANK 5 CACHE STRING "Maximum array rank for generated code.")
 
 
@@ -122,6 +123,9 @@ endif()
 
 set(CMAKE_SHARED_LIBRARY_LINK_Fortran_FLAGS "")
 set(CMAKE_SKIP_RPATH ON)
+
+add_custom_target(tests COMMAND ${CRMAKE_CTEST_COMMAND})
+
 
 add_subdirectory (src)
 add_subdirectory (tests)

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -19,6 +19,7 @@ set (mpi_srcs
   pFUnit.F90
   )
 add_library(pfunit STATIC ${srcs} ${mpi_srcs})
+add_dependencies(pfunit funit)
 if (NOT FTL)
   add_dependencies(pfunit gFTL)
 endif()

--- a/tests/core-tests/CMakeLists.txt
+++ b/tests/core-tests/CMakeLists.txt
@@ -77,10 +77,10 @@ set(SERIAL_TEST_SRCS
 
 list(APPEND SERIAL_TEST_SRCS Test_BasicOpenMP.F90)
 
-add_library(funit_tests STATIC ${SERIAL_TEST_SRCS} ${OTHER_SOURCES})
+add_library(funit_tests EXCLUDE_FROM_ALL STATIC ${SERIAL_TEST_SRCS} ${OTHER_SOURCES})
 target_link_libraries(funit_tests funit)
 
-add_library(new_stests ${new_tests} ${OTHER_SOURCES})
+add_library(new_stests EXCLUDE_FROM_ALL ${new_tests} ${OTHER_SOURCES})
 target_link_libraries(new_stests funit)
 add_executable (new_tests.x EXCLUDE_FROM_ALL ${CMAKE_SOURCE_DIR}/include/driver.F90)
 set_source_files_properties(${CMAKE_SOURCE_DIR}/include/driver.F90 PROPERTIES COMPILE_DEFINITIONS _TEST_SUITES="testSuites.inc")
@@ -88,18 +88,11 @@ target_link_libraries(new_tests.x new_stests funit)
 
 
 
-add_executable (funit_tests.x serial_tests.F90)
+add_executable (funit_tests.x EXCLUDE_FROM_ALL serial_tests.F90)
 target_link_libraries(funit_tests.x funit_tests funit)
 
-add_custom_target(tests
-  COMMAND funit_tests.x
-  COMMAND new_tests.x
-  DEPENDS funit_tests.x new_tests.x WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  )
-
 set(REMOTE_EXE remote.x)
-add_executable (${REMOTE_EXE} serialRemoteProgram.F90)
+add_executable (${REMOTE_EXE} EXCLUDE_FROM_ALL serialRemoteProgram.F90)
 target_link_libraries(${REMOTE_EXE} funit funit_tests)
 #  if (MPI)
 #    target_link_libraries(${REMOTE_EXE} ${MPI_Fortran_LIBRARIES} )
@@ -113,14 +106,17 @@ add_test(NAME new_tests
   COMMAND new_tests.x
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
+add_dependencies(tests new_tests.x)
 set_property (TEST new_tests
     PROPERTY FAIL_REGULAR_EXPRESSION "Encountered 1 or more failures/errors during testing"
     )
 
 add_test(NAME old_tests
-  COMMAND tests/funit_tests.x
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMAND funit_tests.x
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
+add_dependencies(tests funit_tests.x)
+
 set_property (TEST old_tests
     PROPERTY FAIL_REGULAR_EXPRESSION "Encountered 1 or more failures/errors during testing"
     )

--- a/tests/mpi-tests/CMakeLists.txt
+++ b/tests/mpi-tests/CMakeLists.txt
@@ -12,10 +12,10 @@ list(APPEND PARALLEL_TEST_SRCS Test_MpiException.F90)
 list(APPEND PARALLEL_TEST_SRCS Test_MpiTestCase.F90)
 list(APPEND PARALLEL_TEST_SRCS Test_MpiParameterizedTestCase.F90)
 
-add_library(pfunittests STATIC ${SERIAL_TEST_SRCS} ${PARALLEL_TEST_SRCS} ${OTHER_SOURCES})
+add_library(pfunittests EXCLUDE_FROM_ALL STATIC ${SERIAL_TEST_SRCS} ${PARALLEL_TEST_SRCS} ${OTHER_SOURCES})
 target_link_libraries(pfunittests pfunit funit)
 
-add_executable (parallel_tests.x parallel_tests.F90)
+add_executable (parallel_tests.x EXCLUDE_FROM_ALL parallel_tests.F90)
 target_link_libraries(parallel_tests.x ${MPI_Fortran_LIBRARIES} pfunittests pfunit funit)
 
 #set(REMOTE_EXE remote.x)
@@ -33,18 +33,17 @@ if (MPI_USE_MPIEXEC)
   # standard mpiexec.  Not the default because we've found the hardcoded mpirun more portable.
   # There may be situations, however, where the FindMPI-based target will work better.
   #
-  add_custom_target(mpi-tests
+  add_test(NAME mpi-tests
     COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} tests/parallel_tests.x
-    DEPENDS paralell_tests.x
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 else()
   #
   # Add the target for executing the tests with a hardcoded call to mpirun.
   #
-  add_custom_target(mpi-tests
+  add_test(NAME mpi-tests
     COMMAND mpirun ${MPIEXEC_PREFLAGS} -np 4 ./parallel_tests.x
-    DEPENDS funit_tests.x parallel_tests.x
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   #
 endif()
+add_dependencies(tests parallel_tests.x)


### PR DESCRIPTION
- Corrected MPI and OpenMP as cached BOOL cmake options.
- Added top-level "tests" target
  . tests depends on executables defined in the various test subdirectories
- ctest now works as intended.

% cmake .. [-DMPI=YES]
% make
% make tests
% ctest