### PR TITLE
pFUnitParser now provides a "-markers" option to use linemarkers rather than #line directives

### DIFF
--- a/Examples/Fixture/GNUmakefile
+++ b/Examples/Fixture/GNUmakefile
@@ -9,15 +9,11 @@ VPATH = . $(SRC_DIR) $(TEST_DIR)
 
 include $(PFUNIT)/include/base.mk
 
-ifeq ($(USEMPI),YES)
-   FC=mpif90
-endif
-
 EXE = tests$(EXE_EXT)
 
 all: $(EXE)
 ifeq ($(USEMPI),YES)
-	mpirun -np 1 ./$(EXE)
+	mpiexec -n 1 ./$(EXE)
 else
 	./$(EXE)
 endif

--- a/Examples/Fixture/tests/GNUmakefile
+++ b/Examples/Fixture/tests/GNUmakefile
@@ -17,7 +17,7 @@ ifndef SKIP_INTENTIONALLY_BROKEN
 endif
 
 %.F90: %.pf
-	$(PFUNIT)/bin/pFUnitParser.py $<  $@
+	$(PFUNIT)/bin/pFUnitParser.py $(FUFLAGS) $<  $@
 
 %$(OBJ_EXT): %.F90
 	$(FC) -c $(FFLAGS) $(FPPFLAGS) $<

--- a/Examples/MPI_Halo/GNUmakefile
+++ b/Examples/MPI_Halo/GNUmakefile
@@ -9,14 +9,10 @@ VPATH = . $(SRC_DIR) $(TEST_DIR)
 
 include $(PFUNIT)/include/base.mk
 
-ifeq ($(USEMPI),YES)
-   MPIF90=mpif90
-endif
-
 EXE = tests$(EXE_EXT)
 
 all: $(EXE)
-	mpirun -np 4 ./$(EXE)
+	mpiexec -n 4 ./$(EXE)
 
 SUT:
 	make -C $(SRC_DIR) SUT

--- a/Examples/MPI_Halo/tests/GNUmakefile
+++ b/Examples/MPI_Halo/tests/GNUmakefile
@@ -17,7 +17,7 @@ ifndef SKIP_INTENTIONALLY_BROKEN
 endif
 
 %.F90: %.pf
-	$(PFUNIT)/bin/pFUnitParser.py $<  $@
+	$(PFUNIT)/bin/pFUnitParser.py $(FUFLAGS) $<  $@
 
 %$(OBJ_EXT): %.F90
 	$(MPIF90) -c $(FFLAGS) $<

--- a/Examples/MPI_SimpleParameterizedTest/GNUmakefile
+++ b/Examples/MPI_SimpleParameterizedTest/GNUmakefile
@@ -8,14 +8,10 @@ VPATH = . $(TEST_DIR)
 
 include $(PFUNIT)/include/base.mk
 
-ifeq ($(USEMPI),YES)
-   MPIF90=mpif90
-endif
-
 EXE = tests$(EXE_EXT)
 
 all: $(EXE)
-	mpirun -np 4 ./$(EXE)
+	mpiexec -n 4 ./$(EXE)
 
 SUT:
 	make -C $(TEST_DIR) tests

--- a/Examples/MPI_SimpleParameterizedTest/tests/GNUmakefile
+++ b/Examples/MPI_SimpleParameterizedTest/tests/GNUmakefile
@@ -19,7 +19,7 @@ ifndef SKIP_INTENTIONALLY_BROKEN
 endif
 
 %.F90: %.pf
-	$(PFUNIT)/bin/pFUnitParser.py $<  $@
+	$(PFUNIT)/bin/pFUnitParser.py $(FUFLAGS) $<  $@
 
 %$(OBJ_EXT): %.F90
 	$(MPIF90) -c $(FFLAGS) $<

--- a/Examples/ParameterizedTest/GNUmakefile
+++ b/Examples/ParameterizedTest/GNUmakefile
@@ -9,15 +9,11 @@ VPATH = . $(SRC_DIR) $(TEST_DIR)
 
 include $(PFUNIT)/include/base.mk
 
-ifeq ($(USEMPI),YES)
-   FC=mpif90
-endif
-
 EXE = tests$(EXE_EXT)
 
 all: $(EXE)
 ifeq ($(USEMPI),YES)
-	mpirun -np 1 ./$(EXE)
+	mpiexec -n 1 ./$(EXE)
 else
 	./$(EXE)
 endif

--- a/Examples/ParameterizedTest/tests/GNUmakefile
+++ b/Examples/ParameterizedTest/tests/GNUmakefile
@@ -13,7 +13,7 @@ testSuites.inc: $(SRCS)
 FFLAGS += -I$(SRC_DIR) -I$(PFUNIT)/mod
 
 %.F90: %.pf
