### PR TITLE
Fixes #38 - run just one test.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -129,6 +129,8 @@ set(srcs
   ThrowFundamentalTypes.F90
   XmlPrinter.F90
 
+  TestFilter.F90
+  NameFilter.F90
   FUnit.F90
   )
 

--- a/src/core/NameFilter.F90
+++ b/src/core/NameFilter.F90
@@ -1,0 +1,38 @@
+module pf_NameFilter_mod
+  use pf_TestFilter_mod
+  use pf_Test_mod
+  implicit none
+  private
+
+  public :: NameFilter
+
+  type, extends(TestFilter) :: NameFilter
+     character(:), allocatable :: pattern
+   contains
+     procedure :: filter
+  end type NameFilter
+
+
+  interface NameFilter
+     module procedure new_NameFilter
+  end interface NameFilter
+
+contains
+
+  function new_NameFilter(pattern) result(filter)
+    type(NameFilter) :: filter
+    character(*), intent(in) :: pattern
+
+    filter%pattern = pattern
+  end function new_NameFilter
+
+
+  logical function filter(this, a_test)
+    class(NameFilter), intent(in) :: this
+    class(Test), intent(in) :: a_test
+
+    filter = index(a_test%getName(), this%pattern) > 0
+  end function filter
+
+
+end module pf_NameFilter_mod

--- a/src/core/TestFilter.F90
+++ b/src/core/TestFilter.F90
@@ -1,0 +1,24 @@
+module pf_TestFilter_mod
+  implicit none
+  private
+
+  public :: TestFilter
+
+  type, abstract :: TestFilter
+   contains
+     procedure(filter), deferred :: filter
+  end type TestFilter
+
+
+  abstract interface
+
+     logical function filter(this, a_test)
+       use pf_Test_mod
+       import TestFilter
+       class(TestFilter), intent(in) :: this
+       class(Test), intent(in) :: a_test
+     end function filter
+
+  end interface
+
+end module pf_TestFilter_mod

--- a/src/mpi/pFUnit.F90
+++ b/src/mpi/pFUnit.F90
@@ -85,17 +85,16 @@ contains
 
 
    logical function run(load_tests) result(status)
-      use, intrinsic :: iso_fortran_env, only: OUTPUT_UNIT
+     use, intrinsic :: iso_fortran_env, only: OUTPUT_UNIT
       procedure(LoadTests_interface) :: load_tests
       
-      type (TestSuite) :: suite
+      type(TestSuite) :: suite
       class(BaseTestRunner), allocatable :: runner
-      type (TestResult) :: r
-      class (ParallelContext), allocatable :: c
-      class (ListenerPointer), allocatable :: listeners(:)
+      type(TestResult) :: r
+      class(ParallelContext), allocatable :: c
+      type(TestListenerVector) :: listeners
 
-      allocate(listeners(1))
-      allocate(listeners(1)%pListener, source=ResultPrinter(OUTPUT_UNIT))
+      call listeners%push_back(ResultPrinter(OUTPUT_UNIT))
 !!$      options = parse()
       suite = load_tests()
       allocate(runner, source=TestRunner(listeners))

--- a/tests/core-tests/CMakeLists.txt
+++ b/tests/core-tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(pf_tests
   Test_DotPattern.pf
   Test_RepeatPattern.pf
   Test_TapListener.pf
+  Test_NameFilter.pf
   Test_RegularExpression.pf)
 
 set(new_tests)

--- a/tests/core-tests/Test_LiteralPattern.pf
+++ b/tests/core-tests/Test_LiteralPattern.pf
@@ -40,6 +40,7 @@ contains
       
    end subroutine test_match_not_found
 
+   @test
    subroutine test_match_various()
       type (LiteralPattern) :: p
       type (MatchObject) :: m

