### PR TITLE
Support Cray Compiler Environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,9 +159,25 @@ elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL PGI)
     add_definitions(-DPGI)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS_DEBUG} -O0 -g -traceback -Mallocatable=03 -Mbounds -Mchkfpstk -Mchkstk")
 
+elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL Cray)
+
+    # Use the C compiler as a proxy for the Fortran compiler version. This
+    # doesn't work for compilers which do not come as part of a suite but
+    # CCE is a suite so everything is fine.
+    #
+    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 8.5.4)
+      message( FATAL_ERROR "Cray compiler version number ${CMAKE_C_COMPILER_VERSION} < 8.4.6 minimum" )
+    endif()
+
+    # Use Cray
+    add_definitions(-DCray)
+    add_definitions(-DSTRINGIFY_SIMPLE)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS_DEBUG} -G0 -Rb ${CMAKE_Fortran_FLAGS}")
+    set(OPENMP_FLAGS " ")
+
 else()
 
-    message( FATAL_ERROR "Unrecognized compiler. Please use ifort, gfortran, gfortran-mp-4.8, PGI, or nagfor" )
+    message( FATAL_ERROR "Unrecognized compiler. Please use ifort, gfortran, gfortran-mp-4.8, pgfortran, nagfor or cce" )
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,9 +161,9 @@ elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL PGI)
 
 elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL Cray)
 
-    # Use the C compiler as a proxy for the Fortran compiler version. This
-    # doesn't work for compilers which do not come as part of a suite but
-    # CCE is a suite so everything is fine.
+    # The Fortran module does not set a variable to the compiler version
+    # number like the C module does. Since CCE is a suite of compilers we
+    # can use the C version as a proxy for the Fortran version.
     #
     if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 8.5.4)
       message( FATAL_ERROR "Cray compiler version number ${CMAKE_C_COMPILER_VERSION} < 8.4.6 minimum" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,8 +165,8 @@ elseif(${CMAKE_Fortran_COMPILER_ID} STREQUAL Cray)
     # number like the C module does. Since CCE is a suite of compilers we
     # can use the C version as a proxy for the Fortran version.
     #
-    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 8.5.4)
-      message( FATAL_ERROR "Cray compiler version number ${CMAKE_C_COMPILER_VERSION} < 8.4.6 minimum" )
+    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 8.6.0)
+      message( FATAL_ERROR "Cray compiler version number ${CMAKE_C_COMPILER_VERSION} < 8.6.0 minimum" )
     endif()
 
     # Use Cray

--- a/source/XmlPrinter.F90
+++ b/source/XmlPrinter.F90
@@ -168,7 +168,7 @@ contains
               'Location: ', cleanXml(trim(locationString)), ', '
          write(this%unit,'(a)',advance='no') &
               cleanXml(trim(exceptions(j)%getMessage()))
-         write(this%unit,*) '"/>'
+         write(this%unit,'(a)') '"/>'
       end do
       write(this%unit,'(a)') '</testcase>'
 

--- a/source/XmlPrinter.F90
+++ b/source/XmlPrinter.F90
@@ -168,7 +168,7 @@ contains
               'Location: ', cleanXml(trim(locationString)), ', '
          write(this%unit,'(a)',advance='no') &
               cleanXml(trim(exceptions(j)%getMessage()))
-         write(this%unit,*) '"/>'
+         write(this%unit,*) ' "/>'
       end do
       write(this%unit,'(a)') '</testcase>'
 

--- a/source/XmlPrinter.F90
+++ b/source/XmlPrinter.F90
@@ -168,7 +168,7 @@ contains
               'Location: ', cleanXml(trim(locationString)), ', '
          write(this%unit,'(a)',advance='no') &
               cleanXml(trim(exceptions(j)%getMessage()))
-         write(this%unit,*) ' "/>'
+         write(this%unit,*) '"/>'
       end do
       write(this%unit,'(a)') '</testcase>'
 

--- a/source/pFUnitPackage.F90
+++ b/source/pFUnitPackage.F90
@@ -36,7 +36,11 @@
 #endif
 
 #define TOKEN(a) a