-	$(PFUNIT)/bin/pFUnitParser.py $<  $@
+	$(PFUNIT)/bin/pFUnitParser.py $(FUFLAGS) $<  $@
 
 %$(OBJ_EXT): %.F90
 	$(FC) -c $(FFLAGS) $<

--- a/Examples/Robust/GNUmakefile
+++ b/Examples/Robust/GNUmakefile
@@ -9,10 +9,6 @@ VPATH = . $(SRC_DIR) $(TEST_DIR)
 
 include $(PFUNIT)/include/base.mk
 
-ifeq ($(USEMPI),YES)
-   FC=mpif90
-endif
-
 EXE = tests$(EXE_EXT)
 
 # NOTE: use the -robust flag
@@ -22,7 +18,7 @@ ifeq ($(USEMPI),YES)
 	echo            driver.F90 will call mpirun on itself with robust set.
 	echo            "Top" level mpirun not needed, may be problemmatic.
 	./$(EXE) -robust
-	# mpirun -np 1 ./$(EXE) -robust
+	# mpiexec -n 1 ./$(EXE) -robust
 else
 	./$(EXE) -robust -max-timeout-duration 0.16 -max-launch-duration 4.72
 endif

--- a/Examples/Robust/GNUmakefile
+++ b/Examples/Robust/GNUmakefile
@@ -14,9 +14,11 @@ EXE = tests$(EXE_EXT)
 # NOTE: use the -robust flag
 all: $(EXE)
 ifeq ($(USEMPI),YES)
-	echo  Warning:  Testing -robust flag with MPI, robust will override.
-	echo            driver.F90 will call mpirun on itself with robust set.
-	echo            "Top" level mpirun not needed, may be problemmatic.
+	@echo
+	@echo 'Warning:  Testing -robust flag with MPI, robust will override.'
+	@echo '          driver.F90 will call mpirun on itself with robust set.'
+	@echo '          "Top" level mpirun not needed, may be problemmatic.'
+	@echo
 	./$(EXE) -robust
 	# mpiexec -n 1 ./$(EXE) -robust
 else

--- a/Examples/Robust/tests/GNUmakefile
+++ b/Examples/Robust/tests/GNUmakefile
@@ -17,7 +17,7 @@ ifndef SKIP_INTENTIONALLY_BROKEN
 endif
 
 %.F90: %.pf
-	$(PFUNIT)/bin/pFUnitParser.py $<  $@
+	$(PFUNIT)/bin/pFUnitParser.py $(FUFLAGS) $<  $@
 
 %$(OBJ_EXT): %.F90
 	$(FC) -c $(FFLAGS) $<

--- a/Examples/Simple/GNUmakefile
+++ b/Examples/Simple/GNUmakefile
@@ -36,12 +36,6 @@ ifeq ($(UNAME),Windows)
 	endif
 endif
 
-# The following may be redundant since FC should already be
-# appropriately set in include/base.mk.
-ifeq ($(USEMPI),YES)
-   FC=mpif90
-endif
-
 EXE = tests$(EXE_EXT)
 ifneq ($(UNAME),Windows)
 	LIBS = -L$(PFUNIT)/lib -lpfunit 
@@ -51,14 +45,8 @@ endif
 
 all: $(EXE)
 
-# ifeq ($(USEMPI),YES)
-# 	mpirun -np 1 ./$(EXE)
-# else
-# 	./$(EXE)
-# endif
-
 ifeq ($(USEMPI),YES)
-	mpirun -np 1 ./$(EXE) -xml tests.xml
+	mpiexec -n 1 ./$(EXE) -xml tests.xml
 else
 	./$(EXE) -xml tests.xml
 endif

--- a/Examples/Simple/tests/GNUmakefile
+++ b/Examples/Simple/tests/GNUmakefile
@@ -36,7 +36,7 @@ ifneq ($(UNAME),Windows)
 endif
 
 %.F90: %.pf
-	$(PFUNIT)/bin/pFUnitParser.py $<  $@
+	$(PFUNIT)/bin/pFUnitParser.py $(FUFLAGS) $<  $@
 
 %$(OBJ_EXT): %.F90
 	$(FC) -c $(FFLAGS) $(FPPFLAGS) $<

--- a/bin/pFUnitParser.py
+++ b/bin/pFUnitParser.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# For python 2.6-2.7
+# For python 2.7
 from __future__ import print_function
 
 from os.path import *
@@ -21,8 +21,23 @@ assertVariants += '|GreaterThanOrEqual|IsMemberOf|Contains|Any|All|NotAll|None'
 assertVariants += '|IsPermutationOf|ExceptionRaised|SameShape|IsNaN|IsFinite'
 
 