--- a/tests/core-tests/Test_NameFilter.pf
+++ b/tests/core-tests/Test_NameFilter.pf
@@ -1,0 +1,41 @@
+module Test_NameFilter_mod
+   use PF_Exception_mod
+   use PF_ExceptionList_mod
+   use PF_RegularExpression_mod
+   use PF_Assert_mod
+   use Pf_SourceLocation_mod
+
+   @suite(name='NameFilter_suite')
+   
+contains
+
+   @test
+   subroutine test_matches_exact()
+     use pf_TestMethod_mod
+     use pf_NameFilter_mod
+     type(TestMethod) :: method
+     type(NameFilter) :: filter
+
+     method = TestMethod('foo', was_run)
+     filter = NameFilter('foo')
+
+     @assertTrue(filter%filter(method))
+   end subroutine test_matches_exact
+
+   @test
+   subroutine test_does_not_match_exact()
+     use pf_TestMethod_mod
+     use pf_NameFilter_mod
+     type(TestMethod) :: method
+     type(NameFilter) :: filter
+
+     method = TestMethod('foo', was_run)
+     filter = NameFilter('bar')
+
+     @assertFalse(filter%filter(method))
+   end subroutine test_does_not_match_exact
+
+   subroutine was_run()
+   end subroutine was_run
+
+end module Test_NameFilter_mod

--- a/tests/core-tests/serial_tests.F90
+++ b/tests/core-tests/serial_tests.F90
@@ -2,7 +2,7 @@ program main
    use FUnit, only: initialize
    use FUnit, only: finalize
    use FUnit, only: TestResult
-   use FUnit, only: ListenerPointer
+   use FUnit, only: TestListenerVector
    use FUnit, only: ResultPrinter
    use FUnit, only: stub
 !$$   use FUnit, only: DebugListener
@@ -50,10 +50,9 @@ contains
       type (TestRunner) :: runner
       type (TestResult) :: tstResult
 
-      type (ListenerPointer), target, allocatable :: ll(:)
+      type (TestListenerVector) :: ll
 
-      allocate(ll(1))
-      allocate(ll(1)%pListener, source=ResultPrinter(OUTPUT_UNIT))
+      call ll%push_back(ResultPrinter(OUTPUT_UNIT))
       ! TODO: We'll make this a feature in 4.0
 !!$      allocate(ll(2))
 !!$      allocate(ll(1)%pListener, source=ResultPrinter(OUTPUT_UNIT))

--- a/tests/core-tests/testSuites.inc
+++ b/tests/core-tests/testSuites.inc
@@ -15,4 +15,5 @@
    ADD_TEST_SUITE(LiteralPattern_suite)
    ADD_TEST_SUITE(DotPattern_suite)
    ADD_TEST_SUITE(RepeatPattern_suite)
+   ADD_TEST_SUITE(NameFilter_suite)
    ADD_TEST_SUITE(RegularExpression_suite)

--- a/tests/mpi-tests/parallel_tests.F90
+++ b/tests/mpi-tests/parallel_tests.F90
@@ -2,7 +2,7 @@ program main
    use pfunit, only: initialize
    use pfunit, only: finalize
    use pfunit, only: TestResult
-   use pfunit, only: ListenerPointer
+   use pfunit, only: TestListenerVector
    use pfunit, only: ResultPrinter
    use pfunit, only: stub
 !$$   use pfunit, only: DebugListener
@@ -35,20 +35,13 @@ contains
 #ifdef INTEL_13
       type (ResultPrinter), target :: printer
 #endif
-      type (ListenerPointer), target, allocatable :: ll(:)
+      type (TestListenerVector) :: ll
 
-#ifndef INTEL_13
-      allocate(ll(1))
-      allocate(ll(1)%pListener, source=ResultPrinter(OUTPUT_UNIT))
       ! TODO: We'll make this a feature in 4.0
 !!$      allocate(ll(2))
 !!$      allocate(ll(1)%pListener, source=ResultPrinter(OUTPUT_UNIT))
 !!$      allocate(ll(2)%pListener, source=DebugListener())
-#else
-      allocate(ll(1))
-      printer = ResultPrinter(OUTPUT_UNIT)
-      ll(1)%pListener => printer
-#endif
+      call ll%push_back(ResultPrinter(OUTPUT_UNIT))
 
       allTests = TestSuite('allTests')
       runner = TestRunner(ll)


### PR DESCRIPTION
Created a family of filter classes that can be used to prune a test
suite.  For now just a NameFilter that keeps names that contain a
substring.   Later, more regexp capabilities will be added.

 * added fArgParse option for debug

 * added fArgParse option for filter

 usage: ./tests/core-tests/new_tests.x [-h][-d][-f FILTER]

 optional arguments:
  -h, --help                 This message.
  -d, --debug, --verbose     make output more verbose
  -f, --filter               only run tests that match FILTER

Now have fArgParse options for debug and filter.