+#ifdef Cray
+#define RENAME(item) TOKEN(item) => item
+#else
 #define RENAME(item) TOKEN(PFUNIT_PREFIX)TOKEN(item) => item
+#endif
 
 module pFUnit
 

--- a/source/pFUnitPackage.F90
+++ b/source/pFUnitPackage.F90
@@ -35,11 +35,18 @@
 #define PFUNIT_PREFIX pf_
 #endif
 
-#define TOKEN(a) a
-#ifdef Cray
-#define RENAME(item) TOKEN(item) => item
+! The Cray preprocessor for Fortran does not appear to perform recursive
+! expansion. Using the normal macro would lead to
+! "PFUNIT_PREFIX<item> => <item>" instead of the expected result
+! "<prefix><item> => <item>".
+!
+! To get round these issues the "pf_" prefix is hard coded.
+
+#define WORD(word) word
+#ifndef Cray
+#define RENAME(item) WORD(PFUNIT_PREFIX)item => item
 #else
-#define RENAME(item) TOKEN(PFUNIT_PREFIX)TOKEN(item) => item
+#define RENAME(item) WORD(pf_)item => item
 #endif
 
 module pFUnit

--- a/tests/Test_MockRepository.F90
+++ b/tests/Test_MockRepository.F90
@@ -40,7 +40,7 @@ module SUT_mod
 contains
 
    subroutine method1(this)
-      class (SUT), intent(in) :: this
+      class (SUT), intent(inout) :: this
    end subroutine method1
 
 end module SUT_mod
@@ -84,7 +84,7 @@ contains
    end subroutine verifyMocking
 
    subroutine method1(this)
-      class (MockSUT), intent(in) :: this
+      class (MockSUT), intent(inout) :: this
       call this%mocker%hasCalled(this, 'method1')
    end subroutine method1
 

--- a/tests/Test_XmlPrinter.F90
+++ b/tests/Test_XmlPrinter.F90
@@ -157,10 +157,10 @@ contains
 #endif
 '<testcase name="successtest[]''"/>', &
 '<testcase name="failtest[]''">', &
-'<failure message="Location: [[unknown location]], [invalid] "/>', &
+'<failure message="Location: [[unknown location]], [invalid]"/>', &
 '</testcase>', &
 '<testcase name="failtest[]''">', &
-'<failure message="Location: [[unknown location]], ''test'' "/>', &
+'<failure message="Location: [[unknown location]], ''test''"/>', &
 '</testcase>', &
 '</testsuite>' /)
 

--- a/tests/Test_XmlPrinter.F90
+++ b/tests/Test_XmlPrinter.F90
@@ -106,7 +106,7 @@ contains
       ! Validate the file against the de facto JUnit xsd.
       ! If xmlint not found, just move on quietly.
       command = 'xmllint --version > /dev/null 2>&1'
-#if defined(NAG) || defined(IBM)
+#if defined(NAG) || defined(IBM) || defined(Cray)
       ! Fortran 2008 compliant version.
       call execute_command_line(command,exitstat=stat)
 #else
@@ -115,7 +115,7 @@ contains
       if (stat == 0) then
          command = 'xmllint --noout --nowarning --schema ' // trim(xsdPath) &
               // ' ' // trim(fileName) // ' 2> ' // outFile
-#if defined(NAG) || defined(IBM)
+#if defined(NAG) || defined(IBM) || defined(Cray)
          ! Fortran 2008 compliant version.
          call execute_command_line(command,exitstat=stat)
 #else
@@ -149,7 +149,7 @@ contains
      character(len=100), dimension(9) :: expected 
 
      expected=(/ character(len=100) :: &
-#ifndef PGI
+#if !defined( PGI ) && !defined( Cray )
 '<testsuite name="suitename[[]]''''" errors="0" failures="2" tests="0" time=".0000">', &
 #else
 '<testsuite name="suitename[[]]''''" errors="0" failures="2" tests="0"&


### PR DESCRIPTION
A branch for supporting the Cray Compiler Environment (CCE) existed on SourceForge but it has not been migrated. More than that it was quite elderly and had not been kept up to date with the trunk.

This branch re-implements those changes against the head of trunk and has been tested against an XC40. It has been tested not only with the Cray compiler but also Intel and GNU so it should not break anything else.