-def cppSetLineAndFile(line, file):
-    return "#line " + str(line) + ' "' + file + '"\n'
+def cpp_set_line(line, filename):
+    return "#line " + str(line) + ' "' + filename + '"\n'
+
+
+def compiler_set_line(line, filename=None):
+    '''
+    Returns a string holding a linemarker as understood by compilers.
+
+    Currently the flags which may appear in such a linemarker are not
+    supported. These are mostly related to #include debris so are of low
+    priority at the moment.
+    '''
+    linemarker = '#' + str(line)
+    if filename:
+        linemarker += ' "' + filename + '"'
+    linemarker += '\n'
+    return linemarker
 
 
 def getSubroutineName(line):
@@ -276,7 +291,8 @@ class AtAssert(Action):
     def action(self, m, line):
         p = self.parser
 
-        p.outputFile.write(cppSetLineAndFile(p.currentLineNumber, p.fileName))
+        p.outputFile.write(self.parser.set_line(p.currentLineNumber,
+                                                p.fileName))
         p.outputFile.write("  call assert" + m.groups()[0]
                            + "(" + m.groups()[1] + ", &\n")
         self.appendSourceLocation(p.outputFile,
@@ -284,7 +300,7 @@ class AtAssert(Action):
                                   p.currentLineNumber)
         p.outputFile.write(" )\n")
         p.outputFile.write("  if (anyExceptions()) return\n")
-        fragment = cppSetLineAndFile(p.currentLineNumber+1, p.fileName)
+        fragment = self.parser.set_line(p.currentLineNumber+1, p.fileName)
         p.outputFile.write(fragment)
 
 
@@ -322,7 +338,8 @@ class AtAssertAssociated(Action):
         # print(9000,line)
         # print(9001,args)
 
-        p.outputFile.write(cppSetLineAndFile(p.currentLineNumber, p.fileName))
+        p.outputFile.write(self.parser.set_line(p.currentLineNumber,
+                                                p.fileName))
         if len(args) > 1:
             if re.match('.*message=.*', args[1], re.IGNORECASE):
                 p.outputFile.write("  call assertTrue(associated("
@@ -342,7 +359,7 @@ class AtAssertAssociated(Action):
                                   p.currentLineNumber)
         p.outputFile.write(" )\n")
         p.outputFile.write("  if (anyExceptions()) return\n")
-        fragment = cppSetLineAndFile(p.currentLineNumber+1, p.fileName)
+        fragment = self.parser.set_line(p.currentLineNumber+1, p.fileName)
         p.outputFile.write(fragment)
 
 
@@ -392,7 +409,8 @@ class AtAssertNotAssociated(Action):
         # print(9000,line)
         # print(9001,args)
 
-        p.outputFile.write(cppSetLineAndFile(p.currentLineNumber, p.fileName))
+        p.outputFile.write(self.parser.set_line(p.currentLineNumber,
+                                                p.fileName))
         if len(args) > 1:
             if re.match('.*message=.*', args[1], re.IGNORECASE):
                 p.outputFile.write("  call assertFalse(associated("
@@ -412,7 +430,7 @@ class AtAssertNotAssociated(Action):
                                   p.currentLineNumber)
         p.outputFile.write(" )\n")
         p.outputFile.write("  if (anyExceptions()) return\n")
-        fragment = cppSetLineAndFile(p.currentLineNumber + 1, p.fileName)
+        fragment = self.parser.set_line(p.currentLineNumber + 1, p.fileName)
         p.outputFile.write(fragment)
 
 
@@ -446,7 +464,8 @@ class AtAssertEqualUserDefined(Action):
 
         args = parseArgsFirstSecondRest('@assertequaluserdefined', line)
 
-        p.outputFile.write(cppSetLineAndFile(p.currentLineNumber, p.fileName))
+        p.outputFile.write(self.parser.set_line(p.currentLineNumber,
+                                                p.fileName))
         if len(args) > 2:
             p.outputFile.write("  call assertTrue(" + args[0]
                                + "==" + args[1] + ", " + args[2] + ", &\n")
@@ -461,7 +480,7 @@ class AtAssertEqualUserDefined(Action):
                                   p.currentLineNumber)
         p.outputFile.write(" )\n")
         p.outputFile.write("  if (anyExceptions()) return\n")
-        fragment = cppSetLineAndFile(p.currentLineNumber + 1, p.fileName)
+        fragment = self.parser.set_line(p.currentLineNumber + 1, p.fileName)
         p.outputFile.write(fragment)
 
 
@@ -495,7 +514,8 @@ class AtAssertEquivalent(Action):
 
         args = parseArgsFirstSecondRest('@assertequivalent', line)
 
-        p.outputFile.write(cppSetLineAndFile(p.currentLineNumber, p.fileName))
+        p.outputFile.write(self.parser.set_line(p.currentLineNumber,
+                                                p.fileName))
         if len(args) > 2:
             p.outputFile.write("  call assertTrue(" + args[0]
                                + ".eqv." + args[1] + ", " + args[2] + ", &\n")
@@ -510,7 +530,7 @@ class AtAssertEquivalent(Action):
                                   p.currentLineNumber)
         p.outputFile.write(" )\n")
         p.outputFile.write("  if (anyExceptions()) return\n")
-        fragment = cppSetLineAndFile(p.currentLineNumber + 1, p.fileName)
+        fragment = self.parser.set_line(p.currentLineNumber + 1, p.fileName)
         p.outputFile.write(fragment)
 
 
@@ -532,7 +552,8 @@ class AtMpiAssert(Action):
     def action(self, m, line):
         p = self.parser
 
-        p.outputFile.write(cppSetLineAndFile(p.currentLineNumber, p.fileName))
+        p.outputFile.write(self.parser.set_line(p.currentLineNumber,
+                                                p.fileName))
         p.outputFile.write("  call assert"
                            + m.groups()[0] + "(" + m.groups()[1] + ", &\n")
         self.appendSourceLocation(p.outputFile,
@@ -545,7 +566,7 @@ class AtMpiAssert(Action):
             p.outputFile.write("  if (anyExceptions("
                                + p.currentSelfObjectName
                                + "%context)) return\n")
-        fragment = cppSetLineAndFile(p.currentLineNumber + 1, p.fileName)
+        fragment = self.parser.set_line(p.currentLineNumber + 1, p.fileName)
         p.outputFile.write(fragment)
 
 
@@ -610,11 +631,16 @@ class AtTestParameter(Action):
 
 
 class Parser():
-    def __init__(self, inputFileName, outputFileName):
+    def __init__(self, inputFileName, outputFileName, use_markers):
         def getBaseName(fileName):
             from os.path import basename, splitext
             base = basename(fileName)
             return splitext(base)[0]
+
+        if use_markers:
+            self.set_line = compiler_set_line
+        else:
+            self.set_line = cpp_set_line
 
         self.fileName = inputFileName
         self.inputFile = open(inputFileName, 'r')
@@ -988,10 +1014,32 @@ class Parser():
         self.outputFile.close()
 
 
+def process_cli():
+    '''
+    Processes the arguments passed on the command line interface.
+
+    Returns a tuple of source filename (str), target filename (str) and
+    whether to insert linemarkers rather than #line directives (bool).
+    '''
+    import argparse
+
+    description = 'Converts a pFUnit .pf file into compilable Fortran source.'
+    cli_parser = argparse.ArgumentParser(description=description,
+                                         add_help=False)
+    cli_parser.add_argument('-help', '-h', '--help', action='help',
+                            help='Display this help and stop')
+    cli_parser.add_argument('-markers', action='store_true',
+                            help='Use linemarkers instead of #line directives')
+    cli_parser.add_argument('source', help='Filename of .pf file')
+    cli_parser.add_argument('target', help='Filename of geenrated .f90 file')
+    arguments = cli_parser.parse_args()
+    return arguments.source, arguments.target, arguments.markers
+
+
 if __name__ == "__main__":
-    import sys
-    print("Processing file", sys.argv[1])
-    p = Parser(sys.argv[1], sys.argv[2])
+    source_filename, target_filename, use_markers = process_cli()
+    print("Processing file", source_filename)
+    p = Parser(source_filename, target_filename, use_markers)
     p.run()
     p.final()
-    print(" ... Done.  Results in", sys.argv[2])
+    print(" ... Done.  Results in", target_filename)

--- a/bin/parseDirectiveArgs.py
+++ b/bin/parseDirectiveArgs.py
@@ -4,20 +4,27 @@ import re
 import unittest
 import collections
 
+
 def flatten(l):
-    "http://stackoverflow.com/questions/2158395/flatten-an-irregular-list-of-lists-in-python"
+    """
+    http://stackoverflow.com/
+    questions/2158395/flatten-an-irregular-list-of-lists-in-python
+    """
     if l:
         for el in l:
-            if isinstance(el, collections.Iterable) and not isinstance(el, (str,bytes)):
-# The following is incompatible with python 3.
-#            if isinstance(el, collections.Iterable) and not isinstance(el, basestring):
+            if isinstance(el, collections.Iterable) \
+               and not isinstance(el, (str, bytes)):
+                # The following is incompatible with python 3.
+                # if isinstance(el, collections.Iterable) \
+                #    and not isinstance(el, basestring):
                 for sub in flatten(el):
                     yield sub
             else:
                 yield el
 
+
 def parseDirectiveArguments(data):
-    
+
     """Makes a list whose elements are delimited by commas in an input
 
     string. Commas inside a scope started with brackets, parens, single-
@@ -27,14 +34,21 @@ def parseDirectiveArguments(data):
     syntax or ordering rules. It would be nice to throw an exception or
     emit warnings when we detect suspicious syntax.
     """
-    
-    pos = 0; npos = len(data); str=''; maskCommas=False
-    scopeCounts = {'[':0,'(':0,'"':0,"'":0} # Assume well formed scopes.
-    scopeTerminators = {'[':']','(':')','"':'"',"'":"'"}
-    scopeNames = {'(':'parens','[':'brackets','"':'double quotes',"'":'single quotes'}
+
+    pos = 0
+    npos = len(data)
+    str = ''
+    maskCommas = False
+    scopeCounts = {'[': 0, '(': 0, '"': 0, "'": 0}  # Assume well formed scopes
+    scopeTerminators = {'[': ']', '(': ')', '"': '"', "'": "'"}
+    scopeNames = {'(': 'parens',
+                  '[': 'brackets',
+                  '"': 'double quotes',
+                  "'": 'single quotes'}
     while (pos < npos):
         if data[pos] == ',' and not maskCommas:
-            return [i for i in flatten([str,parseDirectiveArguments(data[pos+1:])])]
+            arguments = [str, parseDirectiveArguments(data[pos+1:])]
+            return [i for i in flatten(arguments)]
         else:
             for key in scopeCounts.keys():
                 if data[pos] == key:
@@ -44,32 +58,40 @@ def parseDirectiveArguments(data):
                     scopeCounts[key] = scopeCounts[key] - 1
                     if scopeCounts[key] < 0:
                         # Maybe try exceptions...
-                        print('parseDirectiveArguments::error: mismatched '+scopeNames[key]+' parenCount < 0 "',str,'" from "',data,'"')
+                        print('parseDirectiveArguments::error: mismatched '
+                              + scopeNames[key] + ' parenCount < 0 "', str,
+                              '" from "', data, '"')
                         return None
                     else:
-                        maskCommas = sum(map(abs,scopeCounts.values())) > 0
+                        maskCommas = sum(map(abs, scopeCounts.values())) > 0
         str = str + data[pos]
         pos = pos + 1
     return [str]
-        
-    
+
+
 class TestParseDirectiveArgs(unittest.TestCase):
 
     def test_args1(self):
-        self.assertEqual(['a','b','c'],parseDirectiveArguments('a,b,c'))
+        self.assertEqual(['a', 'b', 'c'], parseDirectiveArguments('a,b,c'))
 
     def test_args2(self):
-        self.assertEqual(['a','b(1,2)','c((1,3,z(x,y(4))))'],parseDirectiveArguments('a,b(1,2),c((1,3,z(x,y(4))))'))
+        result = parseDirectiveArguments('a,b(1,2),c((1,3,z(x,y(4))))')
+        self.assertEqual(['a', 'b(1,2)', 'c((1,3,z(x,y(4))))'], result)
 
     def test_args3(self):
-        self.assertEqual(['a','b','c[d,e,f(x,y)]'],parseDirectiveArguments('a,b,c[d,e,f(x,y)]'))
+        self.assertEqual(['a', 'b', 'c[d,e,f(x,y)]'],
+                         parseDirectiveArguments('a,b,c[d,e,f(x,y)]'))
 
     def test_args4(self):
-        self.assertEqual(['a','b','c[d,e,f(x,y]'],parseDirectiveArguments('a,b,c[d,e,f(x,y]'))
+        self.assertEqual(['a', 'b', 'c[d,e,f(x,y]'],
+                         parseDirectiveArguments('a,b,c[d,e,f(x,y]'))
 
     def test_args5(self):
-        self.assertEqual(['a','b="This, is, a, test."'],parseDirectiveArguments('a,b="This, is, a, test."'))
-        self.assertEqual(["a","b='This, is, a, test.'"],parseDirectiveArguments("a,b='This, is, a, test.'"))
+        self.assertEqual(['a', 'b="This, is, a, test."'],
+                         parseDirectiveArguments('a,b="This, is, a, test."'))
+        self.assertEqual(["a", "b='This, is, a, test.'"],
+                         parseDirectiveArguments("a,b='This, is, a, test.'"))
+
 
 if __name__ == '__main__':
     print('starting')

--- a/bin/tests/expectedOutputs/MpiTestCaseB.F90
+++ b/bin/tests/expectedOutputs/MpiTestCaseB.F90
@@ -2,7 +2,6 @@ module MpiTestCaseB_mod
    use pfunit_mod
    implicit none
 
-   
 !@testCase(npes = [1,3,5])
    type, extends(MpiTestCase) :: MpiTestCaseB
       integer :: componentI
@@ -68,38 +67,54 @@ contains
       call this%testMethodPtr(this)
    end subroutine runMethod
 
-   function makeCustomTest(methodName, testMethod, npesRequested) result(aTest)
+   function makeCustomTest(methodName, testMethod, testParameter) result(aTest)
+#ifdef INTEL_13
+      use pfunit_mod, only: testCase
+#endif
       type (WrapUserTestCase) :: aTest
+#ifdef INTEL_13
+      target :: aTest
+      class (WrapUserTestCase), pointer :: p
+#endif
       character(len=*), intent(in) :: methodName
       procedure(userTestMethod) :: testMethod
-      integer, optional, intent(in) :: npesRequested
-
+      type (MpiTestParameter), intent(in) :: testParameter
       aTest%testMethodPtr => testMethod
+#ifdef INTEL_13
+      p => aTest
+      call p%setName(methodName)
+#else
       call aTest%setName(methodName)
-     if (present(npesRequested)) then
-         call aTest%setNumProcessesRequested(npesRequested) 
-     end if
-
+#endif
+      call aTest%setTestParameter(testParameter)
    end function makeCustomTest
 
 end module WrapMpiTestCaseB_mod
 
 function MpiTestCaseB_mod_suite() result(suite)
    use pFUnit_mod
-   use WrapMpiTestCaseB_mod
    use MpiTestCaseB_mod
+   use WrapMpiTestCaseB_mod
    type (TestSuite) :: suite
 
-   integer, allocatable :: npes(:)
-
+   type (MpiTestParameter), allocatable :: testParameters(:)
+   type (MpiTestParameter) :: testParameter
+   integer :: iParam 
+   integer, allocatable :: cases(:) 
+ 
    suite = newTestSuite('MpiTestCaseB_mod_suite')
 
-   call suite%addTest(makeCustomTest('testA', testA, npesRequested=1))
-   call suite%addTest(makeCustomTest('testA', testA, npesRequested=2))
+   call testParameter%setNumProcessesRequested(1)
+   call suite%addTest(makeCustomTest('testA', testA, testParameter))
+   call testParameter%setNumProcessesRequested(2)
+   call suite%addTest(makeCustomTest('testA', testA, testParameter))
 
-   call suite%addTest(makeCustomTest('testB', testB, npesRequested=1))
-   call suite%addTest(makeCustomTest('testB', testB, npesRequested=3))
-   call suite%addTest(makeCustomTest('testB', testB, npesRequested=5))
+   call testParameter%setNumProcessesRequested(1)
+   call suite%addTest(makeCustomTest('testB', testB, testParameter))
+   call testParameter%setNumProcessesRequested(3)
+   call suite%addTest(makeCustomTest('testB', testB, testParameter))
+   call testParameter%setNumProcessesRequested(5)
+   call suite%addTest(makeCustomTest('testB', testB, testParameter))
 
 
 end function MpiTestCaseB_mod_suite

--- a/bin/tests/expectedOutputs/ParameterizedTestCaseB.F90
+++ b/bin/tests/expectedOutputs/ParameterizedTestCaseB.F90
@@ -2,7 +2,6 @@ module TestCaseB_mod
    use pfunit_mod
    implicit none
 
-   
 !@testCase(constructor=newTestCaseB)
    type, extends(ParameterizedTestCase) :: TestCaseB
       integer, allocatable :: table(:)
@@ -98,14 +97,26 @@ contains
    end subroutine runMethod
 
    function makeCustomTest(methodName, testMethod, testParameter) result(aTest)
+#ifdef INTEL_13
+      use pfunit_mod, only: testCase
+#endif
       type (WrapUserTestCase) :: aTest
+#ifdef INTEL_13
+      target :: aTest
+      class (WrapUserTestCase), pointer :: p
+#endif
       character(len=*), intent(in) :: methodName
       procedure(userTestMethod) :: testMethod
       type (B_Parameter), intent(in) :: testParameter
       aTest%TestCaseB = newTestCaseB(testParameter)
 
       aTest%testMethodPtr => testMethod
+#ifdef INTEL_13
+      p => aTest
+      call p%setName(methodName)
+#else
       call aTest%setName(methodName)
+#endif
       call aTest%setTestParameter(testParameter)
    end function makeCustomTest
 
@@ -113,11 +124,9 @@ end module WrapTestCaseB_mod
 
 function TestCaseB_mod_suite() result(suite)
    use pFUnit_mod
-   use WrapTestCaseB_mod
    use TestCaseB_mod
+   use WrapTestCaseB_mod
    type (TestSuite) :: suite
-
-   integer, allocatable :: npes(:)
 
    type (B_Parameter), allocatable :: testParameters(:)
    type (B_Parameter) :: testParameter

--- a/bin/tests/expectedOutputs/TestA.F90
+++ b/bin/tests/expectedOutputs/TestA.F90
@@ -13,7 +13,7 @@ contains
    !@test
    subroutine testMethodB()
    end subroutine testMethodB
-   
+
    !@mpitest(npes=[1,3,5])
    subroutine testMethodC(this)
       class (MpiTestMethod), intent(inout) :: this
@@ -36,11 +36,9 @@ end module WrapTestA_mod
 
 function TestA_mod_suite() result(suite)
    use pFUnit_mod
-   use WrapTestA_mod
    use TestA_mod
+   use WrapTestA_mod
    type (TestSuite) :: suite
-
-   integer, allocatable :: npes(:)
 
    suite = newTestSuite('TestA_mod_suite')
 

--- a/bin/tests/expectedOutputs/TestCaseA.F90
+++ b/bin/tests/expectedOutputs/TestCaseA.F90
@@ -2,7 +2,6 @@ module TestCaseA_mod
    use pfunit_mod
    implicit none
 
-   
 !@testCase
    type, extends(TestCase) :: TestCaseA
       integer :: componentI
@@ -67,22 +66,32 @@ contains
    end subroutine runMethod
 
    function makeCustomTest(methodName, testMethod) result(aTest)
+#ifdef INTEL_13
+      use pfunit_mod, only: testCase
+#endif
       type (WrapUserTestCase) :: aTest
+#ifdef INTEL_13
+      target :: aTest
+      class (WrapUserTestCase), pointer :: p
+#endif
       character(len=*), intent(in) :: methodName
       procedure(userTestMethod) :: testMethod
       aTest%testMethodPtr => testMethod
+#ifdef INTEL_13
+      p => aTest
+      call p%setName(methodName)
+#else
       call aTest%setName(methodName)
+#endif
    end function makeCustomTest
 
 end module WrapTestCaseA_mod
 
 function TestCaseA_mod_suite() result(suite)
    use pFUnit_mod
-   use WrapTestCaseA_mod
    use TestCaseA_mod
+   use WrapTestCaseA_mod
    type (TestSuite) :: suite
-
-   integer, allocatable :: npes(:)
 
    suite = newTestSuite('TestCaseA_mod_suite')
 

--- a/bin/tests/expectedOutputs/beforeAfter.F90
+++ b/bin/tests/expectedOutputs/beforeAfter.F90
@@ -40,8 +40,6 @@ function beforeAfter_suite() result(suite)
    external initA
    external finalA
 
-   integer, allocatable :: npes(:)
-
    suite = newTestSuite('beforeAfter_suite')
 
    call suite%addTest(newTestMethod('testMethodA', testMethodA, initA, finalA))

--- a/bin/tests/expectedOutputs/simple.F90
+++ b/bin/tests/expectedOutputs/simple.F90
@@ -37,8 +37,6 @@ function simple_suite() result(suite)
    external testMethodC
 
 
-   integer, allocatable :: npes(:)
-
    suite = newTestSuite('simple_suite')
 
    call suite%addTest(newTestMethod('testMethodA', testMethodA))

--- a/bin/tests/inputs/MpiParameterizedTestCaseC.pf
+++ b/bin/tests/inputs/MpiParameterizedTestCaseC.pf
@@ -2,7 +2,6 @@ module TestCaseC_mod
    use pfunit_mod
    implicit none
 
-   
 @testCase(constructor=newTestCaseC)
    type, extends(MpiTestCase) :: TestCaseC
       integer, allocatable :: table(:)

--- a/bin/tests/inputs/MpiTestCaseB.pf
+++ b/bin/tests/inputs/MpiTestCaseB.pf
@@ -2,7 +2,6 @@ module MpiTestCaseB_mod
    use pfunit_mod
    implicit none
 
-   
 @testCase(npes = [1,3,5])
    type, extends(MpiTestCase) :: MpiTestCaseB
       integer :: componentI

--- a/bin/tests/inputs/ParameterizedTestCaseB.pf
+++ b/bin/tests/inputs/ParameterizedTestCaseB.pf
@@ -2,7 +2,6 @@ module TestCaseB_mod
    use pfunit_mod
    implicit none
 
-   
 @testCase(constructor=newTestCaseB)
    type, extends(ParameterizedTestCase) :: TestCaseB
       integer, allocatable :: table(:)

--- a/bin/tests/inputs/TestA.pf
+++ b/bin/tests/inputs/TestA.pf
@@ -13,7 +13,7 @@ contains
    ! Second test
    subroutine testMethodB()
    end subroutine testMethodB
-   
+
    @mpitest(npes=[1,3,5])
    subroutine testMethodC(this)
       class (MpiTestMethod), intent(inout) :: this

--- a/bin/tests/inputs/TestCaseA.pf
+++ b/bin/tests/inputs/TestCaseA.pf
@@ -2,7 +2,6 @@ module TestCaseA_mod
    use pfunit_mod
    implicit none
 
-   
 @testCase
    type, extends(TestCase) :: TestCaseA
       integer :: componentI

--- a/bin/tests/runTests.sh
+++ b/bin/tests/runTests.sh
@@ -1,8 +1,13 @@
-python testParser.py
+#!/bin/sh
 
+python -m unittest discover
+
+TESTS=$(find inputs -name '*.pf' -print)
 mkdir -p outputs
-for file in simple beforeAfter TestA TestCaseA MpiTestCaseB ParameterizedTestCaseB MpiParameterizedTestCaseC
+for file in $TESTS
 do
-   ../pFUnitParser.py inputs/${file}.pf outputs/${file}.F90
-   diff outputs/${file}.F90 expectedOutputs/${file}.F90
+   name=$(basename $file | sed 's/\..*$//')
+
+   ../pFUnitParser.py ${file} outputs/${name}.F90
+   diff outputs/${name}.F90 expectedOutputs/${name}.F90
 done

--- a/bin/tests/testParser.py
+++ b/bin/tests/testParser.py
@@ -100,12 +100,15 @@ class TestParseLine(unittest.TestCase):
 
         nextLine = 'subroutine myTest (] \n' # bad closing paren
         parser = MockParser([nextLine])
-        
-        with self.assertRaises(MyError):
+
+        try:
             atTest = AtTest(parser)
             line = '@test'
             m = atTest.match(line)
             atTest.action(m, line)
+            self.assertTrue(False, msg='Expected assertion was not raised')
+        except MyError:
+            pass  # Correct response
 
 
     def testAtTestSkipComment(self):

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -38,7 +38,7 @@ file_compile_configuration()
 
 # Perform the install.
 #
-install(FILES GNU.mk IBM.mk INTEL.mk NAG.mk PGI.mk extensions.mk driver.F90 DESTINATION include)
+install(FILES CRAY.mk GNU.mk IBM.mk INTEL.mk NAG.mk PGI.mk extensions.mk driver.F90 DESTINATION include)
 install(FILES base-install.mk DESTINATION include RENAME base.mk)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/configuration.mk DESTINATION include)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/TestUtil.F90 DESTINATION include)

--- a/include/CRAY.mk
+++ b/include/CRAY.mk
@@ -1,0 +1,29 @@
+export FUFLAGS=-markers
+
+F90 ?=ftn
+MPIF90 ?= ftn
+
+I=-I
+M=-I
+L=-L
+
+# Cray compiler only exists on Cray machines so no Windows support.
+FFLAGS += -G0 -K trap=fp,unf
+
+ifeq ($(USEOPENMP),YES)
+FFLAGS += -h omp
+endif
+
+
+# Common command line options.
+
+# The Cray compiler always creates a <file>.i file when run in preprocessor
+# mode. None of this stuff seems to be used so I'm commenting it out for
+# the moment.
+#
+# F90_PP_ONLY = -eF
+# F90_PP_OUTPUT = ; mv <file>i 
+
+CPPFLAGS +=-DCray
+FPPFLAGS +=-DCray
+


### PR DESCRIPTION
The Fortran preprocessor integrated with the Cray compiler does not recognise the `#line` directives output by pFUnitParser.py. The compiler itself does recognise linemarkers (`#<line number> ...`) as produced by preprocessors.

This change provides a switch "-markers" which tells pFUnitParser.py to use linemarkers instead of `#line` directives. Thus the user can choose the appropriate behaviour for their compiler.

Testing is ongoing so this change shouldn't go on trunk yet but I thought you should get early sight of it.

While I was at it I discovered that the various tests in "bin/tests" no longer reflected reality. They have been fixed and updated in line with this branch.

This change represents the end of any pretence at supporting Python 2.6. There were already a few non-compatible libraries and idioms from Python 2.7 in there. Rather than working out how to replace them with work-a-likes I've just removed the claim that the code works on 2.6.

I also took the opportunity to run `pycodestyle` over the whole lot.
