### PR TITLE
Changing convention for module suffixes.

### DIFF
--- a/bin/tests/expectedOutputs/MpiParameterizedTestCaseC.F90
+++ b/bin/tests/expectedOutputs/MpiParameterizedTestCaseC.F90
@@ -1,5 +1,5 @@
-module TestCaseC_mod
-   use pfunit_mod
+module TestCaseC
+   use pfunit
    implicit none
 
    
@@ -117,13 +117,13 @@ contains
 
    end function toString
 
-end module TestCaseC_mod
+end module TestCaseC
 
 
 
-module WrapTestCaseC_mod
-   use pFUnit_mod
-   use TestCaseC_mod
+module WrapTestCaseC
+   use pFUnit
+   use TestCaseC
    implicit none
    private
 
@@ -137,7 +137,7 @@ module WrapTestCaseC_mod
 
    abstract interface
      subroutine userTestMethod(this)
-        use TestCaseC_mod
+        use TestCaseC
         class (TestCaseC), intent(inout) :: this
      end subroutine userTestMethod
    end interface
@@ -168,12 +168,12 @@ contains
 
    end function makeCustomTest
 
-end module WrapTestCaseC_mod
+end module WrapTestCaseC
 
-function TestCaseC_mod_suite() result(suite)
-   use pFUnit_mod
-   use WrapTestCaseC_mod
-   use TestCaseC_mod
+function TestCaseC_suite() result(suite)
+   use pFUnit
+   use WrapTestCaseC
+   use TestCaseC
    type (TestSuite) :: suite
 
    integer, allocatable :: npes(:)
@@ -183,7 +183,7 @@ function TestCaseC_mod_suite() result(suite)
    integer :: iParam 
    integer, allocatable :: cases(:) 
  
-   suite = newTestSuite('TestCaseC_mod_suite')
+   suite = newTestSuite('TestCaseC_suite')
 
    testParameters = [newC_Parameter(1,0.1,0.1)]
 
@@ -212,5 +212,5 @@ function TestCaseC_mod_suite() result(suite)
    end do
 
 
-end function TestCaseC_mod_suite
+end function TestCaseC_suite
 

--- a/bin/tests/expectedOutputs/MpiTestCaseB.F90
+++ b/bin/tests/expectedOutputs/MpiTestCaseB.F90
@@ -1,5 +1,5 @@
-module MpiTestCaseB_mod
-   use pfunit_mod
+module MpiTestCaseB
+   use pfunit
    implicit none
 
    
@@ -35,13 +35,13 @@ contains
       class (MpiTestCaseB), intent(inout) :: this
    end subroutine testB
 
-end module MpiTestCaseB_mod
+end module MpiTestCaseB
 
 
 
-module WrapMpiTestCaseB_mod
-   use pFUnit_mod
-   use MpiTestCaseB_mod
+module WrapMpiTestCaseB
+   use pFUnit
+   use MpiTestCaseB
    implicit none
    private
 
@@ -55,7 +55,7 @@ module WrapMpiTestCaseB_mod
 
    abstract interface
      subroutine userTestMethod(this)
-        use MpiTestCaseB_mod
+        use MpiTestCaseB
         class (MpiTestCaseB), intent(inout) :: this
      end subroutine userTestMethod
    end interface
@@ -82,17 +82,17 @@ contains
 
    end function makeCustomTest
 
-end module WrapMpiTestCaseB_mod
+end module WrapMpiTestCaseB
 
-function MpiTestCaseB_mod_suite() result(suite)
-   use pFUnit_mod
-   use WrapMpiTestCaseB_mod
-   use MpiTestCaseB_mod
+function MpiTestCaseB_suite() result(suite)
+   use pFUnit
+   use WrapMpiTestCaseB
+   use MpiTestCaseB
    type (TestSuite) :: suite
 
    integer, allocatable :: npes(:)
 
-   suite = newTestSuite('MpiTestCaseB_mod_suite')
+   suite = newTestSuite('MpiTestCaseB_suite')
 
    call suite%addTest(makeCustomTest('testA', testA, npesRequested=1))
    call suite%addTest(makeCustomTest('testA', testA, npesRequested=2))
@@ -102,5 +102,5 @@ function MpiTestCaseB_mod_suite() result(suite)
    call suite%addTest(makeCustomTest('testB', testB, npesRequested=5))
 
 
-end function MpiTestCaseB_mod_suite
+end function MpiTestCaseB_suite
 

--- a/bin/tests/expectedOutputs/ParameterizedTestCaseB.F90
+++ b/bin/tests/expectedOutputs/ParameterizedTestCaseB.F90
@@ -1,5 +1,5 @@
-module TestCaseB_mod
-   use pfunit_mod
+module TestCaseB
+   use pfunit
    implicit none
 
    
@@ -64,13 +64,13 @@ contains
 
    end function toString
 
-end module TestCaseB_mod
+end module TestCaseB
 
 
 
-module WrapTestCaseB_mod
-   use pFUnit_mod
-   use TestCaseB_mod
+module WrapTestCaseB
+   use pFUnit
+   use TestCaseB
    implicit none
    private
 
@@ -84,7 +84,7 @@ module WrapTestCaseB_mod
 
    abstract interface
      subroutine userTestMethod(this)
-        use TestCaseB_mod
+        use TestCaseB
         class (TestCaseB), intent(inout) :: this
      end subroutine userTestMethod
    end interface
@@ -109,12 +109,12 @@ contains
       call aTest%setTestParameter(testParameter)
    end function makeCustomTest
 
-end module WrapTestCaseB_mod
+end module WrapTestCaseB
 
-function TestCaseB_mod_suite() result(suite)
-   use pFUnit_mod
-   use WrapTestCaseB_mod
-   use TestCaseB_mod
+function TestCaseB_suite() result(suite)
+   use pFUnit
+   use WrapTestCaseB
+   use TestCaseB
    type (TestSuite) :: suite
 
    integer, allocatable :: npes(:)
@@ -124,7 +124,7 @@ function TestCaseB_mod_suite() result(suite)
    integer :: iParam 
    integer, allocatable :: cases(:) 
  
-   suite = newTestSuite('TestCaseB_mod_suite')
+   suite = newTestSuite('TestCaseB_suite')
 
    testParameters = [B_Parameter(0.1,0.2),B_Parameter(0.3,0.1)]
 
@@ -141,5 +141,5 @@ function TestCaseB_mod_suite() result(suite)
    end do
 
 
-end function TestCaseB_mod_suite
+end function TestCaseB_suite
 

--- a/bin/tests/expectedOutputs/TestA.F90
+++ b/bin/tests/expectedOutputs/TestA.F90
@@ -1,5 +1,5 @@
-module TestA_mod
-   use pfunit_mod
+module TestA
+   use pfunit
    implicit none
 
 contains
@@ -19,30 +19,30 @@ contains
       class (MpiTestMethod), intent(inout) :: this
    end subroutine testMethodC
 
-end module TestA_mod
+end module TestA
 
 
 
-module WrapTestA_mod
-   use pFUnit_mod
-   use TestA_mod
+module WrapTestA
+   use pFUnit
+   use TestA
    implicit none
    private
 
 contains
 
 
-end module WrapTestA_mod
+end module WrapTestA
 
-function TestA_mod_suite() result(suite)
-   use pFUnit_mod
-   use WrapTestA_mod
-   use TestA_mod
+function TestA_suite() result(suite)
+   use pFUnit
+   use WrapTestA
+   use TestA
    type (TestSuite) :: suite
 
    integer, allocatable :: npes(:)
 
-   suite = newTestSuite('TestA_mod_suite')
+   suite = newTestSuite('TestA_suite')
 
    call suite%addTest(newTestMethod('testMethodA', testMethodA))
 
@@ -53,5 +53,5 @@ function TestA_mod_suite() result(suite)
    call suite%addTest(newMpiTestMethod('testMethodC', testMethodC, 5))
 
 
-end function TestA_mod_suite
+end function TestA_suite
 

--- a/bin/tests/expectedOutputs/TestCaseA.F90
+++ b/bin/tests/expectedOutputs/TestCaseA.F90
@@ -1,5 +1,5 @@
-module TestCaseA_mod
-   use pfunit_mod
+module TestCaseA
+   use pfunit
    implicit none
 
    
@@ -35,11 +35,11 @@ contains
       class (TestCaseA), intent(inout) :: this
    end subroutine testB
 
-end module TestCaseA_mod
+end module TestCaseA
 
-module WrapTestCaseA_mod
-   use pFUnit_mod
-   use TestCaseA_mod
+module WrapTestCaseA
+   use pFUnit
+   use TestCaseA
    implicit none
    private
 
@@ -53,7 +53,7 @@ module WrapTestCaseA_mod
 
    abstract interface
      subroutine userTestMethod(this)
-        use TestCaseA_mod
+        use TestCaseA
         class (TestCaseA), intent(inout) :: this
      end subroutine userTestMethod
    end interface
@@ -74,22 +74,22 @@ contains
       call aTest%setName(methodName)
    end function makeCustomTest
 
-end module WrapTestCaseA_mod
+end module WrapTestCaseA
 
-function TestCaseA_mod_suite() result(suite)
-   use pFUnit_mod
-   use WrapTestCaseA_mod
-   use TestCaseA_mod
+function TestCaseA_suite() result(suite)
+   use pFUnit
+   use WrapTestCaseA
+   use TestCaseA
    type (TestSuite) :: suite
 
    integer, allocatable :: npes(:)
 
-   suite = newTestSuite('TestCaseA_mod_suite')
+   suite = newTestSuite('TestCaseA_suite')
 
    call suite%addTest(makeCustomTest('testA', testA))
 
    call suite%addTest(makeCustomTest('testB', testB))
 
 
-end function TestCaseA_mod_suite
+end function TestCaseA_suite
 

--- a/bin/tests/expectedOutputs/beforeAfter.F90
+++ b/bin/tests/expectedOutputs/beforeAfter.F90
@@ -20,7 +20,7 @@ end subroutine testMethodB
 
 
 module WrapbeforeAfter
-   use pFUnit_mod
+   use pFUnit
    implicit none
    private
 
@@ -30,7 +30,7 @@ contains
 end module WrapbeforeAfter
 
 function beforeAfter_suite() result(suite)
-   use pFUnit_mod
+   use pFUnit
    use WrapbeforeAfter
    type (TestSuite) :: suite
 

--- a/bin/tests/expectedOutputs/simple.F90
+++ b/bin/tests/expectedOutputs/simple.F90
@@ -11,14 +11,14 @@ end subroutine testMethodB
 ! An MPI test
 !@mpitest(npes=[1,3,5])
 subroutine testMethodC(this)
-   use pfunit_mod
+   use pfunit
    class (MpiTestMethod), intent(inout) :: this
 end subroutine testMethodC
 
 
 
 module Wrapsimple
-   use pFUnit_mod
+   use pFUnit
    implicit none
    private
 
@@ -28,7 +28,7 @@ contains
 end module Wrapsimple
 
 function simple_suite() result(suite)
-   use pFUnit_mod
+   use pFUnit
    use Wrapsimple
    type (TestSuite) :: suite
 

--- a/include/driver.F90
+++ b/include/driver.F90
@@ -44,27 +44,27 @@ contains
 
    function load_tests() result(suite)
 
-#define ADD_MODULE_TEST_SUITE(m,s) use m, only: s
+#define ADDULE_TEST_SUITE(m,s) use m, only: s
 #define ADD_TEST_SUITE(s) ! do nothing
 #include _TEST_SUITES
-#undef ADD_MODULE_TEST_SUITE
+#undef ADDULE_TEST_SUITE
 #undef ADD_TEST_SUITE
 
       type (TestSuite) :: suite
 
-#define ADD_MODULE_TEST_SUITE(m,s) ! do nothing
+#define ADDULE_TEST_SUITE(m,s) ! do nothing
 #define ADD_TEST_SUITE(s) type (TestSuite), external :: s
 #  include _TEST_SUITES
 #undef ADD_TEST_SUITE
-#undef ADD_MODULE_TEST_SUITE
+#undef ADDULE_TEST_SUITE
 
       suite = TestSuite()
 
 #define ADD_TEST_SUITE(s) call suite%addTest(s())
-#define ADD_MODULE_TEST_SUITE(m,s) call suite%addTest(s())
+#define ADDULE_TEST_SUITE(m,s) call suite%addTest(s())
 #  include _TEST_SUITES
 #undef ADD_TEST_SUITE
-#undef ADD_MODULE_TEST_SUITE
+#undef ADDULE_TEST_SUITE
 
    end function load_tests
 

--- a/src/core/AbstractPattern.F90
+++ b/src/core/AbstractPattern.F90
@@ -1,4 +1,4 @@
-module PF_AbstractPattern_mod
+module PF_AbstractPattern
    implicit none
    private
  
@@ -12,7 +12,7 @@ module PF_AbstractPattern_mod
    abstract interface
 
       function match(this, string)
-         use PF_MatchObject_mod
+         use PF_MatchObject
          import AbstractPattern
          implicit none
          type (MatchObject) :: match
@@ -21,10 +21,10 @@ module PF_AbstractPattern_mod
       end function match
    end interface
 
-end module PF_AbstractPattern_mod
+end module PF_AbstractPattern
 
-module PF_AbstractPatternVector_mod
-   use PF_AbstractPattern_mod
+module PF_AbstractPatternVector
+   use PF_AbstractPattern
 #define _type class (AbstractPattern)
 #define _allocatable
 #define _vector AbstractPatternVector
@@ -32,4 +32,4 @@ module PF_AbstractPatternVector_mod
 
 #include "templates/vector.inc"
 
-end module PF_AbstractPatternVector_mod
+end module PF_AbstractPatternVector

--- a/src/core/AbstractTestParameter.F90
+++ b/src/core/AbstractTestParameter.F90
@@ -1,4 +1,4 @@
-module PF_AbstractTestParameter_mod
+module PF_AbstractTestParameter
    implicit none
    private
 
@@ -26,4 +26,4 @@ contains
       string = this%toString()
    end function toStringActual
 
-end module PF_AbstractTestParameter_mod
+end module PF_AbstractTestParameter

--- a/src/core/AbstractTestResult.F90
+++ b/src/core/AbstractTestResult.F90
@@ -1,4 +1,4 @@
-module PF_AbstractTestResult_mod
+module PF_AbstractTestResult
 
   implicit none
   private
@@ -25,28 +25,28 @@ module PF_AbstractTestResult_mod
   abstract interface
 
      function getRunTime(this) result(time)
-!        TestFailure_mod, only : TestFailure
+!        TestFailure, only : TestFailure
        import AbstractTestResult
        class (AbstractTestResult), intent(in) :: this
        real :: time
      end function getRunTime
 
      function getFailures(this) result(failures)
-       use PF_TestFailureVector_mod, only : TestFailureVector
+       use PF_TestFailureVector, only : TestFailureVector
        import AbstractTestResult
        class (AbstractTestResult), target, intent(in) :: this
        type (TestFailureVector), pointer :: failures
      end function getFailures
 
      function getErrors(this) result(errors)
-       use PF_TestFailureVector_mod, only : TestFailureVector
+       use PF_TestFailureVector, only : TestFailureVector
        import AbstractTestResult
        class (AbstractTestResult), target, intent(in) :: this
        type (TestFailureVector), pointer :: errors
      end function getErrors
 
      function getSuccesses(this) result(successes)
-       use PF_TestFailureVector_mod, only : TestFailureVector
+       use PF_TestFailureVector, only : TestFailureVector
        import AbstractTestResult
        class (AbstractTestResult), target, intent(in) :: this
        type (TestFailureVector), pointer :: successes
@@ -87,4 +87,4 @@ module PF_AbstractTestResult_mod
 
   end interface
 
-end module PF_AbstractTestResult_mod
+end module PF_AbstractTestResult

--- a/src/core/Arg.F90
+++ b/src/core/Arg.F90
@@ -1,9 +1,9 @@
 #include "unused_dummy.fh"
 
-module pf_Arg_mod
-   use pf_KeywordEnforcer_mod
+module pf_Arg
+   use pf_KeywordEnforcer
    use gFTL_StringVectorMod
-   use pf_None_mod
+   use pf_None
    implicit none
    private
 
@@ -243,4 +243,4 @@ contains
 
    end subroutine print_help
 
-end module pf_Arg_mod
+end module pf_Arg

--- a/src/core/BaseTestRunner.F90
+++ b/src/core/BaseTestRunner.F90
@@ -20,8 +20,8 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_BaseTestRunner_mod
-   use PF_TestListener_mod
+module PF_BaseTestRunner
+   use PF_TestListener
    implicit none
    private
 
@@ -37,9 +37,9 @@ module PF_BaseTestRunner_mod
    abstract interface
 
       function run(this, aTest, context) result(result)
-         use PF_Test_mod
-         use PF_ParallelContext_mod
-         use PF_TestResult_mod
+         use PF_Test
+         use PF_ParallelContext
+         use PF_TestResult
          import BaseTestRunner
 
          type (TestResult) :: result
@@ -50,4 +50,4 @@ module PF_BaseTestRunner_mod
 
    end interface
 
-end module PF_BaseTestRunner_mod
+end module PF_BaseTestRunner

--- a/src/core/DebugListener.F90
+++ b/src/core/DebugListener.F90
@@ -21,8 +21,8 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_DebugListener_mod
-   use PF_TestListener_mod
+module PF_DebugListener
+   use PF_TestListener
    implicit none
    private
 
@@ -61,7 +61,7 @@ contains
    end function newDebugListener_default
 
    subroutine addFailure(this, testName, exceptions)
-     use PF_ExceptionList_mod
+     use PF_ExceptionList
      class (DebugListener), intent(inOut) :: this
      character(len=*), intent(in) :: testName
      type (ExceptionList), intent(in) :: exceptions
@@ -101,7 +101,7 @@ contains
    end subroutine endTest
 
    subroutine endRun(this, result)
-     use PF_AbstractTestResult_mod, only : AbstractTestResult
+     use PF_AbstractTestResult, only : AbstractTestResult
      class (DebugListener), intent(inout) :: this
      class (AbstractTestResult), intent(in) :: result
      _UNUSED_DUMMY(this)
@@ -115,4 +115,4 @@ contains
      _UNUSED_DUMMY(testName)
    end subroutine addSuccess
 
-end module PF_DebugListener_mod
+end module PF_DebugListener

--- a/src/core/DotPattern.F90
+++ b/src/core/DotPattern.F90
@@ -1,6 +1,6 @@
-module PF_DotPattern_mod
-   use PF_AbstractPattern_mod
-   use PF_MatchObject_mod
+module PF_DotPattern
+   use PF_AbstractPattern
+   use PF_MatchObject
    implicit none
    private
 
@@ -41,4 +41,4 @@ contains
 
    end function match
 
-end module PF_DotPattern_mod
+end module PF_DotPattern

--- a/src/core/DynamicTestCase.F90
+++ b/src/core/DynamicTestCase.F90
@@ -20,8 +20,8 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_DynamicTestCase_mod
-   use PF_TestCase_mod
+module PF_DynamicTestCase
+   use PF_TestCase
    implicit none
    private
 
@@ -74,4 +74,4 @@ contains
       call this%testMethod
    end subroutine runMethod
 
-end module PF_DynamicTestCase_mod
+end module PF_DynamicTestCase

--- a/src/core/Exception.F90
+++ b/src/core/Exception.F90
@@ -20,8 +20,8 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen.
 !
 !-------------------------------------------------------------------------------
-module PF_PrivateException_mod
-   use PF_SourceLocation_mod
+module PF_PrivateException
+   use PF_SourceLocation
    implicit none
    private
 
@@ -141,11 +141,11 @@ contains
 
    end function deserialize
 
-end module PF_PrivateException_mod
+end module PF_PrivateException
 
-module PF_Exception_mod
-   use PF_SourceLocation_mod
-   use PF_PrivateException_mod
+module PF_Exception
+   use PF_SourceLocation
+   use PF_PrivateException
    implicit none
    private
 
@@ -155,4 +155,4 @@ module PF_Exception_mod
    public :: UNKNOWN_LINE_NUMBER
    public :: UNKNOWN_FILE_NAME
 
-end module PF_Exception_mod
+end module PF_Exception

--- a/src/core/ExceptionList.F90
+++ b/src/core/ExceptionList.F90
@@ -1,7 +1,7 @@
-module PF_ExceptionList_mod
-   use PF_SourceLocation_mod
-   use PF_Exception_mod, only: Exception
-   use PF_ExceptionVector_mod
+module PF_ExceptionList
+   use PF_SourceLocation
+   use PF_Exception, only: Exception
+   use PF_ExceptionVector
    implicit none
    private
 
@@ -140,7 +140,7 @@ contains
    end function catch_next
 
    subroutine gather(this, context)
-      use PF_ParallelContext_mod
+      use PF_ParallelContext
       class (ExceptionList), intent(inOut) :: this
       class (ParallelContext), intent(in) :: context
 
@@ -251,7 +251,7 @@ contains
 
 
    logical function anyExceptions_context(context) result(any)
-      use PF_ParallelContext_mod, only: ParallelContext
+      use PF_ParallelContext, only: ParallelContext
       class (ParallelContext), intent(in) :: context
 
       any = context%allReduce(anyExceptions())
@@ -295,7 +295,7 @@ contains
 
 
    integer function getNumExceptions_context(context) result(numExceptions)
-      use PF_ParallelContext_mod, only: ParallelContext
+      use PF_ParallelContext, only: ParallelContext
       class (ParallelContext), intent(in) :: context
 
       numExceptions = context%sum(getNumExceptions())
@@ -306,7 +306,7 @@ contains
 
 
    subroutine gatherExceptions(context)
-      use PF_ParallelContext_mod
+      use PF_ParallelContext
       class (ParallelContext), intent(in) :: context
 
       call global_exception_list%gather(context)
@@ -332,4 +332,4 @@ contains
    end function getExceptions
 
 
-end module PF_ExceptionList_mod
+end module PF_ExceptionList

--- a/src/core/ExceptionVector.F90
+++ b/src/core/ExceptionVector.F90
@@ -1,5 +1,5 @@
-module PF_ExceptionVector_mod
-   use PF_Exception_mod
+module PF_ExceptionVector
+   use PF_Exception
    
 #define _type class(Exception)
 #define _allocatable
@@ -7,4 +7,4 @@ module PF_ExceptionVector_mod
 #define _iterator ExceptionVectorIterator
 #include "templates/vector.inc"
 
-end module PF_ExceptionVector_mod
+end module PF_ExceptionVector

--- a/src/core/Expectation.F90
+++ b/src/core/Expectation.F90
@@ -3,7 +3,7 @@
 ! Note: maybe have multiple expectation types for subroutines, classes, etc.
 ! 
 
-module PF_Expectation_mod
+module PF_Expectation
   implicit none
   private
 
@@ -128,4 +128,4 @@ contains
     name = 'wasCalledOnce'
  end function get_name_was_called_once
 
-end module PF_Expectation_mod
+end module PF_Expectation

--- a/src/core/FUnit.F90
+++ b/src/core/FUnit.F90
@@ -21,39 +21,39 @@
 !
 !-------------------------------------------------------------------------------
 module FUnit_private
-   use PF_SourceLocation_mod
-   use PF_Exception_mod
-   use PF_ExceptionVector_mod
-   use PF_ExceptionList_mod
-   use PF_Expectation_mod
-   use PF_Test_mod
-   use PF_TestSuite_mod
-   use PF_TestCase_mod
-   use PF_TestMethod_mod
-   use PF_AbstractTestParameter_mod
-   use PF_ParameterizedTestCase_mod
-   use PF_TestResult_mod
-   use PF_TestRunner_mod
-   use PF_BaseTestRunner_mod
-   use PF_SubsetRunner_mod
+   use PF_SourceLocation
+   use PF_Exception
+   use PF_ExceptionVector
+   use PF_ExceptionList
+   use PF_Expectation
+   use PF_Test
+   use PF_TestSuite
+   use PF_TestCase
+   use PF_TestMethod
+   use PF_AbstractTestParameter
+   use PF_ParameterizedTestCase
+   use PF_TestResult
+   use PF_TestRunner
+   use PF_BaseTestRunner
+   use PF_SubsetRunner
 
-   use PF_TestListener_mod
-   use PF_TestListenerVector_mod
-   use PF_XmlPrinter_mod
-   use PF_ResultPrinter_mod
-   use PF_DebugListener_mod
+   use PF_TestListener
+   use PF_TestListenerVector
+   use PF_XmlPrinter
+   use PF_ResultPrinter
+   use PF_DebugListener
 
-   use gFTL_StringVectorMod
-   use gFTL_StringUnlimitedMapMod
+   use gFTL_StringVector
+   use gFTL_StringUnlimitedMap
 
-   use PF_RobustRunner_mod
-   use PF_Assert_mod
-   use PF_ParallelContext_mod
-   use PF_SerialContext_mod
+   use PF_RobustRunner
+   use PF_Assert
+   use PF_ParallelContext
+   use PF_SerialContext
 
-   use Pf_TestAnnotation_mod
+   use Pf_TestAnnotation
 
-   use pf_NameFilter_mod
+   use pf_NameFilter
 
    use fParse
 

--- a/src/core/GlobPattern.F90
+++ b/src/core/GlobPattern.F90
@@ -1,4 +1,4 @@
-module PF_GlobPattern_mod
+module PF_GlobPattern
    implicit none
    private
 
@@ -72,4 +72,4 @@ contains
 
    end function match_
 
-end module PF_GlobPattern_mod
+end module PF_GlobPattern

--- a/src/core/KeywordEnforcer.F90
+++ b/src/core/KeywordEnforcer.F90
@@ -21,7 +21,7 @@
 ! ABSTRACT extensions can be created, but do not circumvent the
 ! keyword enforcement.
 
-module pf_KeywordEnforcer_mod
+module pf_KeywordEnforcer
    implicit none
    private
 
@@ -37,4 +37,4 @@ module pf_KeywordEnforcer_mod
       end subroutine nonimplementable
    end interface
 
-end module pf_KeywordEnforcer_mod
+end module pf_KeywordEnforcer

--- a/src/core/LiteralPattern.F90
+++ b/src/core/LiteralPattern.F90
@@ -1,6 +1,6 @@
-module PF_LiteralPattern_mod
-   use PF_AbstractPattern_mod
-   use PF_MatchObject_mod
+module PF_LiteralPattern
+   use PF_AbstractPattern
+   use PF_MatchObject
    implicit none
    private
 
@@ -52,4 +52,4 @@ contains
 
    end function match
 
-end module PF_LiteralPattern_mod
+end module PF_LiteralPattern

--- a/src/core/MatchObject.F90
+++ b/src/core/MatchObject.F90
@@ -1,4 +1,4 @@
-module PF_MatchObject_mod
+module PF_MatchObject
    implicit none
    private
 
@@ -10,4 +10,4 @@ module PF_MatchObject_mod
       character(len=:), allocatable :: string
    end type MatchObject
 
-end module PF_MatchObject_mod
+end module PF_MatchObject

--- a/src/core/Mock.F90
+++ b/src/core/Mock.F90
@@ -22,9 +22,9 @@
 !
 !-------------------------------------------------------------------------------
 
-module Mock_mod
+module Mock
 
-  use MockRepository_mod
+  use MockRepository
 
   implicit none
   private
@@ -49,6 +49,6 @@ contains
     call this%repository%registerMockCallBy(this%name)
   end subroutine registerCall
 
-end module Mock_mod
+end module Mock
 
 

--- a/src/core/MockCall.F90
+++ b/src/core/MockCall.F90
@@ -20,8 +20,8 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_MockCall_mod
-   use PF_Exception_mod
+module PF_MockCall
+   use PF_Exception
    implicit none
    private
 
@@ -57,4 +57,4 @@ contains
       p => this%argument
    end function getExpectedValue
 
-end module PF_MockCall_mod
+end module PF_MockCall

--- a/src/core/MockRepository.F90
+++ b/src/core/MockRepository.F90
@@ -22,11 +22,11 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_MockRepository_mod
-   use PF_Expectation_mod, only : Expectation
-   use PF_Expectation_mod, only : Subject
-   use PF_Expectation_mod, only : Predicate
-   use PF_Expectation_mod, only : wasCalled! , wasNotCalled, wasCalledOnce
+module PF_MockRepository
+   use PF_Expectation, only : Expectation
+   use PF_Expectation, only : Subject
+   use PF_Expectation, only : Predicate
+   use PF_Expectation, only : wasCalled! , wasNotCalled, wasCalledOnce
 
    implicit none
    private
@@ -117,8 +117,8 @@ contains
    end subroutine delete
 
    subroutine verifyMocking(this, object)
-      use PF_Exception_mod
-      use PF_ExceptionList_mod
+      use PF_Exception
+      use PF_ExceptionList
       class (MockRepository), intent(inout) :: this
       class (*) :: object
       
@@ -202,8 +202,8 @@ contains
    end subroutine registerMockCallBy_subName_
 
    subroutine verify(this)
-      use PF_Exception_mod
-      use PF_ExceptionList_mod
+      use PF_Exception
+      use PF_ExceptionList
       class (MockRepository), intent(inout), target :: this
       integer iExp, iReg
       class (Expectation), pointer :: exp, reg
@@ -263,4 +263,4 @@ contains
     end subroutine verify
 
    
-end module PF_MockRepository_mod
+end module PF_MockRepository

--- a/src/core/NameFilter.F90
+++ b/src/core/NameFilter.F90
@@ -1,6 +1,6 @@
-module pf_NameFilter_mod
-  use pf_TestFilter_mod
-  use pf_Test_mod
+module pf_NameFilter
+  use pf_TestFilter
+  use pf_Test
   implicit none
   private
 
@@ -35,4 +35,4 @@ contains
   end function filter
 
 
-end module pf_NameFilter_mod
+end module pf_NameFilter

--- a/src/core/None.F90
+++ b/src/core/None.F90
@@ -1,4 +1,4 @@
-module pf_None_mod
+module pf_None
    implicit none
    private
 
@@ -9,4 +9,4 @@ module pf_None_mod
 
    type (t_None), parameter :: NONE = t_NONE()
    
-end module pf_None_mod
+end module pf_None

--- a/src/core/ParallelContext.F90
+++ b/src/core/ParallelContext.F90
@@ -24,7 +24,7 @@
 ! Subclass for MPI operations
 
 #include "unused_dummy.fh"
-module PF_ParallelContext_mod
+module PF_ParallelContext
    implicit none
    private
 
@@ -126,4 +126,4 @@ contains
 
    end function labelProcess
 
-end module PF_ParallelContext_mod
+end module PF_ParallelContext

--- a/src/core/ParameterizedTestCase.F90
+++ b/src/core/ParameterizedTestCase.F90
@@ -21,9 +21,9 @@
 ! 01 Jan 2014 - Added "hidden" method toStringActual()
 !
 !-------------------------------------------------------------------------------
-module PF_ParameterizedTestCase_mod
-   use PF_TestCase_mod
-   use PF_AbstractTestParameter_mod
+module PF_ParameterizedTestCase
+   use PF_TestCase
+   use PF_AbstractTestParameter
    implicit none
    private
    
@@ -55,4 +55,4 @@ contains
       allocate(this%testParameter, source=testParameter)
    end subroutine setTestParameter
 
-end module PF_ParameterizedTestCase_mod
+end module PF_ParameterizedTestCase

--- a/src/core/Params.F90
+++ b/src/core/Params.F90
@@ -21,7 +21,7 @@
 !
 !-------------------------------------------------------------------------------
 
-module PF_Params_mod
+module PF_Params
   use, intrinsic :: iso_fortran_env
   implicit none
 
@@ -38,5 +38,5 @@ module PF_Params_mod
   integer, parameter :: NEQP=0, EQP=1, GTP=2, GEP=3, LTP=4, LEP=5, &
   &  RELEQP=6
 
-end module PF_Params_mod
+end module PF_Params
 

--- a/src/core/RegularExpression.F90
+++ b/src/core/RegularExpression.F90
@@ -1,4 +1,4 @@
-module PF_RegularExpression_mod
+module PF_RegularExpression
    implicit none
    private
 
@@ -61,4 +61,4 @@ contains
 
    end function match
 
-end module PF_RegularExpression_mod
+end module PF_RegularExpression

--- a/src/core/RemoteProxyTestCase.F90
+++ b/src/core/RemoteProxyTestCase.F90
@@ -20,11 +20,11 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_RemoteProxyTestCase_mod
-   use PF_UnixProcess_mod
-   use PF_ExceptionList_mod
-   use PF_Test_mod
-   use PF_TestCase_mod
+module PF_RemoteProxyTestCase
+   use PF_UnixProcess
+   use PF_ExceptionList
+   use PF_Test
+   use PF_TestCase
    implicit none
    private
 
@@ -66,8 +66,8 @@ contains
    end function newRemoteProxyTestCase
 
    subroutine runMethod(this)
-      use PF_SourceLocation_mod
-      use PF_UnixProcess_mod
+      use PF_SourceLocation
+      use PF_UnixProcess
       use, intrinsic :: iso_c_binding
       class (RemoteProxyTestCase), intent(inout) :: this
       character(len=:), allocatable :: line
@@ -212,4 +212,4 @@ contains
       call system_clock(this%clockStart)
    end subroutine setStartTime
 
-end module PF_RemoteProxyTestCase_mod
+end module PF_RemoteProxyTestCase

--- a/src/core/RepeatPattern.F90
+++ b/src/core/RepeatPattern.F90
@@ -1,6 +1,6 @@
-module PF_RepeatPattern_mod
-   use PF_AbstractPattern_mod
-   use PF_MatchObject_mod
+module PF_RepeatPattern
+   use PF_AbstractPattern
+   use PF_MatchObject
    implicit none
    private
 
@@ -56,4 +56,4 @@ contains
 
    end function match
 
-end module PF_RepeatPattern_mod
+end module PF_RepeatPattern

--- a/src/core/ResultPrinter.F90
+++ b/src/core/ResultPrinter.F90
@@ -22,9 +22,9 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen.
 !
 !-------------------------------------------------------------------------------
-module PF_ResultPrinter_mod
-   use PF_Exception_mod
-   use PF_TestListener_mod, only : TestListener
+module PF_ResultPrinter
+   use PF_Exception
+   use PF_TestListener, only : TestListener
    implicit none
    private
 
@@ -68,7 +68,7 @@ contains
   end function new_ResultPrinter
 
   subroutine addFailure(this, testName, exceptions)
-     use PF_ExceptionList_mod
+     use PF_ExceptionList
      class (ResultPrinter), intent(inOut) :: this
      character(len=*), intent(in) :: testName
      type (ExceptionList), intent(in) :: exceptions
@@ -81,7 +81,7 @@ contains
   end subroutine addFailure
 
   subroutine addError(this, testName, exceptions)
-     use PF_ExceptionList_mod
+     use PF_ExceptionList
      class (ResultPrinter), intent(inOut) :: this
      character(len=*), intent(in) :: testName
      type (ExceptionList), intent(in) :: exceptions
@@ -133,7 +133,7 @@ contains
    end subroutine endTest
 
    subroutine endRun(this, result)
-      use PF_AbstractTestResult_mod, only : AbstractTestResult
+      use PF_AbstractTestResult, only : AbstractTestResult
       class (ResultPrinter), intent(inout) :: this
       class (AbstractTestResult), intent(in) :: result
 
@@ -142,8 +142,8 @@ contains
     end subroutine endRun
 
    subroutine print(this, result)
-      use PF_AbstractTestResult_mod, only : AbstractTestResult
-      use PF_TestFailureVector_mod
+      use PF_AbstractTestResult, only : AbstractTestResult
+      use PF_TestFailureVector
       class (ResultPrinter), intent(in) :: this
       class (AbstractTestResult), intent(in) :: result
 
@@ -165,9 +165,9 @@ contains
    end subroutine printHeader
 
    subroutine printFailures(this, label, failures)
-      use PF_TestFailure_mod
-      use PF_TestFailureVector_mod
-      use PF_SourceLocation_mod
+      use PF_TestFailure
+      use PF_TestFailureVector
+      use PF_SourceLocation
       class (ResultPrinter), intent(in) :: this
       character(len=*), intent(in) :: label
       type (TestFailureVector), intent(in) :: failures
@@ -195,7 +195,7 @@ contains
    end subroutine printFailures
 
    subroutine printFooter(this, result)
-      use PF_AbstractTestResult_mod
+      use PF_AbstractTestResult
       class (ResultPrinter), intent(in) :: this
       class (AbstractTestResult), intent(in) :: result
 
@@ -241,4 +241,4 @@ contains
 
    end subroutine addSuccess
      
-end module PF_ResultPrinter_mod
+end module PF_ResultPrinter

--- a/src/core/RobustRunner.F90
+++ b/src/core/RobustRunner.F90
@@ -22,12 +22,12 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_RobustRunner_mod
-   use PF_Test_mod
-   use PF_TestCase_mod
-   use PF_BaseTestRunner_mod
-   use PF_TestListener_mod
-   use PF_UnixProcess_mod
+module PF_RobustRunner
+   use PF_Test
+   use PF_TestCase
+   use PF_BaseTestRunner
+   use PF_TestListener
+   use PF_UnixProcess
    implicit none
    private
 
@@ -127,10 +127,10 @@ contains
    end subroutine runMethod
 
    function run(this, aTest, context) result(result)
-      use PF_Test_mod
-      use PF_TestSuite_mod
-      use PF_TestResult_mod
-      use PF_ParallelContext_mod
+      use PF_Test
+      use PF_TestSuite
+      use PF_TestResult
+      use PF_ParallelContext
 
       type (TestResult) :: result
       class (RobustRunner), target, intent(inout) :: this
@@ -144,13 +144,13 @@ contains
    end function run
 
    subroutine runWithResult(this, aTest, context, result)
-      use PF_Test_mod
-      use PF_ParallelContext_mod
-      use PF_TestResult_mod
-      use PF_RemoteProxyTestCase_mod
-      use PF_TestSuite_mod
-      use PF_TestVector_mod
-      use PF_ExceptionList_mod
+      use PF_Test
+      use PF_ParallelContext
+      use PF_TestResult
+      use PF_RemoteProxyTestCase
+      use PF_TestSuite
+      use PF_TestVector
+      use PF_ExceptionList
       class (RobustRunner), target, intent(inout) :: this
       class (Test), intent(inout) :: aTest
       class (ParallelContext), intent(in) :: context
@@ -205,8 +205,8 @@ contains
    end subroutine runWithResult
 
    subroutine launchRemoteRunner(this, numSkip)
-      use PF_UnixProcess_mod
-      use PF_ExceptionList_mod
+      use PF_UnixProcess
+      use PF_ExceptionList
       class (RobustRunner), intent(inout) :: this
       integer, intent(in) :: numSkip
 
@@ -286,7 +286,7 @@ contains
    end subroutine endTest
 
    subroutine endRun(this, result)
-     use PF_AbstractTestResult_mod
+     use PF_AbstractTestResult
      class (RobustRunner), intent(inout) :: this
      class (AbstractTestResult), intent(in) :: result
 
@@ -296,7 +296,7 @@ contains
    end subroutine endRun
 
    subroutine addFailure(this, testName, exceptions)
-      use PF_ExceptionList_mod
+      use PF_ExceptionList
       class (RobustRunner), intent(inout) :: this
       character(len=*), intent(in) :: testName
       type (ExceptionList), intent(in) :: exceptions
@@ -308,7 +308,7 @@ contains
    end subroutine addFailure
 
    subroutine addError(this, testName, exceptions)
-      use PF_ExceptionList_mod
+      use PF_ExceptionList
       class (RobustRunner), intent(inout) :: this
       character(len=*), intent(in) :: testName
       type (ExceptionList), intent(in) :: exceptions
@@ -320,7 +320,7 @@ contains
    end subroutine addError
 
    function createTestResult(this) result(tstResult)
-      use PF_TestResult_mod
+      use PF_TestResult
       class (RobustRunner), intent(inout) :: this
       type (TestResult) :: tstResult
 
@@ -340,4 +340,4 @@ contains
 
    end subroutine addSuccess
 
-end module PF_RobustRunner_mod
+end module PF_RobustRunner

--- a/src/core/SerialContext.F90
+++ b/src/core/SerialContext.F90
@@ -21,8 +21,8 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_SerialContext_mod
-   use PF_ParallelContext_mod
+module PF_SerialContext
+   use PF_ParallelContext
    implicit none
    private
 
@@ -140,4 +140,4 @@ contains
       _UNUSED_DUMMY(this)
    end subroutine clean
 
-end module PF_SerialContext_mod
+end module PF_SerialContext

--- a/src/core/SourceLocation.F90
+++ b/src/core/SourceLocation.F90
@@ -23,7 +23,7 @@
 ! This module just provides a data type - not a class.
 ! Meant to be shared for easy access.
 
-module PF_SourceLocation_mod
+module PF_SourceLocation
    implicit none
    private
 
@@ -123,4 +123,4 @@ contains
 
    end function deserialize
 
-end module PF_SourceLocation_mod
+end module PF_SourceLocation

--- a/src/core/StringUtilities.F90
+++ b/src/core/StringUtilities.F90
@@ -33,10 +33,10 @@
 ! Further control of field width could be added at a later time.
 !
 
-module PF_StringUtilities_mod
+module PF_StringUtilities
 
-  use PF_Params_mod, only : r32, r64
-  use PF_Params_mod, only : i32, i64
+  use PF_Params, only : r32, r64
+  use PF_Params, only : i32, i64
 
    implicit none
    private
@@ -295,4 +295,4 @@ contains
    end function trimTrailingWhitespace
 
 
-end module PF_StringUtilities_mod
+end module PF_StringUtilities

--- a/src/core/SubsetRunner.F90
+++ b/src/core/SubsetRunner.F90
@@ -37,9 +37,9 @@
 ! RobustRunner and SubsetRunner.
 ! -----------------------------------------------------------------------
 
-module PF_SubsetRunner_mod
-   use PF_Test_mod
-   use PF_BaseTestRunner_mod
+module PF_SubsetRunner
+   use PF_Test
+   use PF_BaseTestRunner
    implicit none
    private
 
@@ -89,12 +89,12 @@ contains
 
    function run(this, aTest, context) result(result)
       use, intrinsic :: iso_fortran_env, only: OUTPUT_UNIT
-      use PF_Test_mod
-      use PF_TestVector_mod
-      use PF_ParallelContext_mod
-      use PF_TestCase_mod
-      use PF_TestResult_mod
-      use PF_TestSuite_mod
+      use PF_Test
+      use PF_TestVector
+      use PF_ParallelContext
+      use PF_TestCase
+      use PF_TestResult
+      use PF_TestSuite
 
       type (TestResult) :: result
       class (SubsetRunner), target, intent(inout) :: this
@@ -135,8 +135,8 @@ contains
    end function run
 
    subroutine addFailure(this, testName, exceptions)
-      use PF_Exception_mod
-      use PF_ExceptionList_mod
+      use PF_Exception
+      use PF_ExceptionList
       use, intrinsic :: iso_c_binding
       class (SubsetRunner), intent(inout) :: this
       character(len=*), intent(in) :: testName
@@ -177,7 +177,7 @@ contains
    end subroutine endTest
 
    subroutine endRun(this, result)
-     use PF_AbstractTestResult_mod, only : AbstractTestResult
+     use PF_AbstractTestResult, only : AbstractTestResult
      class (SubsetRunner), intent(inout) :: this
      class (AbstractTestResult), intent(in) :: result
 
@@ -194,4 +194,4 @@ contains
 
    end subroutine addSuccess
    
-end module PF_SubsetRunner_mod
+end module PF_SubsetRunner

--- a/src/core/SurrogateTestCase.F90
+++ b/src/core/SurrogateTestCase.F90
@@ -32,7 +32,7 @@
 ! Multiple-Inheritance design pattern is also required.  That portion
 ! is implemented in the TestCase module.
 
-module PF_SurrogateTestCase_mod
+module PF_SurrogateTestCase
    implicit none
    private
 
@@ -76,4 +76,4 @@ module PF_SurrogateTestCase_mod
 
    end interface
 
-end module PF_SurrogateTestCase_mod
+end module PF_SurrogateTestCase

--- a/src/core/TapListener.F90
+++ b/src/core/TapListener.F90
@@ -25,9 +25,9 @@
 !    May need to separate status reports from the end-of-run summary
 !
 !-------------------------------------------------------------------------------
-module PF_TapListener_mod
-   use PF_Exception_mod
-   use PF_TestListener_mod
+module PF_TapListener
+   use PF_Exception
+   use PF_TestListener
    implicit none
    private
 
@@ -66,7 +66,7 @@ contains
    end function newTapListener
 
    subroutine addFailure(this, testName, exceptions)
-      use PF_ExceptionList_mod
+      use PF_ExceptionList
       class (TapListener), intent(inOut) :: this
       character(len=*), intent(in) :: testName
       type (ExceptionList), intent(in) :: exceptions
@@ -83,7 +83,7 @@ contains
    end subroutine addFailure
 
    subroutine addError(this, testName, exceptions)
-      use PF_ExceptionList_mod
+      use PF_ExceptionList
       class (TapListener), intent(inOut) :: this
       character(len=*), intent(in) :: testName
       type (ExceptionList), intent(in) :: exceptions
@@ -119,7 +119,7 @@ contains
    end subroutine endTest
 
    subroutine endRun(this, result)
-     use PF_AbstractTestResult_mod, only : AbstractTestResult
+     use PF_AbstractTestResult, only : AbstractTestResult
      class (TapListener), intent(inOut) :: this
      class (AbstractTestResult), intent(in) :: result
 
@@ -127,7 +127,7 @@ contains
    end subroutine endRun
 
    subroutine print(this, result)
-      use PF_AbstractTestResult_mod, only : AbstractTestResult
+      use PF_AbstractTestResult, only : AbstractTestResult
       class (TapListener), intent(in) :: this
       class (AbstractTestResult), intent(in) :: result
 
@@ -140,7 +140,7 @@ contains
    end subroutine print
 
    subroutine printHeader(this, result)
-      use PF_AbstractTestResult_mod, only : AbstractTestResult
+      use PF_AbstractTestResult, only : AbstractTestResult
       class (TapListener), intent(in) :: this
       class (AbstractTestResult), intent(in) :: result
 
@@ -156,8 +156,8 @@ contains
    end subroutine printHeader
 
    subroutine printFailure(this, label, aFailedTest)
-      use PF_TestFailure_mod
-      use PF_SourceLocation_mod
+      use PF_TestFailure
+      use PF_SourceLocation
       class (TapListener), intent(in) :: this
       character(len=*), intent(in) :: label
       type (TestFailure), intent(in) :: aFailedTest
@@ -168,9 +168,9 @@ contains
    end subroutine printFailure
 
    subroutine printExceptions(this, label, testName, exceptions)
-      use PF_TestFailure_mod
-      use PF_SourceLocation_mod
-      use PF_ExceptionList_mod
+      use PF_TestFailure
+      use PF_SourceLocation
+      use PF_ExceptionList
       class (TapListener), intent(in) :: this
       character(len=*), intent(in) :: label
       character(len=*), intent(in) :: testName
@@ -207,8 +207,8 @@ contains
 
 !mlr old version
    subroutine printFailure1(this, label, aFailedTest)
-      use PF_TestFailure_mod
-      use PF_SourceLocation_mod
+      use PF_TestFailure
+      use PF_SourceLocation
       class (TapListener), intent(in) :: this
       character(len=*), intent(in) :: label
       type (TestFailure), intent(in) :: aFailedTest
@@ -241,9 +241,9 @@ contains
    end subroutine printFailure1
 
    subroutine printFailures(this, label, failures)
-      use PF_TestFailure_mod
-      use PF_TestFailureVector_mod
-      use PF_SourceLocation_mod
+      use PF_TestFailure
+      use PF_TestFailureVector
+      use PF_SourceLocation
       class (TapListener), intent(in) :: this
       character(len=*), intent(in) :: label
       type (TestFailureVector), intent(in) :: failures
@@ -257,7 +257,7 @@ contains
    end subroutine printFailures
 
    subroutine printTestName(this, testName)
-      use PF_TestFailure_mod
+      use PF_TestFailure
       class (TapListener), intent(in) :: this
       character(len=*), intent(in) :: testName
 
@@ -269,7 +269,7 @@ contains
     end subroutine printTestName
 
    subroutine printSuccess(this, aSuccessTest)
-      use PF_TestFailure_mod
+      use PF_TestFailure
       class (TapListener), intent(in) :: this
       type (TestFailure) :: aSuccessTest
 
@@ -283,8 +283,8 @@ contains
    end subroutine printSuccess
 
    subroutine printSuccesses(this, successes)
-      use PF_TestFailure_mod
-      use PF_TestFailurevector_mod
+      use PF_TestFailure
+      use PF_TestFailurevector
       class (TapListener), intent(in) :: this
       type (TestFailureVector), intent(in) :: successes
 
@@ -297,7 +297,7 @@ contains
    end subroutine printSuccesses
 
    subroutine printFooter(this, result)
-      use PF_AbstractTestResult_mod
+      use PF_AbstractTestResult
       class (TapListener), intent(in) :: this
       class (AbstractTestResult), intent(in) :: result
 
@@ -338,4 +338,4 @@ contains
       write(this%unit,*) 'ok - ',testName
    end subroutine addSuccess
 
-end module PF_TapListener_mod
+end module PF_TapListener

--- a/src/core/Test.F90
+++ b/src/core/Test.F90
@@ -21,9 +21,9 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_Test_mod
-   use pf_TestAnnotation_mod
-   use pf_StringTestAnnotationMap_mod
+module PF_Test
+   use pf_TestAnnotation
+   use pf_StringTestAnnotationMap
    implicit none
    private
 
@@ -49,8 +49,8 @@ module PF_Test_mod
       end function countTestCases
 
       recursive subroutine run(this, tstResult, context)
-         use PF_TestResult_mod
-         use PF_ParallelContext_mod
+         use PF_TestResult
+         use PF_ParallelContext
          import Test
          class (Test), target, intent(inout) :: this
          class (TestResult), intent(inout) :: tstResult
@@ -84,4 +84,4 @@ contains
 
    end function is_disabled
 
-end module PF_Test_mod
+end module PF_Test

--- a/src/core/TestAnnotation.F90
+++ b/src/core/TestAnnotation.F90
@@ -1,4 +1,4 @@
-module pf_TestAnnotation_mod
+module pf_TestAnnotation
    implicit none
    private
 
@@ -37,11 +37,11 @@ contains
       
    end function disable_type_name
 
-end module pf_TestAnnotation_mod
+end module pf_TestAnnotation
 
 
-module pf_StringTestAnnotationMap_mod
-   use pf_TestAnnotation_mod
+module pf_StringTestAnnotationMap
+   use pf_TestAnnotation
 
 #define _map StringTestAnnotationMap
 #define _iterator StringTestAnnotationMapIterator
@@ -51,4 +51,4 @@ module pf_StringTestAnnotationMap_mod
 #define _alt
 #include "templates/map.inc"
 
-end module pf_StringTestAnnotationMap_mod
+end module pf_StringTestAnnotationMap

--- a/src/core/TestCase.F90
+++ b/src/core/TestCase.F90
@@ -22,10 +22,10 @@
 !
 !-------------------------------------------------------------------------------
 ! Serial TestCase 
-module PF_TestCase_mod
-   use PF_SurrogateTestCase_mod
-   use PF_TestResult_mod
-   use PF_Test_mod
+module PF_TestCase
+   use PF_SurrogateTestCase
+   use PF_TestResult
+   use PF_Test
 
    private
 
@@ -94,9 +94,9 @@ contains
 
 ! Implement deferred method from class Test
    recursive subroutine run(this, tstResult, context)
-      use PF_SerialContext_mod
-      use PF_TestResult_mod
-      use PF_ParallelContext_mod
+      use PF_SerialContext
+      use PF_TestResult
+      use PF_ParallelContext
       class (TestCase), target, intent(inout) :: this
       class (TestResult), intent(inout) :: tstResult
       class (ParallelContext), intent(in) :: context
@@ -128,7 +128,7 @@ contains
    end subroutine run
 
    recursive subroutine runBare(this)
-      use PF_ExceptionList_mod, only: anyExceptions
+      use PF_ExceptionList, only: anyExceptions
       class (TestCase), intent(inout) :: this
 
       call this%setUp()
@@ -181,7 +181,7 @@ contains
    end subroutine setSurrogate
 
    recursive subroutine runMethod(this)
-      use PF_ExceptionList_mod, only: throw
+      use PF_ExceptionList, only: throw
       class (TestCase), intent(inout) :: this
       _UNUSED_DUMMY(this)
       call throw('TestCase::runMethod() must be overridden.')
@@ -194,4 +194,4 @@ contains
 
    end function is_disabled
 
-end module PF_TestCase_mod
+end module PF_TestCase

--- a/src/core/TestFailure.F90
+++ b/src/core/TestFailure.F90
@@ -20,9 +20,9 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_TestFailure_mod
-   use PF_Exception_mod
-   use PF_ExceptionList_mod
+module PF_TestFailure
+   use PF_Exception
+   use PF_ExceptionList
    implicit none
    private
 
@@ -44,4 +44,4 @@ module PF_TestFailure_mod
 !!$      type (Exception), intent(in) :: exceptions(:)
 !!$   end function newTestFailure
 
-end module PF_TestFailure_mod
+end module PF_TestFailure

--- a/src/core/TestFailureVector.F90
+++ b/src/core/TestFailureVector.F90
@@ -1,8 +1,8 @@
-module PF_TestFailureVector_mod
-   use PF_TestFailure_mod
+module PF_TestFailureVector
+   use PF_TestFailure
 #define _type type (TestFailure)
 #define _vector TestFailureVector
 #define _iterator TestFailureVectorIterator
 #include "templates/vector.inc"
 
-end module PF_TestFailureVector_mod
+end module PF_TestFailureVector

--- a/src/core/TestFilter.F90
+++ b/src/core/TestFilter.F90
@@ -1,4 +1,4 @@
-module pf_TestFilter_mod
+module pf_TestFilter
   implicit none
   private
 
@@ -13,7 +13,7 @@ module pf_TestFilter_mod
   abstract interface
 
      logical function filter(this, a_test)
-       use pf_Test_mod
+       use pf_Test
        import TestFilter
        class(TestFilter), intent(in) :: this
        class(Test), intent(in) :: a_test
@@ -21,4 +21,4 @@ module pf_TestFilter_mod
 
   end interface
 
-end module pf_TestFilter_mod
+end module pf_TestFilter

--- a/src/core/TestListener.F90
+++ b/src/core/TestListener.F90
@@ -21,7 +21,7 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_TestListener_mod
+module PF_TestListener
    implicit none
    private
 
@@ -50,8 +50,8 @@ module PF_TestListener_mod
 
    abstract interface
       subroutine addFailure(this, testName, exceptions)
-         use PF_Exception_mod
-         use PF_ExceptionList_mod
+         use PF_Exception
+         use PF_ExceptionList
          import TestListener
          class (TestListener), intent(inout) :: this
          character(len=*), intent(in) :: testName
@@ -78,7 +78,7 @@ module PF_TestListener_mod
 !
       ! Stub for future implementation.
       subroutine endRun(this, result)
-         use PF_AbstractTestResult_mod, only : AbstractTestResult
+         use PF_AbstractTestResult, only : AbstractTestResult
          import TestListener
          class (TestListener), intent(inout) :: this
          class (AbstractTestResult), intent(in) :: result
@@ -91,7 +91,7 @@ contains
    ! Most scenarios in Fortran cannot diagnose true errors, so
    ! an empty stub is provided here for convenience.
    subroutine addError(this, testName, exceptions)
-      use PF_ExceptionList_mod
+      use PF_ExceptionList
       class (TestListener), intent(inout) :: this
       character(len=*), intent(in) :: testName
       type (ExceptionList), intent(in) :: exceptions
@@ -123,4 +123,4 @@ contains
     end subroutine disableTest
     
 
- end module PF_TestListener_mod
+ end module PF_TestListener

--- a/src/core/TestListenerVector.F90
+++ b/src/core/TestListenerVector.F90
@@ -1,9 +1,9 @@
-module PF_TestListenerVector_mod
-   use PF_TestListener_mod
+module PF_TestListenerVector
+   use PF_TestListener
 #define _type class (TestListener)
 #define _allocatable
 #define _vector TestListenerVector
 #define _iterator TestListenerVectorIterator
 #include "templates/vector.inc"
 
-end module PF_TestListenerVector_mod
+end module PF_TestListenerVector

--- a/src/core/TestMethod.F90
+++ b/src/core/TestMethod.F90
@@ -20,8 +20,8 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_TestMethod_mod
-   use PF_TestCase_mod, only: TestCase
+module PF_TestMethod
+   use PF_TestCase, only: TestCase
    implicit none
    private
 
@@ -90,4 +90,4 @@ contains
       if (associated(this%userTearDown)) call this%userTearDown()
    end subroutine tearDown
 
-end module PF_TestMethod_mod
+end module PF_TestMethod

--- a/src/core/TestResult.F90
+++ b/src/core/TestResult.F90
@@ -21,13 +21,13 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_TestResult_mod
-   use PF_AbstractTestResult_mod
-   use PF_SurrogateTestCase_mod
-   use PF_TestListener_mod
-   use PF_TestListenerVector_mod
-   use PF_TestFailure_mod
-   use PF_TestFailureVector_mod
+module PF_TestResult
+   use PF_AbstractTestResult
+   use PF_SurrogateTestCase
+   use PF_TestListener
+   use PF_TestListenerVector
+   use PF_TestFailure
+   use PF_TestFailureVector
 
    implicit none
    private
@@ -96,8 +96,8 @@ contains
    end function new_TestResult
 
    subroutine addFailure(this, aTest, exceptions)
-      use PF_ExceptionList_mod
-      use PF_TestFailure_mod
+      use PF_ExceptionList
+      use PF_TestFailure
       class (TestResult), intent(inout) :: this
       class (SurrogateTestCase), intent(in) :: aTest
       type (ExceptionList), intent(in) :: exceptions
@@ -115,8 +115,8 @@ contains
    end subroutine addFailure
 
    subroutine addError(this, aTest, exceptions)
-      use PF_TestFailure_mod
-      use PF_ExceptionList_mod
+      use PF_TestFailure
+      use PF_ExceptionList
       class (TestResult), intent(inout) :: this
       class (SurrogateTestCase), intent(in) :: aTest
       type (ExceptionList), intent(in) :: exceptions
@@ -134,8 +134,8 @@ contains
    end subroutine addError
 
    subroutine addSuccess(this, aTest)
-      use PF_TestFailure_mod
-      use PF_ExceptionList_mod
+      use PF_TestFailure
+      use PF_ExceptionList
       class (TestResult), intent(inout) :: this
       class (SurrogateTestCase), intent(in) :: aTest
 
@@ -213,9 +213,9 @@ contains
 
 ! only invoked for a "real" test, not suites etc.
    recursive subroutine run(this, test, context)
-      use PF_Exception_mod
-      use PF_ExceptionList_mod
-      use PF_ParallelContext_mod
+      use PF_Exception
+      use PF_ExceptionList
+      use PF_ParallelContext
       class (TestResult), intent(inout) :: this
       class (SurrogateTestCase), intent(inout) :: test 
       class (ParallelContext), intent(in) :: context
@@ -245,7 +245,7 @@ contains
    end subroutine run
 
    subroutine addListener(this, listener)
-      use PF_TestListener_mod, only: TestListener
+      use PF_TestListener, only: TestListener
       class (TestResult), intent(inOut) :: this
       class (TestListener), target, intent(in) :: listener
 
@@ -316,4 +316,4 @@ contains
       this%name = trim(name)
    end subroutine setName
 
-end module PF_TestResult_mod
+end module PF_TestResult

--- a/src/core/TestRunner.F90
+++ b/src/core/TestRunner.F90
@@ -23,11 +23,11 @@
 !
 !-------------------------------------------------------------------------------
 
-module PF_TestRunner_mod
-   use PF_Test_mod
-   use PF_BaseTestRunner_mod
-   use PF_TestListener_mod
-   use PF_TestListenerVector_mod
+module PF_TestRunner
+   use PF_Test
+   use PF_BaseTestRunner
+   use PF_TestListener
+   use PF_TestListenerVector
    implicit none
    private
 
@@ -63,7 +63,7 @@ contains
    end function newTestRunner_unit
 
    function createTestResult(this) result(tstResult)
-      use PF_TestResult_mod
+      use PF_TestResult
       class (TestRunner), intent(inout) :: this
       type (TestResult) :: tstResult
 
@@ -74,11 +74,11 @@ contains
     end function createTestResult
 
     recursive function run(this, aTest, context) result(result)
-      use PF_Test_mod
-      use PF_TestSuite_mod
-      use PF_TestCase_mod
-      use PF_TestResult_mod
-      use PF_ParallelContext_mod
+      use PF_Test
+      use PF_TestSuite
+      use PF_TestCase
+      use PF_TestResult
+      use PF_ParallelContext
 
       type (TestResult) :: result
       class (TestRunner), target, intent(inout) :: this
@@ -142,7 +142,7 @@ contains
     end subroutine endTest
 
     subroutine endRun(this, result)
-      use PF_AbstractTestResult_mod, only : AbstractTestResult
+      use PF_AbstractTestResult, only : AbstractTestResult
       class (TestRunner), intent(inout) :: this
       class (AbstractTestResult), intent(in) :: result
 
@@ -152,7 +152,7 @@ contains
     end subroutine endRun
 
     subroutine addFailure(this, testName, exceptions)
-       use PF_ExceptionList_mod
+       use PF_ExceptionList
        class (TestRunner), intent(inout) :: this
        character(len=*), intent(in) :: testName
        type (ExceptionList), intent(in) :: exceptions
@@ -174,4 +174,4 @@ contains
 
    end subroutine addSuccess
 
-end module PF_TestRunner_mod
+end module PF_TestRunner

--- a/src/core/TestSuite.F90
+++ b/src/core/TestSuite.F90
@@ -20,10 +20,10 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_TestSuite_mod
-   use PF_ExceptionList_mod, only : throw
-   use PF_Test_mod
-   use PF_TestVector_mod
+module PF_TestSuite
+   use PF_ExceptionList, only : throw
+   use PF_Test
+   use PF_TestVector
    implicit none
    private
 
@@ -94,8 +94,8 @@ contains
    end function countTestCases
 
    recursive subroutine run(this, tstResult, context)
-      use PF_ParallelContext_mod
-      use PF_TestResult_mod
+      use PF_ParallelContext
+      use PF_TestResult
       class (TestSuite), target, intent(inout) :: this
       class (TestResult), intent(inout) :: tstResult
       class (ParallelContext), intent(in) :: context
@@ -141,9 +141,9 @@ contains
    end subroutine setName
 
    subroutine  getTestCases(this, testList)
-      use PF_Exception_mod
-      use PF_Test_mod
-      use PF_TestCase_mod
+      use PF_Exception
+      use PF_Test
+      use PF_TestCase
       class (TestSuite), intent(in) :: this
       type (TestVector), intent(out) :: testList
 
@@ -177,7 +177,7 @@ contains
 
 
     recursive function filter(this, a_filter) result(new_suite)
-      use pf_TestFilter_mod
+      use pf_TestFilter
       type(TestSuite) :: new_suite
       class(TestSuite), intent(in) :: this
       class(TestFilter), intent(in) :: a_filter
@@ -205,4 +205,4 @@ contains
     end function filter
 
 
- end module PF_TestSuite_mod
+ end module PF_TestSuite

--- a/src/core/TestVector.F90
+++ b/src/core/TestVector.F90
@@ -1,9 +1,9 @@
-module PF_TestVector_mod
-   use PF_Test_mod
+module PF_TestVector
+   use PF_Test
 #define _type class (Test)
 #define _allocatable
 #define _vector TestVector
 #define _iterator TestVectorIterator
 #include "templates/vector.inc"
 
-end module PF_TestVector_mod
+end module PF_TestVector

--- a/src/core/ThrowFundamentalTypes.F90
+++ b/src/core/ThrowFundamentalTypes.F90
@@ -21,13 +21,13 @@
 !
 !-------------------------------------------------------------------------------
 
-module PF_ThrowFundamentalTypes_mod
+module PF_ThrowFundamentalTypes
 
-  use PF_Params_mod
-  use PF_StringUtilities_mod
-  use PF_Exception_mod
-  use PF_ExceptionList_mod
-  use PF_SourceLocation_mod
+  use PF_Params
+  use PF_StringUtilities
+  use PF_Exception
+  use PF_ExceptionList
+  use PF_SourceLocation
 
   implicit none
   private
@@ -214,4 +214,4 @@ contains
       differenceReport = '    difference: |' // trim(toString(difference)) // '| > tolerance:' // trim(toString(tolerance))
    end function differenceReport
 
-end module PF_ThrowFundamentalTypes_mod
+end module PF_ThrowFundamentalTypes

--- a/src/core/UnixPipeInterfaces.F90
+++ b/src/core/UnixPipeInterfaces.F90
@@ -31,7 +31,7 @@
 ! should be safer for routine use.
 !-------------
 
-module PF_UnixPipeInterfaces_mod
+module PF_UnixPipeInterfaces
    use, intrinsic :: ISO_C_BINDING
    private
 
@@ -94,4 +94,4 @@ module PF_UnixPipeInterfaces_mod
 
    end interface
 
-end module PF_UnixPipeInterfaces_mod
+end module PF_UnixPipeInterfaces

--- a/src/core/UnixProcess.F90
+++ b/src/core/UnixProcess.F90
@@ -37,7 +37,7 @@
 ! portable on any Unix system, and easily adapted to Windows by
 ! someone with relevant expertise.
 
-module PF_UnixProcess_mod
+module PF_UnixProcess
    use, intrinsic :: iso_c_binding
    implicit none
    private
@@ -67,9 +67,9 @@ module PF_UnixProcess_mod
 contains
 
    function newProcess(command, runInBackground) result(process)
-      use PF_UnixPipeInterfaces_mod, only: popen
-      use PF_StringUtilities_mod, only: nullTerminate
-      use PF_ExceptionList_mod, only: throw
+      use PF_UnixPipeInterfaces, only: popen
+      use PF_StringUtilities, only: nullTerminate
+      use PF_ExceptionList, only: throw
       type (UnixProcess) :: process
       character(len=*), intent(in) :: command
       logical, optional, intent(in) :: runInBackground
@@ -106,7 +106,7 @@ contains
    ! Background commands must return a PID for further interactions.
    ! Also commands need to be null-terminated to send to C procedures.
    function makeCommand(baseCommand, runInBackground) result(command)
-      use PF_StringUtilities_mod, only: nullTerminate
+      use PF_StringUtilities, only: nullTerminate
       character(len=:), allocatable :: command
       character(len=*), intent(in) :: baseCommand
       logical, optional, intent(in) :: runInBackground
@@ -160,8 +160,8 @@ contains
    end subroutine terminate
 
    function getLine(this) result(line)
-      use PF_UnixPipeInterfaces_mod, only: c_getLine => getLine
-      use PF_UnixPipeInterfaces_mod, only: free
+      use PF_UnixPipeInterfaces, only: c_getLine => getLine
+      use PF_UnixPipeInterfaces, only: free
       class (UnixProcess) :: this
       character(len=:), allocatable :: line
 
@@ -186,8 +186,8 @@ contains
    end function getLine
 
    function getDelim(this, delimeter) result(line)
-      use PF_UnixPipeInterfaces_mod, only: c_getDelim => getDelim
-      use PF_UnixPipeInterfaces_mod, only: free
+      use PF_UnixPipeInterfaces, only: c_getDelim => getDelim
+      use PF_UnixPipeInterfaces, only: free
       character(len=:), allocatable :: line
       class (UnixProcess) :: this
       character(len=C_CHAR), intent(in) :: delimeter
@@ -245,4 +245,4 @@ contains
    end subroutine execute_command_line
 #endif
    
-end module PF_UnixProcess_mod
+end module PF_UnixProcess

--- a/src/core/XmlPrinter.F90
+++ b/src/core/XmlPrinter.F90
@@ -25,9 +25,9 @@
 !    May need to separate status reports from the end-of-run summary
 !
 !-------------------------------------------------------------------------------
-module PF_XmlPrinter_mod
-   use PF_Exception_mod
-   use PF_TestListener_mod
+module PF_XmlPrinter
+   use PF_Exception
+   use PF_TestListener
    implicit none
    private
 
@@ -65,7 +65,7 @@ contains
    end function newXmlPrinter
 
    subroutine addFailure(this, testName, exceptions)
-      use PF_ExceptionList_mod
+      use PF_ExceptionList
       class (XmlPrinter), intent(inOut) :: this
       character(len=*), intent(in) :: testName
       type (ExceptionList), intent(in) :: exceptions
@@ -76,7 +76,7 @@ contains
    end subroutine addFailure
 
    subroutine addError(this, testName, exceptions)
-      use PF_ExceptionList_mod
+      use PF_ExceptionList
       class (XmlPrinter), intent(inOut) :: this
       character(len=*), intent(in) :: testName
       type (ExceptionList), intent(in) :: exceptions
@@ -103,7 +103,7 @@ contains
    end subroutine endTest
 
    subroutine endRun(this, result)
-     use PF_AbstractTestResult_mod, only : AbstractTestResult
+     use PF_AbstractTestResult, only : AbstractTestResult
      class (XmlPrinter), intent(inOut) :: this
      class (AbstractTestResult), intent(in) :: result
 
@@ -111,7 +111,7 @@ contains
    end subroutine endRun
 
    subroutine print(this, result)
-      use PF_AbstractTestResult_mod, only : AbstractTestResult
+      use PF_AbstractTestResult, only : AbstractTestResult
       class (XmlPrinter), intent(in) :: this
       class (AbstractTestResult), intent(in) :: result
 
@@ -124,7 +124,7 @@ contains
    end subroutine print
 
    subroutine printHeader(this, result)
-      use PF_AbstractTestResult_mod, only : AbstractTestResult
+      use PF_AbstractTestResult, only : AbstractTestResult
       class (XmlPrinter), intent(in) :: this
       class (AbstractTestResult), intent(in) :: result
 
@@ -140,8 +140,8 @@ contains
    end subroutine printHeader
 
    subroutine printFailure(this, label, aFailedTest)
-      use PF_TestFailure_mod
-      use PF_SourceLocation_mod
+      use PF_TestFailure
+      use PF_SourceLocation
       class (XmlPrinter), intent(in) :: this
       character(len=*), intent(in) :: label
       type (TestFailure), intent(in) :: aFailedTest
@@ -152,9 +152,9 @@ contains
    end subroutine printFailure
 
    subroutine printExceptions(this, label, testName, exceptions)
-      use PF_TestFailure_mod
-      use PF_SourceLocation_mod
-      use PF_ExceptionList_mod
+      use PF_TestFailure
+      use PF_SourceLocation
+      use PF_ExceptionList
       class (XmlPrinter), intent(in) :: this
       character(len=*), intent(in) :: label
       character(len=*), intent(in) :: testName
@@ -191,8 +191,8 @@ contains
 
 !mlr old version
    subroutine printFailure1(this, label, aFailedTest)
-      use PF_TestFailure_mod
-      use PF_SourceLocation_mod
+      use PF_TestFailure
+      use PF_SourceLocation
       class (XmlPrinter), intent(in) :: this
       character(len=*), intent(in) :: label
       type (TestFailure), intent(in) :: aFailedTest
@@ -225,9 +225,9 @@ contains
    end subroutine printFailure1
 
    subroutine printFailures(this, label, failures)
-      use PF_TestFailure_mod
-      use PF_TestFailureVector_mod
-      use PF_SourceLocation_mod
+      use PF_TestFailure
+      use PF_TestFailureVector
+      use PF_SourceLocation
       class (XmlPrinter), intent(in) :: this
       character(len=*), intent(in) :: label
       type (TestFailureVector), intent(in) :: failures
@@ -241,7 +241,7 @@ contains
    end subroutine printFailures
 
    subroutine printTestName(this, testName)
-      use PF_TestFailure_mod
+      use PF_TestFailure
       class (XmlPrinter), intent(in) :: this
       character(len=*), intent(in) :: testName
 
@@ -253,7 +253,7 @@ contains
     end subroutine printTestName
 
    subroutine printSuccess(this, aSuccessTest)
-      use PF_TestFailure_mod
+      use PF_TestFailure
       class (XmlPrinter), intent(in) :: this
       type (TestFailure) :: aSuccessTest
 
@@ -267,8 +267,8 @@ contains
    end subroutine printSuccess
 
    subroutine printSuccesses(this, successes)
-      use PF_TestFailure_mod
-      use PF_TestFailurevector_mod
+      use PF_TestFailure
+      use PF_TestFailurevector
       class (XmlPrinter), intent(in) :: this
       type (TestFailureVector), intent(in) :: successes
 
@@ -281,7 +281,7 @@ contains
    end subroutine printSuccesses
 
    subroutine printFooter(this, result)
-      use PF_AbstractTestResult_mod
+      use PF_AbstractTestResult
       class (XmlPrinter), intent(in) :: this
       class (AbstractTestResult), intent(in) :: result
 
@@ -324,4 +324,4 @@ contains
 
    end subroutine addSuccess
 
-end module PF_XmlPrinter_mod
+end module PF_XmlPrinter

--- a/src/core/asserts/Assert.F90
+++ b/src/core/asserts/Assert.F90
@@ -20,14 +20,14 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_Assert_mod
-   use PF_AssertBasic_mod
-   use pf_AssertString_mod
+module PF_Assert
+   use PF_AssertBasic
+   use pf_AssertString
    !#include "AssertArrays.fh"
 
-   use pf_AssertInteger_0d_mod
-   use pf_AssertReal_0d_mod
-   use pf_AssertComplex_0d_mod
+   use pf_AssertInteger_0d
+   use pf_AssertReal_0d
+   use pf_AssertComplex_0d
    implicit none
    private
 
@@ -54,4 +54,4 @@ module PF_Assert_mod
    public :: WhitespaceOptions
    public :: IGNORE_ALL, TRIM_ALL, KEEP_ALL, IGNORE_DIFFERENCES
 
-end module PF_Assert_mod
+end module PF_Assert

--- a/src/core/asserts/AssertBasic.F90
+++ b/src/core/asserts/AssertBasic.F90
@@ -43,11 +43,11 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_AssertBasic_mod
-   use PF_Exception_mod
-   use PF_ExceptionList_mod
-   use PF_SourceLocation_mod
-   use PF_StringUtilities_mod
+module PF_AssertBasic
+   use PF_Exception
+   use PF_ExceptionList
+   use PF_SourceLocation
+   use PF_StringUtilities
 #ifdef _REAL16_IEEE_SUPPORT
    use, intrinsic :: iso_fortran_env, only: REAL16
 #endif
@@ -247,7 +247,7 @@ contains
 
 
    subroutine assertExceptionRaisedBasic(location)
-      use PF_ExceptionList_mod, only: throw, catch
+      use PF_ExceptionList, only: throw, catch
       type (SourceLocation), optional, intent(in) :: location
 
       if (.not. catch()) then
@@ -258,7 +258,7 @@ contains
 
 
    subroutine assertExceptionRaisedMessage(message, location)
-      use PF_ExceptionList_mod, only: throw, catch
+      use PF_ExceptionList, only: throw, catch
       character(len=*), intent(in) :: message
       type (SourceLocation), optional, intent(in) :: location
 
@@ -334,7 +334,7 @@ contains
 
    subroutine assertEqualString_(expected, found, message, location, &
         & whitespace)
-      use PF_ExceptionList_mod, only: throw
+      use PF_ExceptionList, only: throw
 
       character(len=*), intent(in) :: expected
       character(len=*), intent(in) :: found
@@ -912,4 +912,4 @@ contains
 #endif
 
 
-end module PF_AssertBasic_mod
+end module PF_AssertBasic

--- a/src/core/asserts/AssertString.F90
+++ b/src/core/asserts/AssertString.F90
@@ -1,7 +1,7 @@
-module pf_AssertString_mod
-   use pf_SourceLocation_mod
-   use pf_StringUtilities_mod
-   use pf_Exception_mod
+module pf_AssertString
+   use pf_SourceLocation
+   use pf_StringUtilities
+   use pf_Exception
    implicit none
    private
 
@@ -17,7 +17,7 @@ contains
    
    subroutine assertEqual_string(expected, found, message, location, &
         & whitespace)
-      use PF_ExceptionList_mod, only: throw
+      use PF_ExceptionList, only: throw
 
       character(len=*), intent(in) :: expected
       character(len=*), intent(in) :: found
@@ -278,4 +278,4 @@ contains
 
    end subroutine assertEqual_string
 
-end module pf_AssertString_mod
+end module pf_AssertString

--- a/src/core/asserts/AssertUtilities.F90
+++ b/src/core/asserts/AssertUtilities.F90
@@ -1,10 +1,10 @@
 #include "unused_dummy.fh"
 
-module pf_AssertUtilities_mod
-   use pf_KeywordEnforcer_mod
-   use pf_SourceLocation_mod
-   use pf_StringUtilities_mod
-   use pf_ExceptionList_mod
+module pf_AssertUtilities
+   use pf_KeywordEnforcer
+   use pf_SourceLocation
+   use pf_StringUtilities
+   use pf_ExceptionList
    implicit none
    private
 
@@ -365,4 +365,4 @@ contains
    end function base_message
      
    
-end module pf_AssertUtilities_mod
+end module pf_AssertUtilities

--- a/src/core/asserts/Assert_Complex.tmpl
+++ b/src/core/asserts/Assert_Complex.tmpl
@@ -93,13 +93,13 @@
 
 #include "unused_dummy.fh"
 
-module pf_AssertComplex_{rank}d_mod
+module pf_AssertComplex_{rank}d
    use, intrinsic :: iso_fortran_env, only: REAL32
    use, intrinsic :: iso_fortran_env, only: REAL64
    use, intrinsic :: iso_fortran_env, only: REAL128
-   use pf_KeywordEnforcer_mod
-   use pf_SourceLocation_mod
-   use pf_AssertUtilities_mod
+   use pf_KeywordEnforcer
+   use pf_SourceLocation
+   use pf_AssertUtilities
    implicit none
    private
 
@@ -341,7 +341,7 @@ contains
    @instantiate(assert_equal, minimal)
    @instantiate(assert_not_equal, minimal)
    
-end module pf_AssertComplex_{rank}d_mod
+end module pf_AssertComplex_{rank}d
 
 
    

--- a/src/core/asserts/Assert_Integer.tmpl
+++ b/src/core/asserts/Assert_Integer.tmpl
@@ -29,14 +29,14 @@
 
 #include "unused_dummy.fh"
 
-module pf_AssertInteger_{rank}d_mod
+module pf_AssertInteger_{rank}d
    use, intrinsic :: iso_fortran_env, only: INT8
    use, intrinsic :: iso_fortran_env, only: INT16
    use, intrinsic :: iso_fortran_env, only: INT32
    use, intrinsic :: iso_fortran_env, only: INT64
-   use pf_KeywordEnforcer_mod
-   use pf_SourceLocation_mod
-   use pf_AssertUtilities_mod
+   use pf_KeywordEnforcer
+   use pf_SourceLocation
+   use pf_AssertUtilities
 
    implicit none
    private
@@ -598,7 +598,7 @@ contains
    @instantiate(assert_greater_than, minimal)
    @instantiate(assert_greater_than_or_equal, minimal)
    
-end module pf_AssertInteger_{rank}d_mod
+end module pf_AssertInteger_{rank}d
 
 
    

--- a/src/core/asserts/Assert_Logical.tmpl
+++ b/src/core/asserts/Assert_Logical.tmpl
@@ -13,10 +13,10 @@
 @end tkr_parameters
 
 
-module pf_AssertLogical_{rank}d_mod
-   use pf_KeywordEnforcer_mod
-   use pf_SourceLocation_mod
-   use pf_AssertUtilities_mod
+module pf_AssertLogical_{rank}d
+   use pf_KeywordEnforcer
+   use pf_SourceLocation
+   use pf_AssertUtilities
 
    implicit none
    private
@@ -263,4 +263,4 @@ contains
    @instantiate(assert_equivalent, minimal)
    @instantiate(assert_not_equivalent, minimal)
 
-end module pf_AssertLogical_{rank}d_mod
+end module pf_AssertLogical_{rank}d

--- a/src/core/asserts/Assert_Real.tmpl
+++ b/src/core/asserts/Assert_Real.tmpl
@@ -125,7 +125,7 @@
 
 #include "unused_dummy.fh"
 
-module pf_AssertReal_{rank}d_mod
+module pf_AssertReal_{rank}d
 #ifdef _ISO_REAL16
    use, intrinsic :: iso_fortran_env, only: REAL16
 #endif
@@ -146,9 +146,9 @@ module pf_AssertReal_{rank}d_mod
 #endif
 
    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
-   use pf_KeywordEnforcer_mod
-   use pf_SourceLocation_mod
-   use pf_AssertUtilities_mod
+   use pf_KeywordEnforcer
+   use pf_SourceLocation
+   use pf_AssertUtilities
    implicit none
 !!$   private
 
@@ -1008,7 +1008,7 @@ contains
    @instantiate(assert_greater_than_or_equal, minimal)
    @instantiate(assert_relatively_equal, minimal)
    
-end module pf_AssertReal_{rank}d_mod
+end module pf_AssertReal_{rank}d
 
 
    

--- a/src/core/asserts/FormatIntrinsic.tmpl
+++ b/src/core/asserts/FormatIntrinsic.tmpl
@@ -16,7 +16,7 @@
 
 
 
-module pf_Formatter_mod
+module pf_Formatter
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64, REAL128
    use, intrinsic :: iso_fortran_env, only: INT32, INT64
    implicit none
@@ -51,4 +51,4 @@ contains
 
    @instantiate(format, cases)
 
-end module pf_Formatter_mod
+end module pf_Formatter

--- a/src/core/asserts/Norms.tmpl
+++ b/src/core/asserts/Norms.tmpl
@@ -14,7 +14,7 @@
 [(complex,  double, rank)]
 @end tkr_parameters
 
-module pf_Norms_{rank}d_mod
+module pf_Norms_{rank}d
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64, REAL128
    implicit none
    private
@@ -81,4 +81,4 @@ contains
    @instantiate(L2Norm, minimal)
    @instantiate(L1Norm, minimal)
 
-end module pf_Norms_{rank}d_mod
+end module pf_Norms_{rank}d

--- a/src/esmf/ESMF_TestCase.F90
+++ b/src/esmf/ESMF_TestCase.F90
@@ -1,6 +1,6 @@
-module ESMF_TestCase_mod
+module ESMF_TestCase
    use ESMF
-   use ESMF_TestParameter_mod
+   use ESMF_TestParameter
    use pFUnit, only: MpiTestCase
 
    implicit none
@@ -39,8 +39,8 @@ contains
 
 
    recursive subroutine runBare(this)
-      use PF_Exception_mod
-      use PF_ExceptionList_mod
+      use PF_Exception
+      use PF_ExceptionList
       use ESMF
       class (ESMF_TestCase), intent(inout) :: this
 
@@ -279,7 +279,7 @@ contains
 
    
    integer function getNumPETsRequested(this) result(numPETsRequested)
-      use PF_Exception_mod
+      use PF_Exception
       class (ESMF_TestCase), intent(in) :: this
       select type (p => this%testParameter)
       class is (ESMF_TestParameter)
@@ -291,4 +291,4 @@ contains
    end function getNumPETsRequested
 
 
-end module ESMF_TestCase_mod
+end module ESMF_TestCase

--- a/src/esmf/ESMF_TestMethod.F90
+++ b/src/esmf/ESMF_TestMethod.F90
@@ -1,9 +1,9 @@
-module ESMF_TestMethod_mod
-   use PF_MpiTestParameter_mod
+module ESMF_TestMethod
+   use PF_MpiTestParameter
    use pFUnit
    use ESMF
-   use ESMF_TestCase_mod
-   use ESMF_TestParameter_mod
+   use ESMF_TestCase
+   use ESMF_TestParameter
    implicit none
    private
 
@@ -93,4 +93,4 @@ contains
 
    end subroutine tearDown
 
-end module ESMF_TestMethod_mod
+end module ESMF_TestMethod

--- a/src/esmf/ESMF_TestParameter.F90
+++ b/src/esmf/ESMF_TestParameter.F90
@@ -1,4 +1,4 @@
-module ESMF_TestParameter_mod
+module ESMF_TestParameter
    use pfunit, only: MpiTestParameter
    implicit none
 
@@ -79,4 +79,4 @@ contains
    end function getNumPETsRequested
 
    
-end module ESMF_TestParameter_mod
+end module ESMF_TestParameter

--- a/src/hamcrest/AbstractMatcher.F90
+++ b/src/hamcrest/AbstractMatcher.F90
@@ -1,5 +1,5 @@
-module pf_AbstractMatcher_mod
-   use pf_TypeSafeSelfDescribing_mod
+module pf_AbstractMatcher
+   use pf_TypeSafeSelfDescribing
    implicit none
    private
 
@@ -20,7 +20,7 @@ module pf_AbstractMatcher_mod
       end function matches
 
       subroutine describe_mismatch(this, actual, description)
-         use pf_MatcherDescription_mod, only: MatcherDescription
+         use pf_MatcherDescription, only: MatcherDescription
          import AbstractMatcher
          class (AbstractMatcher), intent(in) :: this
          class (*), intent(in) :: actual
@@ -28,4 +28,4 @@ module pf_AbstractMatcher_mod
       end subroutine describe_mismatch
    end interface
 
- end module pf_AbstractMatcher_mod
+ end module pf_AbstractMatcher

--- a/src/hamcrest/AllOf.F90
+++ b/src/hamcrest/AllOf.F90
@@ -1,9 +1,9 @@
-module pf_AllOf_mod
-  use pf_AbstractMatcher_mod
-  use pf_MatcherDescription_mod
-  use pf_BaseMatcher_mod
-  use pf_MatcherVector_mod
-  use pf_SelfDescribingVector_mod
+module pf_AllOf
+  use pf_AbstractMatcher
+  use pf_MatcherDescription
+  use pf_BaseMatcher
+  use pf_MatcherVector
+  use pf_SelfDescribingVector
   implicit none
   private
 
@@ -139,4 +139,4 @@ contains
   end subroutine describe_mismatch
 
 
-end module pf_AllOf_mod
+end module pf_AllOf

--- a/src/hamcrest/AnyOf.F90
+++ b/src/hamcrest/AnyOf.F90
@@ -1,9 +1,9 @@
-module pf_AnyOf_mod
-  use pf_AbstractMatcher_mod
-  use pf_BaseMatcher_mod
-  use pf_MatcherDescription_mod
-  use pf_MatcherVector_mod
-  use pf_SelfDescribingVector_mod
+module pf_AnyOf
+  use pf_AbstractMatcher
+  use pf_BaseMatcher
+  use pf_MatcherDescription
+  use pf_MatcherVector
+  use pf_SelfDescribingVector
   implicit none
   private
 
@@ -146,4 +146,4 @@ contains
   end subroutine describe_mismatch
 
 
-end module pf_AnyOf_mod
+end module pf_AnyOf

--- a/src/hamcrest/Array.F90
+++ b/src/hamcrest/Array.F90
@@ -4,7 +4,7 @@
 ! be re-engineered.
 
 
-module pf_Array_mod
+module pf_Array
   implicit none
   private
 
@@ -56,4 +56,4 @@ contains
     a%items = items
   end function wrap_3d
   
-end module pf_Array_mod
+end module pf_Array

--- a/src/hamcrest/BaseDescription.F90
+++ b/src/hamcrest/BaseDescription.F90
@@ -1,7 +1,7 @@
-module pf_BaseDescription_mod
-  use pf_MatcherDescription_mod
-  use pf_SelfDescribing_mod
-  use pf_SelfDescribingVector_mod
+module pf_BaseDescription
+  use pf_MatcherDescription
+  use pf_SelfDescribing
+  use pf_SelfDescribingVector
   use, intrinsic :: iso_fortran_env
    implicit none
    private
@@ -66,8 +66,8 @@ contains
 
 
    subroutine append_value_scalar(this, value)
-     use pf_Matchable_mod
-     use pf_Array_mod
+     use pf_Matchable
+     use pf_Array
      class (BaseDescription), intent(inout) :: this
      class(*), intent(in) :: value
 
@@ -162,8 +162,8 @@ contains
     end subroutine append_value_scalar
 
     subroutine append_value_list(this, start, separator, end, values)
-     use pf_Matchable_mod
-     use pf_Array_mod
+     use pf_Matchable
+     use pf_Array
      class (BaseDescription), intent(inout) :: this
      character(*), intent(in) :: start
      character(*), intent(in) :: separator
@@ -254,7 +254,7 @@ contains
 
 
     function description_of_logical(value) result(string)
-      use pf_Matchable_mod
+      use pf_Matchable
       character(:), allocatable :: string
       logical, intent(in) :: value
 
@@ -267,7 +267,7 @@ contains
     end function description_of_logical
 
     function description_of_int32(value) result(string)
-      use pf_Matchable_mod
+      use pf_Matchable
       character(:), allocatable :: string
       integer(kind=INT32), intent(in) :: value
 
@@ -277,7 +277,7 @@ contains
     end function description_of_int32
 
     function description_of_int64(value) result(string)
-      use pf_Matchable_mod
+      use pf_Matchable
       character(:), allocatable :: string
       integer(kind=INT64), intent(in) :: value
 
@@ -287,7 +287,7 @@ contains
     end function description_of_int64
 
     function description_of_real32(value) result(string)
-      use pf_Matchable_mod
+      use pf_Matchable
       character(:), allocatable :: string
       real(kind=REAL32), intent(in) :: value
 
@@ -297,7 +297,7 @@ contains
     end function description_of_real32
 
     function description_of_real64(value) result(string)
-      use pf_Matchable_mod
+      use pf_Matchable
       character(:), allocatable :: string
       real(kind=REAL64), intent(in) :: value
 
@@ -308,7 +308,7 @@ contains
 
 
     function description_of_real128(value) result(string)
-      use pf_Matchable_mod
+      use pf_Matchable
       character(:), allocatable :: string
       real(kind=REAL128), intent(in) :: value
 
@@ -318,7 +318,7 @@ contains
     end function description_of_real128
 
     function description_of_complex32(value) result(string)
-      use pf_Matchable_mod
+      use pf_Matchable
       character(:), allocatable :: string
       complex(kind=REAL32), intent(in) :: value
 
@@ -328,7 +328,7 @@ contains
     end function description_of_complex32
 
     function description_of_complex64(value) result(string)
-      use pf_Matchable_mod
+      use pf_Matchable
       character(:), allocatable :: string
       complex(kind=REAL64), intent(in) :: value
 
@@ -339,7 +339,7 @@ contains
 
 
     function description_of_complex128(value) result(string)
-      use pf_Matchable_mod
+      use pf_Matchable
       character(:), allocatable :: string
       complex(kind=REAL128), intent(in) :: value
 
@@ -349,4 +349,4 @@ contains
     end function description_of_complex128
 
     
-end module pf_BaseDescription_mod
+end module pf_BaseDescription

--- a/src/hamcrest/BaseMatcher.F90
+++ b/src/hamcrest/BaseMatcher.F90
@@ -1,6 +1,6 @@
-module pf_BaseMatcher_mod
-  use pf_AbstractMatcher_mod
-  use pf_MatcherDescription_mod
+module pf_BaseMatcher
+  use pf_AbstractMatcher
+  use pf_MatcherDescription
   implicit none
   private
 
@@ -24,4 +24,4 @@ contains
 
   end subroutine describe_mismatch
     
-end module pf_BaseMatcher_mod
+end module pf_BaseMatcher

--- a/src/hamcrest/DescribedAs.F90
+++ b/src/hamcrest/DescribedAs.F90
@@ -1,7 +1,7 @@
-module pf_DescribedAs_mod
-  use pf_AbstractMatcher_mod
-  use pf_MatcherDescription_mod
-  use pf_BaseMatcher_mod
+module pf_DescribedAs
+  use pf_AbstractMatcher
+  use pf_MatcherDescription
+  use pf_BaseMatcher
   implicit none
   private
 
@@ -65,4 +65,4 @@ contains
 
   end subroutine describe_mismatch
 
-end module pf_DescribedAs_mod
+end module pf_DescribedAs

--- a/src/hamcrest/Every.F90
+++ b/src/hamcrest/Every.F90
@@ -1,9 +1,9 @@
-module pf_Every_mod
+module pf_Every
   use iso_fortran_env
-  use pf_AbstractMatcher_mod
-  use pf_BaseMatcher_mod
-  use pf_MatcherDescription_mod
-  use pf_Array_mod
+  use pf_AbstractMatcher
+  use pf_BaseMatcher
+  use pf_MatcherDescription
+  use pf_Array
   implicit none
   private
 
@@ -85,4 +85,4 @@ contains
 
   end subroutine describe_to
 
-end module pf_Every_mod
+end module pf_Every

--- a/src/hamcrest/FeatureMatcher.F90
+++ b/src/hamcrest/FeatureMatcher.F90
@@ -1,7 +1,7 @@
-module pf_FeatureMatcher_mod
-  use pf_AbstractMatcher_mod
-  use pf_TypeSafeMatcher_mod
-  use pf_MatcherDescription_mod
+module pf_FeatureMatcher
+  use pf_AbstractMatcher
+  use pf_TypeSafeMatcher
+  use pf_MatcherDescription
   implicit none
   private
 
@@ -75,4 +75,4 @@ contains
 
 
 
-end module pf_FeatureMatcher_mod
+end module pf_FeatureMatcher

--- a/src/hamcrest/Is.F90
+++ b/src/hamcrest/Is.F90
@@ -1,8 +1,8 @@
-module pf_Is_mod
-  use pf_AbstractMatcher_mod
-  use pf_BaseMatcher_mod
-  use pf_MatcherDescription_mod
-  use pf_IsEqual_mod
+module pf_Is
+  use pf_AbstractMatcher
+  use pf_BaseMatcher
+  use pf_MatcherDescription
+  use pf_IsEqual
   use, intrinsic :: iso_fortran_env
   implicit none
   private
@@ -69,4 +69,4 @@ contains
   end subroutine describe_mismatch
 
 
-end module pf_Is_mod
+end module pf_Is

--- a/src/hamcrest/IsArrayWithSize.F90
+++ b/src/hamcrest/IsArrayWithSize.F90
@@ -1,10 +1,10 @@
-module pf_IsArrayWithSize_mod
-  use pf_AbstractMatcher_mod
-  use pf_MatcherDescription_mod
-  use pf_FeatureMatcher_mod
-  use pf_DescribedAs_mod
-  use pf_IsEqual_mod
-  use pf_Array_mod
+module pf_IsArrayWithSize
+  use pf_AbstractMatcher
+  use pf_MatcherDescription
+  use pf_FeatureMatcher
+  use pf_DescribedAs
+  use pf_IsEqual
+  use pf_Array
   implicit none
   private
 
@@ -89,4 +89,4 @@ contains
        
   end function expects_type_of
   
-end module pf_IsArrayWithSize_mod
+end module pf_IsArrayWithSize

--- a/src/hamcrest/IsEqual.F90
+++ b/src/hamcrest/IsEqual.F90
@@ -1,9 +1,9 @@
-module pf_IsEqual_mod
+module pf_IsEqual
   use iso_fortran_env
-  use pf_AbstractMatcher_mod
-  use pf_BaseMatcher_mod
-  use pf_MatcherDescription_mod
-  use pf_Array_mod
+  use pf_AbstractMatcher
+  use pf_BaseMatcher
+  use pf_MatcherDescription
+  use pf_Array
   implicit none
   private
 
@@ -68,7 +68,7 @@ contains
   ! allows CLASS(*) on RHS.
   ! Intrinsics are checked case by case.
   logical function matches(this, actual_value)
-    use pf_Matchable_mod
+    use pf_Matchable
     class(IsEqual), intent(in) :: this
     class(*), intent(in) :: actual_value
 
@@ -194,4 +194,4 @@ contains
 
   end function matches_intrinsic
 
-end module pf_IsEqual_mod
+end module pf_IsEqual

--- a/src/hamcrest/IsNear.F90
+++ b/src/hamcrest/IsNear.F90
@@ -1,6 +1,6 @@
-module pf_IsNear_mod
-  use pf_TypeSafeMatcher_mod
-  use pf_MatcherDescription_mod
+module pf_IsNear
+  use pf_TypeSafeMatcher
+  use pf_MatcherDescription
   implicit none
   private
 
@@ -114,4 +114,4 @@ contains
 
   end subroutine describe_to
 
-end module pf_IsNear_mod
+end module pf_IsNear

--- a/src/hamcrest/IsNot.F90
+++ b/src/hamcrest/IsNot.F90
@@ -1,8 +1,8 @@
-module pf_IsNot_mod
-  use pf_AbstractMatcher_mod
-  use pf_BaseMatcher_mod
-  use pf_MatcherDescription_mod
-  use pf_IsEqual_mod
+module pf_IsNot
+  use pf_AbstractMatcher
+  use pf_BaseMatcher
+  use pf_MatcherDescription
+  use pf_IsEqual
   use, intrinsic :: iso_fortran_env
   implicit none
   private
@@ -70,4 +70,4 @@ contains
   end subroutine describe_mismatch
 
 
-end module pf_IsNot_mod
+end module pf_IsNot

--- a/src/hamcrest/IsRelativelyNear.F90
+++ b/src/hamcrest/IsRelativelyNear.F90
@@ -1,6 +1,6 @@
-module pf_IsRelativelyNear_mod
-  use pf_TypeSafeMatcher_mod
-  use pf_MatcherDescription_mod
+module pf_IsRelativelyNear
+  use pf_TypeSafeMatcher
+  use pf_MatcherDescription
   implicit none
   private
 
@@ -107,4 +107,4 @@ contains
 
   end subroutine describe_to
 
-end module pf_IsRelativelyNear_mod
+end module pf_IsRelativelyNear

--- a/src/hamcrest/Matchable.F90
+++ b/src/hamcrest/Matchable.F90
@@ -1,5 +1,5 @@
-module pf_Matchable_mod
-  use pf_TypeSafeSelfDescribing_mod
+module pf_Matchable
+  use pf_TypeSafeSelfDescribing
   implicit none
   private
 
@@ -21,4 +21,4 @@ module pf_Matchable_mod
 
   end interface
      
-end module pf_Matchable_mod
+end module pf_Matchable

--- a/src/hamcrest/MatcherAssert.F90
+++ b/src/hamcrest/MatcherAssert.F90
@@ -1,7 +1,7 @@
-module pf_MatcherAssert_mod
-   use pf_AbstractMatcher_mod
-   use pf_SourceLocation_mod
-   use pf_Array_mod
+module pf_MatcherAssert
+   use pf_AbstractMatcher
+   use pf_SourceLocation
+   use pf_Array
    use funit, only: throw
    implicit none
    private
@@ -29,7 +29,7 @@ contains
  
 
    subroutine assert_that_reason(reason, actual, matcher, location)
-      use pf_StringDescription_mod
+      use pf_StringDescription
       character(*), intent(in) :: reason
       class(*), intent(in) :: actual
       class(AbstractMatcher), intent(in) :: matcher
@@ -50,7 +50,7 @@ contains
    end subroutine assert_that_reason
  
    subroutine assert_that_1d(actual, matcher, location)
-     use pf_StringDescription_mod
+     use pf_StringDescription
      class(*), intent(in) :: actual(:)
      class(AbstractMatcher), intent(in) :: matcher
      type (SourceLocation), optional, intent(in) :: location
@@ -60,7 +60,7 @@ contains
    end subroutine assert_that_1d
 
    subroutine assert_that_1d_reason(reason, actual, matcher, location)
-     use pf_StringDescription_mod
+     use pf_StringDescription
      character(*), intent(in) :: reason
      class(*), intent(in) :: actual(:)
      class(AbstractMatcher), intent(in) :: matcher
@@ -70,4 +70,4 @@ contains
      
    end subroutine assert_that_1d_reason
 
-end module pf_MatcherAssert_mod
+end module pf_MatcherAssert

--- a/src/hamcrest/MatcherDescription.F90
+++ b/src/hamcrest/MatcherDescription.F90
@@ -1,7 +1,7 @@
-module pf_MatcherDescription_mod
-  use pf_SurrogateDescription_mod
-  use pf_SelfDescribing_mod
-  use pf_SelfDescribingVector_mod
+module pf_MatcherDescription
+  use pf_SurrogateDescription
+  use pf_SelfDescribing
+  use pf_SelfDescribingVector
   implicit none
   private
 
@@ -74,4 +74,4 @@ module pf_MatcherDescription_mod
    end interface
 
 
-end module pf_MatcherDescription_mod
+end module pf_MatcherDescription

--- a/src/hamcrest/MatcherVector.F90
+++ b/src/hamcrest/MatcherVector.F90
@@ -1,5 +1,5 @@
-module pf_MatcherVector_mod
-  use pf_AbstractMatcher_mod
+module pf_MatcherVector
+  use pf_AbstractMatcher
 
 #define _type class(AbstractMatcher)
 #define _vector MatcherVector
@@ -13,4 +13,4 @@ module pf_MatcherVector_mod
 #undef _vector
 #undef _type
   
-end module pf_MatcherVector_mod
+end module pf_MatcherVector

--- a/src/hamcrest/SelfDescribing.F90
+++ b/src/hamcrest/SelfDescribing.F90
@@ -1,5 +1,5 @@
-module pf_SelfDescribing_mod
-  use pf_SurrogateDescription_mod
+module pf_SelfDescribing
+  use pf_SurrogateDescription
   implicit none
   private
 
@@ -44,4 +44,4 @@ module pf_SelfDescribing_mod
      this%type_name = type_name
    end subroutine set_type_name
    
-end module pf_SelfDescribing_mod
+end module pf_SelfDescribing

--- a/src/hamcrest/SelfDescribingVector.F90
+++ b/src/hamcrest/SelfDescribingVector.F90
@@ -1,5 +1,5 @@
-module pf_SelfDescribingVector_mod
-  use pf_SelfDescribing_mod
+module pf_SelfDescribingVector
+  use pf_SelfDescribing
 
 #define _type class(SelfDescribing)
 #define _vector SelfDescribingVector
@@ -13,4 +13,4 @@ module pf_SelfDescribingVector_mod
 #undef _vector
 #undef _type
   
-end module pf_SelfDescribingVector_mod
+end module pf_SelfDescribingVector

--- a/src/hamcrest/StringContains.F90
+++ b/src/hamcrest/StringContains.F90
@@ -1,6 +1,6 @@
-module pf_StringContains_mod
-  use pf_MatcherDescription_mod
-  use pf_SubstringMatcher_mod
+module pf_StringContains
+  use pf_MatcherDescription
+  use pf_SubstringMatcher
   implicit none
   private
 
@@ -38,4 +38,4 @@ contains
     eval_substring_of = index(this%converted(item), this%converted(this%get_substring())) > 0
   end function eval_substring_of
 
-end module pf_StringContains_mod
+end module pf_StringContains

--- a/src/hamcrest/StringDescription.F90
+++ b/src/hamcrest/StringDescription.F90
@@ -1,7 +1,7 @@
-module pf_StringDescription_mod
-   use pf_MatcherDescription_mod
-   use pf_BaseDescription_mod
-   use pf_SelfDescribing_mod
+module pf_StringDescription
+   use pf_MatcherDescription
+   use pf_BaseDescription
+   use pf_SelfDescribing
    implicit none
    private
 
@@ -53,4 +53,4 @@ contains
 
    end function to_string
 
-end module pf_StringDescription_mod
+end module pf_StringDescription

--- a/src/hamcrest/StringEndsWith.F90
+++ b/src/hamcrest/StringEndsWith.F90
@@ -1,7 +1,7 @@
-module pf_StringEndsWith_mod
-  use pf_AbstractMatcher_mod
-  use pf_MatcherDescription_mod
-  use pf_SubstringMatcher_mod
+module pf_StringEndsWith
+  use pf_AbstractMatcher
+  use pf_MatcherDescription
+  use pf_SubstringMatcher
   implicit none
   private
 
@@ -41,4 +41,4 @@ contains
     eval_substring_of = idx_substring == (len(item) - len(this%get_substring()) + 1)
   end function eval_substring_of
 
-end module pf_StringEndsWith_mod
+end module pf_StringEndsWith

--- a/src/hamcrest/StringStartsWith.F90
+++ b/src/hamcrest/StringStartsWith.F90
@@ -1,7 +1,7 @@
-module pf_StringStartsWith_mod
-  use pf_AbstractMatcher_mod
-  use pf_MatcherDescription_mod
-  use pf_SubstringMatcher_mod
+module pf_StringStartsWith
+  use pf_AbstractMatcher
+  use pf_MatcherDescription
+  use pf_SubstringMatcher
   implicit none
   private
 
@@ -36,4 +36,4 @@ contains
     eval_substring_of = index(this%converted(item), this%converted(this%get_substring())) == 1
   end function eval_substring_of
 
-end module pf_StringStartsWith_mod
+end module pf_StringStartsWith

--- a/src/hamcrest/SubstringMatcher.F90
+++ b/src/hamcrest/SubstringMatcher.F90
@@ -1,7 +1,7 @@
-module pf_SubstringMatcher_mod
-  use pf_MatcherDescription_mod
-  use pf_AbstractMatcher_mod
-  use pf_TypeSafeMatcher_mod
+module pf_SubstringMatcher
+  use pf_MatcherDescription
+  use pf_AbstractMatcher
+  use pf_TypeSafeMatcher
   implicit none
   private
 
@@ -151,4 +151,4 @@ contains
   end function expects_type_of
 
   
-end module pf_SubstringMatcher_mod
+end module pf_SubstringMatcher

--- a/src/hamcrest/SurrogateDescription.F90
+++ b/src/hamcrest/SurrogateDescription.F90
@@ -6,7 +6,7 @@
 ! Trans. Math. Softw.. 37. 10.1145/1644001.1644004.
 !
 !
-module pf_SurrogateDescription_mod
+module pf_SurrogateDescription
   implicit none
   private
 
@@ -15,4 +15,4 @@ module pf_SurrogateDescription_mod
   type, abstract :: SurrogateDescription
   end type SurrogateDescription
 
-end module pf_SurrogateDescription_mod
+end module pf_SurrogateDescription

--- a/src/hamcrest/TypeSafeMatcher.F90
+++ b/src/hamcrest/TypeSafeMatcher.F90
@@ -1,10 +1,10 @@
-module pf_TypeSafeMatcher_mod
-  use pf_AbstractMatcher_mod
-  use pf_BaseMatcher_mod
-  use pf_SelfDescribing_mod
-  use pf_MatcherDescription_mod, only: MatcherDescription
+module pf_TypeSafeMatcher
+  use pf_AbstractMatcher
+  use pf_BaseMatcher
+  use pf_SelfDescribing
+  use pf_MatcherDescription, only: MatcherDescription
 
-  use pf_Array_mod
+  use pf_Array
   use iso_fortran_env
   implicit none
   private
@@ -170,4 +170,4 @@ contains
      end select
    end function type_of
 
-end module pf_TypeSafeMatcher_mod
+end module pf_TypeSafeMatcher

--- a/src/hamcrest/TypeSafeSelfDescribing.F90
+++ b/src/hamcrest/TypeSafeSelfDescribing.F90
@@ -1,7 +1,7 @@
-module pf_TypeSafeSelfDescribing_mod
-  use pf_SurrogateDescription_mod
-  use pf_SelfDescribing_mod
-  use pf_MatcherDescription_mod
+module pf_TypeSafeSelfDescribing
+  use pf_SurrogateDescription
+  use pf_SelfDescribing
+  use pf_MatcherDescription
   implicit none
   private
 
@@ -40,5 +40,5 @@ module pf_TypeSafeSelfDescribing_mod
 
    end subroutine type_unsafe_describe_to
 
- end module pf_TypeSafeSelfDescribing_mod
+ end module pf_TypeSafeSelfDescribing
     

--- a/src/hamcrest/hamcrest.F90
+++ b/src/hamcrest/hamcrest.F90
@@ -1,21 +1,21 @@
 module hamcrest
-  use pf_MatcherDescription_mod
-  use pf_StringDescription_mod
-  use pf_MatcherAssert_mod
+  use pf_MatcherDescription
+  use pf_StringDescription
+  use pf_MatcherAssert
 
-  use pf_AbstractMatcher_mod
-  use pf_Is_mod
-  use pf_IsNot_mod
-  use pf_IsEqual_mod
-  use pf_IsNear_mod
-  use pf_IsRelativelyNear_mod
-  use pf_AnyOf_mod
-  use pf_AllOf_mod
-  use pf_Every_mod
-  use pf_StringContains_mod
-  use pf_StringStartsWith_mod
-  use pf_StringEndsWith_mod
-  use pf_IsArrayWithSize_mod
+  use pf_AbstractMatcher
+  use pf_Is
+  use pf_IsNot
+  use pf_IsEqual
+  use pf_IsNear
+  use pf_IsRelativelyNear
+  use pf_AnyOf
+  use pf_AllOf
+  use pf_Every
+  use pf_StringContains
+  use pf_StringStartsWith
+  use pf_StringEndsWith
+  use pf_IsArrayWithSize
 
-  use pf_Matchable_mod
+  use pf_Matchable
 end module hamcrest

--- a/src/mpi/MpiContext.F90
+++ b/src/mpi/MpiContext.F90
@@ -20,9 +20,9 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_MpiContext_mod
-   use PF_ParallelContext_mod
-   use PF_ExceptionList_mod, only: throw
+module PF_MpiContext
+   use PF_ParallelContext
+   use PF_ExceptionList, only: throw
    use mpi
    implicit none
    private
@@ -112,7 +112,7 @@ contains
    ! Returns a new context which represents just a subset of the
    ! processes in the current group.
    function makeSubcontext(this, numSubprocesses) result(subContext)
-      use PF_Exception_mod
+      use PF_Exception
       class (MpiContext), intent(in) :: this
       integer, intent(in) :: numSubprocesses
       type (MpiContext) :: subContext
@@ -354,4 +354,4 @@ contains
 !!$      call debug(__LINE__,__FILE__)
    end subroutine clean
 
-end module PF_MpiContext_mod
+end module PF_MpiContext

--- a/src/mpi/MpiStubs.F90
+++ b/src/mpi/MpiStubs.F90
@@ -20,7 +20,7 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module MpiStubs_mod
+module MpiStubs
    implicit none
    private
 
@@ -111,4 +111,4 @@ contains
       newCommunicator = nextCommunicator
    end function newCommunicator
    
-end module MpiStubs_mod
+end module MpiStubs

--- a/src/mpi/MpiTestCase.F90
+++ b/src/mpi/MpiTestCase.F90
@@ -21,13 +21,13 @@
 !
 !-------------------------------------------------------------------------------
 
-module PF_MpiTestCase_mod
+module PF_MpiTestCase
    use mpi
-   use PF_MpiContext_mod
-   use PF_TestCase_mod
-   use PF_AbstractTestParameter_mod
-   use PF_MpiTestParameter_mod
-   use PF_ParameterizedTestCase_mod, only: ParameterizedTestCase
+   use PF_MpiContext
+   use PF_TestCase
+   use PF_AbstractTestParameter
+   use PF_MpiTestParameter
+   use PF_ParameterizedTestCase, only: ParameterizedTestCase
    implicit none
    private
 
@@ -56,10 +56,10 @@ contains
    end function countTestCases_mpi
 
    recursive subroutine run(this, tstResult, context)
-      use PF_TestResult_mod, only: TestResult
-      use PF_ParallelContext_mod
-      use PF_ExceptionList_mod
-      use PF_SurrogateTestCase_mod
+      use PF_TestResult, only: TestResult
+      use PF_ParallelContext
+      use PF_ExceptionList
+      use PF_SurrogateTestCase
       class (MpiTestCase), target, intent(inout) :: this
       class (TestResult), intent(inout) :: tstResult
       class (ParallelContext), intent(in) :: context
@@ -80,7 +80,7 @@ contains
    end subroutine run
 
    recursive subroutine runBare(this)
-      use PF_ExceptionList_mod
+      use PF_ExceptionList
       class (MpiTestCase), intent(inout) :: this
 
       logical :: discard
@@ -119,7 +119,7 @@ contains
    end function getNumProcesses
 
    integer function getNumProcessesRequested(this) result(numProcessesRequested)
-      use PF_ExceptionList_mod
+      use PF_ExceptionList
       class (MpiTestCase), intent(in) :: this
       select type (p => this%testParameter)
       class is (MpiTestParameter)
@@ -142,4 +142,4 @@ contains
 
    end function getContext
 
-end module PF_MpiTestCase_mod
+end module PF_MpiTestCase

--- a/src/mpi/MpiTestMethod.F90
+++ b/src/mpi/MpiTestMethod.F90
@@ -20,11 +20,11 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module PF_MpiTestMethod_mod
-   use PF_Test_mod
-   use PF_TestCase_mod
-   use PF_MpiTestCase_mod
-   use PF_MpiTestParameter_mod
+module PF_MpiTestMethod
+   use PF_Test
+   use PF_TestCase
+   use PF_MpiTestCase
+   use PF_MpiTestParameter
    implicit none
    private
 
@@ -98,4 +98,4 @@ contains
       if (associated(this%userTearDown)) call this%userTearDown(this)
    end subroutine tearDown
 
-end module PF_MpiTestMethod_mod
+end module PF_MpiTestMethod

--- a/src/mpi/MpiTestParameter.F90
+++ b/src/mpi/MpiTestParameter.F90
@@ -1,5 +1,5 @@
-module PF_MpiTestParameter_mod
-   use PF_AbstractTestParameter_mod
+module PF_MpiTestParameter
+   use PF_AbstractTestParameter
    implicit none
    private
 
@@ -76,4 +76,4 @@ contains
    end function getNumProcessesRequested
 
 
-end module PF_MpiTestParameter_mod
+end module PF_MpiTestParameter

--- a/src/mpi/pFUnit.F90
+++ b/src/mpi/pFUnit.F90
@@ -21,10 +21,10 @@
 !
 !-------------------------------------------------------------------------------
 module pFUnit_private
-   use PF_MpiContext_mod
-   use PF_MpiTestCase_mod
-   use PF_MpiTestParameter_mod
-   use PF_MpiTestMethod_mod
+   use PF_MpiContext
+   use PF_MpiTestCase
+   use PF_MpiTestParameter
+   use PF_MpiTestMethod
    implicit none
    private
 

--- a/tests/core-tests/BrokenSetUpCase.F90
+++ b/tests/core-tests/BrokenSetUpCase.F90
@@ -1,7 +1,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: BrokenSetUpCase_mod
+!  MODULE: BrokenSetUpCase
 !
 !> @brief
 !! <BriefDescription>
@@ -20,34 +20,34 @@
 ! 20 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module BrokenSetUpCase_mod
-   use PF_TestCase_mod, only: TestCase
-   use PF_ExceptionList_mod, only: throw
+module BrokenSetUpCase
+   use PF_TestCase, only: TestCase
+   use PF_ExceptionList, only: throw
    implicit none
    private
    
-   public :: BrokenSetUpCase
-   public :: newBrokenSetUpCase
+   public :: BrokenSetUp
+   public :: newBrokenSetUp
    
-   type, extends(TestCase) :: BrokenSetUpCase
+   type, extends(TestCase) :: BrokenSetUp
       private
       character(len=40), public :: runLog
    contains
       procedure :: setUp
       procedure :: runMethod
       procedure :: tearDown
-   end type BrokenSetUpCase
+   end type BrokenSetUp
    
 contains
 
-   function newBrokenSetUpCase() result(this)
-      type (BrokenSetUpCase), pointer :: this
+   function newBrokenSetUp() result(this)
+      type (BrokenSetUp), pointer :: this
       allocate(this)
-      call this%setName('BrokenSetUpCase')
-   end function newBrokenSetUpCase
+      call this%setName('BrokenSetUp')
+   end function newBrokenSetUp
 
    subroutine setUp(this)
-      class(BrokenSetUpCase), intent(inOut) :: this
+      class(BrokenSetUp), intent(inOut) :: this
 
       this%runLog = 'broken setUp'
       call throw('This setUp() is intentionally broken.')
@@ -55,17 +55,17 @@ contains
    end subroutine setUp
 
    subroutine tearDown(this)
-      class(BrokenSetUpCase), intent(inOut) :: this
+      class(BrokenSetUp), intent(inOut) :: this
 
       this%runLog = trim(this%runLog)//' tearDown'
 
    end subroutine tearDown
 
    subroutine runMethod(this)
-      class(BrokenSetUpCase), intent(inOut) :: this
+      class(BrokenSetUp), intent(inOut) :: this
 
       this%runLog = trim(this%runLog)//' run'
 
    end subroutine runMethod
 
-end module BrokenSetUpCase_mod
+end module BrokenSetUpCase

--- a/tests/core-tests/BrokenTestCase.F90
+++ b/tests/core-tests/BrokenTestCase.F90
@@ -1,7 +1,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: BrokenTestCase_mod
+!  MODULE: BrokenTestCase
 !
 !> @brief
 !! <BriefDescription>
@@ -20,34 +20,34 @@
 ! 20 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module BrokenTestCase_mod
-   use PF_TestCase_mod, only: TestCase
+module BrokenTestCase
+   use PF_TestCase, only: TestCase
    implicit none
    private
    
-   public :: BrokenTestCase
+   public :: BrokenTest
    
-   type, extends(TestCase) :: BrokenTestCase
+   type, extends(TestCase) :: BrokenTest
       private
       character(len=40), public :: runLog
    contains
       procedure :: setUp
       procedure :: tearDown
       procedure :: runMethod
-   end type BrokenTestCase
+   end type BrokenTest
    
 contains
 
    subroutine setUp(this)
-      class(BrokenTestCase), intent(inOut) :: this
+      class(BrokenTest), intent(inOut) :: this
 
       this%runLog = 'setUp'
 
    end subroutine setUp
 
    subroutine runMethod(this)
-      use PF_ExceptionList_mod, only: throw
-      class(BrokenTestCase), intent(inOut) :: this
+      use PF_ExceptionList, only: throw
+      class(BrokenTest), intent(inOut) :: this
 
       this%runLog = trim(this%runLog) // ' broken run'
       call throw('This test is intentionally broken.')
@@ -55,10 +55,10 @@ contains
    end subroutine runMethod
 
    subroutine tearDown(this)
-      class(BrokenTestCase), intent(inOut) :: this
+      class(BrokenTest), intent(inOut) :: this
 
       this%runLog = trim(this%runLog) // ' tearDown'
 
    end subroutine tearDown
 
-end module BrokenTestCase_mod
+end module BrokenTestCase

--- a/tests/core-tests/FixtureTestCase.F90
+++ b/tests/core-tests/FixtureTestCase.F90
@@ -3,7 +3,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: FixtureTestCase_mod
+!  MODULE: FixtureTestCase
 !
 !> @brief
 !! <BriefDescription>
@@ -22,26 +22,26 @@
 ! 20 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module FixtureTestCase_mod
-   use PF_TestCase_mod, only: TestCase
+module FixtureTestCase
+   use PF_TestCase, only: TestCase
    implicit none
    private
 
-   public :: FixtureTestCase
-   public :: newFixtureTestCase
+   public :: FixtureTest
+   public :: newFixtureTest
    public :: delete
    public :: methodA
    public :: methodB
    public :: simpleTestMethod
 
-   type, extends(TestCase) :: FixtureTestCase
+   type, extends(TestCase) :: FixtureTest
       private
       character(len=30), public :: runLog
    contains
       procedure :: setUp
       procedure :: runMethod
       procedure :: tearDown
-   end type FixtureTestCase
+   end type FixtureTest
 
    interface delete
       module procedure delete_
@@ -49,49 +49,49 @@ module FixtureTestCase_mod
    
 contains
 
-   function newFixtureTestCase() result(this)
-      type(FixtureTestCase) :: this
+   function newFixtureTest() result(this)
+      type(FixtureTest) :: this
 
-      call this%setName('FixtureTestCase')
+      call this%setName('FixtureTest')
       this%runLog = ' '
 
-   end function newFixtureTestCase
+   end function newFixtureTest
 
    subroutine setUp(this)
-      class(FixtureTestCase), intent(inOut) :: this
+      class(FixtureTest), intent(inOut) :: this
       this%runLog = trim(this%runLog) // 'setUp '
    end subroutine setUp
 
    subroutine tearDown(this)
-      class(FixtureTestCase), intent(inOut) :: this
+      class(FixtureTest), intent(inOut) :: this
       this%runLog = trim(this%runLog) // ' tearDown'
    end subroutine tearDown
 
    subroutine runMethod(this)
-      class(FixtureTestCase), intent(inOut) :: this
+      class(FixtureTest), intent(inOut) :: this
 
       this%runLog = trim(this%runLog) // ' run'
 
    end subroutine runMethod
 
    subroutine simpleTestMethod(this)
-      class (FixtureTestCase), intent(inOut) :: this
+      class (FixtureTest), intent(inOut) :: this
       this%runLog = trim(this%runLog) // ' run'
    end subroutine simpleTestMethod
 
    subroutine methodA(this)
-      class (FixtureTestCase), intent(inOut) :: this
+      class (FixtureTest), intent(inOut) :: this
       this%runLog = trim(this%runLog) // ' methodA'
    end subroutine methodA
 
    subroutine methodB(this)
-      class (FixtureTestCase), intent(inOut) :: this
+      class (FixtureTest), intent(inOut) :: this
       this%runLog = trim(this%runLog) // ' methodB'
    end subroutine methodB
 
    subroutine delete_(this)
-      type (FixtureTestCase), intent(inOut) :: this
+      type (FixtureTest), intent(inOut) :: this
       _UNUSED_DUMMY(this)
    end subroutine delete_
 
-end module FixtureTestCase_mod
+end module FixtureTestCase

--- a/tests/core-tests/MakeInf.F90
+++ b/tests/core-tests/MakeInf.F90
@@ -21,7 +21,7 @@
 !
 !-------------------------------------------------------------------------------
 
-module MakeInf_mod
+module MakeInf
 #ifdef _REAL32_IEEE_SUPPORT
    use, intrinsic :: iso_fortran_env, only: REAL32
 #endif
@@ -87,4 +87,4 @@ contains
 #endif
 
 
-end module MakeInf_mod
+end module MakeInf

--- a/tests/core-tests/MakeNaN.F90
+++ b/tests/core-tests/MakeNaN.F90
@@ -21,7 +21,7 @@
 !
 !-------------------------------------------------------------------------------
 
-module MakeNaN_mod
+module MakeNaN
 #ifdef _REAL32_IEEE_SUPPORT
    use, intrinsic :: iso_fortran_env, only: REAL32
 #endif
@@ -76,4 +76,4 @@ contains
 
 
 
-end module MakeNaN_mod
+end module MakeNaN

--- a/tests/core-tests/MockListener.F90
+++ b/tests/core-tests/MockListener.F90
@@ -3,7 +3,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: MockListener_mod
+!  MODULE: MockListener
 !
 !> @brief
 !! <BriefDescription>
@@ -22,8 +22,8 @@
 ! 20 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module MockListener_mod
-   use PF_TestListener_mod
+module pf_MockListener
+   use PF_TestListener
    implicit none
    private
 
@@ -47,7 +47,7 @@ module MockListener_mod
 contains
 
   subroutine addFailure(this, testName, exceptions)
-     use PF_ExceptionList_mod
+     use PF_ExceptionList
      class (MockListener), intent(inOut) :: this
      character(len=*), intent(in) :: testName
      type (ExceptionList), intent(in) :: exceptions
@@ -91,7 +91,7 @@ contains
 
 
    subroutine endRun(this, result)
-     use PF_AbstractTestResult_mod, only : AbstractTestResult
+     use PF_AbstractTestResult, only : AbstractTestResult
      class (MockListener), intent(inOut) :: this
      class (AbstractTestResult), intent(in) :: result
 
@@ -111,4 +111,4 @@ contains
    end subroutine addSuccess
 
 
-end module MockListener_mod
+end module Pf_MockListener

--- a/tests/core-tests/SimpleTestCase.F90
+++ b/tests/core-tests/SimpleTestCase.F90
@@ -3,7 +3,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: SimpleTestCase_mod
+!  MODULE: pf_SimpleTestCase
 !
 !> @brief
 !! <BriefDescription>
@@ -22,8 +22,8 @@
 ! 20 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module SimpleTestCase_mod
-   use PF_TestCase_mod, only: TestCase
+module pf_SimpleTestCase
+   use PF_TestCase, only: TestCase
    implicit none
    private
 
@@ -42,7 +42,7 @@ module SimpleTestCase_mod
 
    abstract interface
       subroutine method(this)
-        use PF_Test_mod
+        use PF_Test
         import SimpleTestCase
         class (SimpleTestCase), intent(inOut) :: this
       end subroutine method
@@ -51,7 +51,7 @@ module SimpleTestCase_mod
 contains
 
    function suite()
-     use PF_TestSuite_mod, only: TestSuite
+     use PF_TestSuite, only: TestSuite
       type (TestSuite) :: suite
 
       suite = TestSuite('SimpleTestCase')
@@ -96,7 +96,7 @@ contains
    end subroutine method2
 
    subroutine methodWith2Exceptions(this)
-      use PF_ExceptionList_mod, only: throw
+      use PF_ExceptionList, only: throw
       class (SimpleTestCase), intent(inOut) :: this
 
       _UNUSED_DUMMY(this)
@@ -109,4 +109,4 @@ contains
       _UNUSED_DUMMY(this)
    end subroutine delete_
 
-end module SimpleTestCase_mod
+end module Pf_SimpleTestCase

--- a/tests/core-tests/Test_Assert.F90
+++ b/tests/core-tests/Test_Assert.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_Assert_mod
+!  MODULE: Test_Assert
 !
 !> @brief
 !! <BriefDescription>
@@ -21,10 +21,10 @@
 ! 20 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_Assert_mod
-   use PF_TestSuite_mod
-   use PF_Assert_mod
-   use PF_ExceptionList_mod, only: catch
+module Test_Assert
+   use PF_TestSuite
+   use PF_Assert
+   use PF_ExceptionList, only: catch
    implicit none
    private
 
@@ -33,9 +33,9 @@ module Test_Assert_mod
 contains
 
    function suite() result(aSuite)
-      use PF_Test_mod
-      use PF_TestMethod_mod
-      use PF_TestSuite_mod
+      use PF_Test
+      use PF_TestMethod
+      use PF_TestSuite
       type (TestSuite) :: aSuite
 
       aSuite = TestSuite('Assert')
@@ -61,10 +61,10 @@ contains
    end subroutine testAssertEqualStringDiffer1st
 
    subroutine testAssertWithLocation
-      use PF_SourceLocation_mod
+      use PF_SourceLocation
       call assertTrue(.false., 'intentional fail', &
            & SourceLocation(fileName='nowhere', lineNumber=5))
       call assertTrue(catch('intentional fail'))
    end subroutine testAssertWithLocation
 
-end module Test_Assert_mod
+end module Test_Assert

--- a/tests/core-tests/Test_AssertBasic.F90
+++ b/tests/core-tests/Test_AssertBasic.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_AssertBasic_mod
+!  MODULE: Test_AssertBasic
 !
 !> @brief
 !! <BriefDescription>
@@ -21,10 +21,10 @@
 ! 20 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_AssertBasic_mod
-   use PF_Exception_mod, only: NULL_MESSAGE
-   use PF_AssertBasic_mod
-   use PF_ExceptionList_mod, only: catch
+module Test_AssertBasic
+   use PF_Exception, only: NULL_MESSAGE
+   use PF_AssertBasic
+   use PF_ExceptionList, only: catch
    implicit none
    private
 
@@ -33,9 +33,9 @@ module Test_AssertBasic_mod
 contains
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestMethod_mod, only: TestMethod
-      use PF_Test_mod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestMethod, only: TestMethod
+      use PF_Test
 
       type (TestSuite) :: suite
 
@@ -223,7 +223,7 @@ contains
    end subroutine testAssertNotAllFail
 
    subroutine testAssertIsNaN()
-      use MakeNaN_mod, only: makeNaN_32, makeNaN_64
+      use MakeNaN, only: makeNaN_32, makeNaN_64
 
       call assertIsNaN(1.e0, 'not NaN')
       call assertExceptionRaised('not NaN')
@@ -237,7 +237,7 @@ contains
 
 
    subroutine testAssertIsNotNaN()
-      use MakeNaN_mod, only: makeNaN_32, makeNaN_64
+      use MakeNaN, only: makeNaN_32, makeNaN_64
 
       call assertIsNotNaN(1.e0,'not Nan')
       call assertIsNotNaN(makeNan_32(),'is NaN')
@@ -252,7 +252,7 @@ contains
 
 
    subroutine testAssertIsFinite()
-      use MakeInf_mod, only: makeInf_32, makeInf_64
+      use MakeInf, only: makeInf_32, makeInf_64
 
       call assertIsFinite(1.e0, 'finite')
       call assertIsFinite(1.d0, 'finite')
@@ -265,7 +265,7 @@ contains
    end subroutine testAssertIsFinite
 
    subroutine testAssertIsInfinite()
-      use MakeInf_mod, only: makeInf_32, makeInf_64
+      use MakeInf, only: makeInf_32, makeInf_64
 
       call assertIsInfinite(1.e0, 'finite')
       call assertExceptionRaised('finite')
@@ -278,8 +278,8 @@ contains
    end subroutine testAssertIsInfinite
 
    subroutine testAssertExceptionRaised()
-      use PF_ExceptionList_mod, only: throw
-      use PF_SourceLocation_mod
+      use PF_ExceptionList, only: throw
+      use PF_SourceLocation
 
       character(len=*), parameter :: message = 'a message'
 
@@ -292,7 +292,7 @@ contains
    end subroutine testAssertExceptionRaised
 
    subroutine testAssertFail()
-      use PF_SourceLocation_mod
+      use PF_SourceLocation
 
       character(len=*), parameter :: message = 'a message'
 
@@ -303,4 +303,4 @@ contains
       call assertExceptionRaised(message,SourceLocation('here',5))
    end subroutine testAssertFail
 
-end module Test_AssertBasic_mod
+end module Test_AssertBasic

--- a/tests/core-tests/Test_AssertComplex.F90
+++ b/tests/core-tests/Test_AssertComplex.F90
@@ -3,7 +3,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_AssertComplex_mod
+!  MODULE: Test_AssertComplex
 !
 !> @brief
 !! <BriefDescription>
@@ -24,7 +24,7 @@
 !-------------------------------------------------------------------------------
 
 !
-! Test_AssertComplex_mod
+! Test_AssertComplex
 !    Were tests for AssertReal using TestAssertReal.F90 as a model.
 !
 !    2013-0425 MLR: First version. 
@@ -33,16 +33,16 @@
 ! Note: `note name' is a mark to remind me of references to code being
 !    tested.  I.e. non-boilerplate.
 
-module Test_AssertComplex_mod ! note name
-!  use PF_Exception_mod, only: getNumExceptions, anyExceptions
-  use PF_TestSuite_mod
-  use PF_Params_mod, only : r32, i64, i32
-  use PF_StringUtilities_mod, only: toString, appendWithSpace
-  use PF_AssertBasic_mod
-  use PF_Assert_mod
-  use PF_AssertArraysSupport_mod, only: differenceReport, valuesReport
-  use PF_ThrowFundamentalTypes_mod, only: locationFormat
-  use PF_SourceLocation_mod
+module Test_AssertComplex ! note name
+!  use PF_Exception, only: getNumExceptions, anyExceptions
+  use PF_TestSuite
+  use PF_Params, only : r32, i64, i32
+  use PF_StringUtilities, only: toString, appendWithSpace
+  use PF_AssertBasic
+  use PF_Assert
+  use PF_AssertArraysSupport, only: differenceReport, valuesReport
+  use PF_ThrowFundamentalTypes, only: locationFormat
+  use PF_SourceLocation
 
   implicit none
   private
@@ -55,8 +55,8 @@ module Test_AssertComplex_mod ! note name
 contains
 
   function suite()
-    use PF_TestSuite_mod, only: TestSuite, newTestSuite 
-    use PF_TestMethod_mod, only: newTestMethod
+    use PF_TestSuite, only: TestSuite, newTestSuite 
+    use PF_TestMethod, only: newTestMethod
 
     type (TestSuite) :: suite
 
@@ -156,7 +156,7 @@ contains
 
 
   subroutine testEquals_C_complexScalar()
-    use PF_Params_mod
+    use PF_Params
 
     complex(kind=r32) :: expected
     complex(kind=r32) :: found
@@ -186,7 +186,7 @@ contains
 
   ! Same rank, different shape.
   subroutine testEquals_C_0D1D()
-    use PF_Params_mod
+    use PF_Params
 
     integer(kind=i64) :: expected
     integer, parameter :: good = 42
@@ -218,7 +218,7 @@ contains
 
   ! Same rank, different shape.
   subroutine testEquals_C_1D_nonConformable1()
-    use PF_Params_mod
+    use PF_Params
 
 
     integer(kind=i32), dimension(2) :: expected
@@ -246,7 +246,7 @@ contains
   end subroutine testEquals_C_1D_nonConformable1
 
   subroutine testEquals_C_2D_SingleElementDifferent()
-    use PF_Params_mod
+    use PF_Params
 
     complex, dimension(2,2) :: expected, found
 
@@ -281,7 +281,7 @@ contains
   end subroutine testEquals_C_2D_SingleElementDifferent
 
   subroutine testEquals_C_MultiD_SingleElementDifferent()
-    use PF_Params_mod
+    use PF_Params
 
     real(kind=r32) :: expected
     complex(kind=r32), dimension(:,:), allocatable :: found
@@ -320,7 +320,7 @@ contains
   end subroutine testEquals_C_MultiD_SingleElementDifferent
 
   subroutine testEquals_C_MultiD_SingleElementDifferent1
-    use PF_Params_mod
+    use PF_Params
 
 ! Don't do ths.
 !    real(kind=r32), dimension(:,:), allocatable :: found
@@ -364,7 +364,7 @@ contains
   end subroutine testEquals_C_MultiD_SingleElementDifferent1
 
   subroutine testEquals_C_MultiD_SingleElementDifferent2
-    use PF_Params_mod
+    use PF_Params
 
 ! Don't do this...
 !    complex(kind=r32), dimension(:,:,:), allocatable :: expected
@@ -409,7 +409,7 @@ contains
   end subroutine testEquals_C_MultiD_SingleElementDifferent2
 
   subroutine testEquals_C_MultiD_SingleElementDifferent3
-    use PF_Params_mod
+    use PF_Params
 
     complex(kind=r32), dimension(:,:,:,:), allocatable :: expected, found
 
@@ -449,7 +449,7 @@ contains
   end subroutine testEquals_C_MultiD_SingleElementDifferent3
 
   subroutine testEquals_C_MultiD_SingleElementDifferent4
-    use PF_Params_mod
+    use PF_Params
 
     complex(kind=r32), dimension(:,:,:,:,:), allocatable :: expected, found
 
@@ -487,7 +487,7 @@ contains
   end subroutine testEquals_C_MultiD_SingleElementDifferent4
 
   subroutine testEquals_C_MultiD_SingleElementDifferent5
-    use PF_Params_mod
+    use PF_Params
 
     complex(kind=r32), dimension(:,:,:,:,:), allocatable :: expected, found
 
@@ -530,7 +530,7 @@ contains
   end subroutine testEquals_C_MultiD_SingleElementDifferent5
 
   subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:), allocatable :: expected, found
@@ -570,7 +570,7 @@ contains
   end subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff
 
   subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff1()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:,:), allocatable :: expected, found
@@ -609,7 +609,7 @@ contains
   end subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff1
 
   subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff2()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:,:,:), allocatable :: expected, found
@@ -651,7 +651,7 @@ contains
   end subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff2
 
   subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff3()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:,:,:,:), allocatable :: expected, found
@@ -690,7 +690,7 @@ contains
   end subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff3
 
   subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff4()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:,:,:,:), allocatable :: expected, found
@@ -733,7 +733,7 @@ contains
   end subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff4
 
   subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff5()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:), allocatable :: expected, found
@@ -771,7 +771,7 @@ contains
   end subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff5
 
   subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff6()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:,:), allocatable :: expected, found
@@ -808,7 +808,7 @@ contains
   end subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff6
 
   subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff7()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:,:,:), allocatable :: expected, found
@@ -847,7 +847,7 @@ contains
   end subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff7
 
   subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff8()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:,:,:,:), allocatable :: expected, found
@@ -915,7 +915,7 @@ contains
   end subroutine testEquals_C_MultiDMultiPrec_SingleEltDiff8
 
   subroutine testEquals_ScalarWithTolerance()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r32) :: expected, found
@@ -957,7 +957,7 @@ contains
   end subroutine testEquals_ScalarWithTolerance
 
   subroutine testEquals_C_MultiDWithTolerance()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r32), dimension(:,:), allocatable :: expected, found
@@ -1001,7 +1001,7 @@ contains
   end subroutine testEquals_C_MultiDWithTolerance
 
   subroutine testEquals_C_MultiDWithTolerance1()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r32), dimension(:,:), allocatable :: expected, found
@@ -1038,7 +1038,7 @@ contains
   end subroutine testEquals_C_MultiDWithTolerance1
 
   subroutine testEquals_C_MultiDWithTolerance64()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:), allocatable :: expected, found
@@ -1085,7 +1085,7 @@ contains
 end subroutine testEquals_C_MultiDWithTolerance64
 
   subroutine testEquals_C_MultiDWithTolerance64_1()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:), allocatable :: expected, found
@@ -1124,7 +1124,7 @@ end subroutine testEquals_C_MultiDWithTolerance64
 
 
   subroutine testEquals_C_MultiDWithTolerance64_2()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:,:), allocatable :: expected, found
@@ -1171,7 +1171,7 @@ end subroutine testEquals_C_MultiDWithTolerance64
   end subroutine testEquals_C_MultiDWithTolerance64_2
 
   subroutine testEquals_C_MultiDSourceLocation()
-    use PF_Params_mod
+    use PF_Params
     implicit none
 
     complex(kind=r64), dimension(:,:), allocatable :: expected, found
@@ -1226,7 +1226,7 @@ end subroutine testEquals_C_MultiDWithTolerance64
   end subroutine testEquals_C_MultiDSourceLocation
 
   subroutine testEquals_4DPComplex_DifferenceReport()
-    use PF_Params_mod
+    use PF_Params
     implicit none
     
     complex(kind=r64), dimension(4) :: expected, found
@@ -1272,7 +1272,7 @@ end subroutine testEquals_C_MultiDWithTolerance64
   end subroutine testEquals_4DPComplex_DifferenceReport
 
   subroutine testEquals_ComplexMultiD_SingleElementNE1
-    use PF_Params_mod
+    use PF_Params
 
     complex, parameter :: good = 1
 
@@ -1316,7 +1316,7 @@ end subroutine testEquals_C_MultiDWithTolerance64
   end subroutine testEquals_ComplexMultiD_SingleElementNE1
 
   subroutine testEquals_ComplexMultiD_SingleElementRE1
-    use PF_Params_mod
+    use PF_Params
 
     complex, parameter :: good = 1
 
@@ -1368,7 +1368,7 @@ end subroutine testEquals_C_MultiDWithTolerance64
 
 
   subroutine testEquals_ComplexMultiD_SingleEltVarious1
-    use PF_Params_mod
+    use PF_Params
 
     complex, parameter :: good = 1
 
@@ -1433,10 +1433,10 @@ end subroutine testEquals_C_MultiDWithTolerance64
 
   ! Check to see that the test result is as expected...
   subroutine assertCatch(string,location)
-    use PF_Params_mod
-    use PF_Exception_mod, only: Exception
-    use PF_ExceptionList_mod, only: getNumExceptions, catchNext
-    use PF_Assert_mod, only: assertEqual
+    use PF_Params
+    use PF_Exception, only: Exception
+    use PF_ExceptionList, only: getNumExceptions, catchNext
+    use PF_Assert, only: assertEqual
     character(len=*), intent(in) :: string
     type (SourceLocation), optional, intent(in) :: location
     type (Exception) :: anException
@@ -1460,6 +1460,6 @@ end subroutine testEquals_C_MultiDWithTolerance64
   end subroutine assertCatch
 
   
-end module Test_AssertComplex_mod
+end module Test_AssertComplex
 
   

--- a/tests/core-tests/Test_AssertEqual_Real.pf
+++ b/tests/core-tests/Test_AssertEqual_Real.pf
@@ -3,27 +3,27 @@
 ! Reference comparison:  default real scalar
 
 
-module Test_AssertEqual_Real_mod
+module Test_AssertEqual_Real
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
    use, intrinsic :: iso_fortran_env, only: REAL128
-   use pf_StringUtilities_mod
-   use pf_SourceLocation_mod
-   use pf_Exceptionlist_mod
+   use pf_StringUtilities
+   use pf_SourceLocation
+   use pf_Exceptionlist
    use FUnit, only: SourceLocation, throw, anyExceptions, AssertExceptionRaised
-   use pf_AssertBasic_mod
-   use pf_AssertReal_0d_mod
-   use pf_AssertReal_1d_mod
-   use pf_AssertReal_2d_mod
-   use pf_AssertReal_3d_mod
+   use pf_AssertBasic
+   use pf_AssertReal_0d
+   use pf_AssertReal_1d
+   use pf_AssertReal_2d
+   use pf_AssertReal_3d
 #ifdef _REAL32_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_32
-      use MakeInf_mod, only:  strInf
+      use MakeInf, only:  makeInf_32
+      use MakeInf, only:  strInf
 #endif
 #ifdef _REAL64_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_64
+      use MakeInf, only:  makeInf_64
 #endif
 #ifdef _REAL128_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_128
+      use MakeInf, only:  makeInf_128
 #endif
    implicit none
       
@@ -504,5 +504,5 @@ contains
       
    end function to_string
 
-end module Test_AssertEqual_Real_mod
+end module Test_AssertEqual_Real
    

--- a/tests/core-tests/Test_AssertGreaterThanOrEqual_Real.pf
+++ b/tests/core-tests/Test_AssertGreaterThanOrEqual_Real.pf
@@ -3,27 +3,27 @@
 ! Reference comparison:  default real scalar
 
 
-module Test_AssertGreaterThanOrEqual_Real_mod
+module Test_AssertGreaterThanOrEqual_Real
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
    use, intrinsic :: iso_fortran_env, only: REAL128
-   use pf_StringUtilities_mod
-   use pf_SourceLocation_mod
-   use pf_Exceptionlist_mod
+   use pf_StringUtilities
+   use pf_SourceLocation
+   use pf_Exceptionlist
    use FUnit, only: SourceLocation, throw, anyExceptions, AssertExceptionRaised
-   use pf_AssertBasic_mod
-   use pf_AssertReal_0d_mod
-   use pf_AssertReal_1d_mod
-   use pf_AssertReal_2d_mod
-   use pf_AssertReal_3d_mod
+   use pf_AssertBasic
+   use pf_AssertReal_0d
+   use pf_AssertReal_1d
+   use pf_AssertReal_2d
+   use pf_AssertReal_3d
 #ifdef _REAL32_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_32
-      use MakeInf_mod, only:  strInf
+      use MakeInf, only:  makeInf_32
+      use MakeInf, only:  strInf
 #endif
 #ifdef _REAL64_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_64
+      use MakeInf, only:  makeInf_64
 #endif
 #ifdef _REAL128_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_128
+      use MakeInf, only:  makeInf_128
 #endif
    implicit none
       
@@ -500,5 +500,5 @@ contains
  end function to_string
 
 
-end module Test_AssertGreaterThanOrEqual_Real_mod
+end module Test_AssertGreaterThanOrEqual_Real
 

--- a/tests/core-tests/Test_AssertGreaterThan_Real.pf
+++ b/tests/core-tests/Test_AssertGreaterThan_Real.pf
@@ -3,27 +3,27 @@
 ! Reference comparison:  default real scalar
 
 
-module Test_AssertGreaterThan_Real_mod
+module Test_AssertGreaterThan_Real
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
    use, intrinsic :: iso_fortran_env, only: REAL128
-   use pf_StringUtilities_mod
-   use pf_SourceLocation_mod
-   use pf_Exceptionlist_mod
+   use pf_StringUtilities
+   use pf_SourceLocation
+   use pf_Exceptionlist
    use FUnit, only: SourceLocation, throw, anyExceptions, AssertExceptionRaised
-   use pf_AssertBasic_mod
-   use pf_AssertReal_0d_mod
-   use pf_AssertReal_1d_mod
-   use pf_AssertReal_2d_mod
-   use pf_AssertReal_3d_mod
+   use pf_AssertBasic
+   use pf_AssertReal_0d
+   use pf_AssertReal_1d
+   use pf_AssertReal_2d
+   use pf_AssertReal_3d
 #ifdef _REAL32_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_32
-      use MakeInf_mod, only:  strInf
+      use MakeInf, only:  makeInf_32
+      use MakeInf, only:  strInf
 #endif
 #ifdef _REAL64_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_64
+      use MakeInf, only:  makeInf_64
 #endif
 #ifdef _REAL128_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_128
+      use MakeInf, only:  makeInf_128
 #endif
    implicit none
       
@@ -490,5 +490,5 @@ contains
 
  end function to_string
 
-end module Test_AssertGreaterThan_Real_mod
+end module Test_AssertGreaterThan_Real
 

--- a/tests/core-tests/Test_AssertLessThanOrEqual_Real.pf
+++ b/tests/core-tests/Test_AssertLessThanOrEqual_Real.pf
@@ -3,27 +3,27 @@
 ! Reference comparison:  default real scalar
 
 
-module Test_AssertLessThanOrEqual_Real_mod
+module Test_AssertLessThanOrEqual_Real
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
    use, intrinsic :: iso_fortran_env, only: REAL128
-   use pf_StringUtilities_mod
-   use pf_SourceLocation_mod
-   use pf_Exceptionlist_mod
+   use pf_StringUtilities
+   use pf_SourceLocation
+   use pf_Exceptionlist
    use FUnit, only: SourceLocation, throw, anyExceptions, AssertExceptionRaised
-   use pf_AssertBasic_mod
-   use pf_AssertReal_0d_mod
-   use pf_AssertReal_1d_mod
-   use pf_AssertReal_2d_mod
-   use pf_AssertReal_3d_mod
+   use pf_AssertBasic
+   use pf_AssertReal_0d
+   use pf_AssertReal_1d
+   use pf_AssertReal_2d
+   use pf_AssertReal_3d
 #ifdef _REAL32_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_32
-      use MakeInf_mod, only:  strInf
+      use MakeInf, only:  makeInf_32
+      use MakeInf, only:  strInf
 #endif
 #ifdef _REAL64_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_64
+      use MakeInf, only:  makeInf_64
 #endif
 #ifdef _REAL128_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_128
+      use MakeInf, only:  makeInf_128
 #endif
    implicit none
       
@@ -495,5 +495,5 @@ contains
 
  end function to_string
 
-end module Test_AssertLessThanOrEqual_Real_mod
+end module Test_AssertLessThanOrEqual_Real
 

--- a/tests/core-tests/Test_AssertLessThan_Real.pf
+++ b/tests/core-tests/Test_AssertLessThan_Real.pf
@@ -3,27 +3,27 @@
 ! Reference comparison:  default real scalar
 
 
-module Test_AssertLessThan_Real_mod
+module Test_AssertLessThan_Real
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
    use, intrinsic :: iso_fortran_env, only: REAL128
-   use pf_StringUtilities_mod
-   use pf_SourceLocation_mod
-   use pf_Exceptionlist_mod
+   use pf_StringUtilities
+   use pf_SourceLocation
+   use pf_Exceptionlist
    use FUnit, only: SourceLocation, throw, anyExceptions, AssertExceptionRaised
-   use pf_AssertBasic_mod
-   use pf_AssertReal_0d_mod
-   use pf_AssertReal_1d_mod
-   use pf_AssertReal_2d_mod
-   use pf_AssertReal_3d_mod
+   use pf_AssertBasic
+   use pf_AssertReal_0d
+   use pf_AssertReal_1d
+   use pf_AssertReal_2d
+   use pf_AssertReal_3d
 #ifdef _REAL32_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_32
-      use MakeInf_mod, only:  strInf
+      use MakeInf, only:  makeInf_32
+      use MakeInf, only:  strInf
 #endif
 #ifdef _REAL64_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_64
+      use MakeInf, only:  makeInf_64
 #endif
 #ifdef _REAL128_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_128
+      use MakeInf, only:  makeInf_128
 #endif
    implicit none
       
@@ -497,5 +497,5 @@ contains
 
  end function to_string
 
-end module Test_AssertLessThan_Real_mod
+end module Test_AssertLessThan_Real
 

--- a/tests/core-tests/Test_AssertNotEqual_Real.pf
+++ b/tests/core-tests/Test_AssertNotEqual_Real.pf
@@ -3,27 +3,27 @@
 ! Reference comparison:  default real scalar
 
 
-module Test_AssertNotEqual_Real_mod
+module Test_AssertNotEqual_Real
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
    use, intrinsic :: iso_fortran_env, only: REAL128
-   use pf_StringUtilities_mod
-   use pf_SourceLocation_mod
-   use pf_Exceptionlist_mod
+   use pf_StringUtilities
+   use pf_SourceLocation
+   use pf_Exceptionlist
    use FUnit, only: SourceLocation, throw, anyExceptions, AssertExceptionRaised
-   use pf_AssertBasic_mod
-   use pf_AssertReal_0d_mod
-   use pf_AssertReal_1d_mod
-   use pf_AssertReal_2d_mod
-   use pf_AssertReal_3d_mod
+   use pf_AssertBasic
+   use pf_AssertReal_0d
+   use pf_AssertReal_1d
+   use pf_AssertReal_2d
+   use pf_AssertReal_3d
 #ifdef _REAL32_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_32
-      use MakeInf_mod, only:  strInf
+      use MakeInf, only:  makeInf_32
+      use MakeInf, only:  strInf
 #endif
 #ifdef _REAL64_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_64
+      use MakeInf, only:  makeInf_64
 #endif
 #ifdef _REAL128_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_128
+      use MakeInf, only:  makeInf_128
 #endif
    implicit none
       
@@ -480,5 +480,5 @@ contains
 
  end function to_string
 
-end module Test_AssertNotEqual_Real_mod
+end module Test_AssertNotEqual_Real
    

--- a/tests/core-tests/Test_AssertRelativelyEqual_Real.pf
+++ b/tests/core-tests/Test_AssertRelativelyEqual_Real.pf
@@ -3,26 +3,26 @@
 ! Reference comparison:  default real scalar
 
 
-module Test_AssertRelativelyEqual_Real_mod
+module Test_AssertRelativelyEqual_Real
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
    use, intrinsic :: iso_fortran_env, only: REAL128
-   use pf_StringUtilities_mod
-   use pf_SourceLocation_mod
-   use pf_Exceptionlist_mod
+   use pf_StringUtilities
+   use pf_SourceLocation
+   use pf_Exceptionlist
    use FUnit, only: SourceLocation, throw, anyExceptions, AssertExceptionRaised
-   use pf_AssertBasic_mod
-   use pf_AssertReal_0d_mod
-   use pf_AssertReal_1d_mod
-   use pf_AssertReal_2d_mod
-   use pf_AssertReal_3d_mod
+   use pf_AssertBasic
+   use pf_AssertReal_0d
+   use pf_AssertReal_1d
+   use pf_AssertReal_2d
+   use pf_AssertReal_3d
 #ifdef _REAL32_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_32
+      use MakeInf, only:  makeInf_32
 #endif
 #ifdef _REAL64_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_64
+      use MakeInf, only:  makeInf_64
 #endif
 #ifdef _REAL128_IEEE_SUPPORT
-      use MakeInf_mod, only:  makeInf_128
+      use MakeInf, only:  makeInf_128
 #endif
    implicit none
       
@@ -161,5 +161,5 @@ contains
 
  end function to_string
 
-end module Test_AssertRelativelyEqual_Real_mod
+end module Test_AssertRelativelyEqual_Real
    

--- a/tests/core-tests/Test_AssertString.pf
+++ b/tests/core-tests/Test_AssertString.pf
@@ -1,4 +1,4 @@
-module Test_AssertString_mod
+module Test_AssertString
    use FUnit
 
    @suite(name='AssertString_suite')
@@ -265,4 +265,4 @@ contains
    end subroutine testAssertEqualNonzeroBlanks4
    
 
-end module Test_AssertString_mod
+end module Test_AssertString

--- a/tests/core-tests/Test_Assert_Integer.pf
+++ b/tests/core-tests/Test_Assert_Integer.pf
@@ -1,14 +1,14 @@
 ! Goal is not to exhaustively test all combinations, but rather at least
 ! one variant along each axis:
 
-module Test_Assert_Integer_mod
-   use pf_SourceLocation_mod
-   use pf_Exceptionlist_mod
+module Test_Assert_Integer
+   use pf_SourceLocation
+   use pf_Exceptionlist
    use FUnit, only: SourceLocation, throw, anyExceptions, AssertExceptionRaised
    use, intrinsic :: iso_fortran_env, only: INT32, INT64
-   use pf_AssertInteger_0d_mod
-   use pf_AssertInteger_1d_mod
-   use pf_AssertInteger_2d_mod
+   use pf_AssertInteger_0d
+   use pf_AssertInteger_1d
+   use pf_AssertInteger_2d
    implicit none
    
    @suite(name='AssertInteger_suite')
@@ -238,4 +238,4 @@ contains
       call assertGreaterThanOrEqual(2, 1)
    end subroutine testAssertGreaterThanOrEqual_trueB
    
-end module Test_Assert_Integer_mod
+end module Test_Assert_Integer

--- a/tests/core-tests/Test_BasicOpenMP.F90
+++ b/tests/core-tests/Test_BasicOpenMP.F90
@@ -1,7 +1,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_BasicOpenMP_mod
+!  MODULE: Test_BasicOpenMP
 !
 !> @brief
 !! <BriefDescription>
@@ -20,7 +20,7 @@
 ! 20 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_BasicOpenMP_mod
+module Test_BasicOpenMP
    implicit none
    private
 
@@ -29,8 +29,8 @@ module Test_BasicOpenMP_mod
 contains
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
-!$    use PF_TestMethod_mod, only: TestMethod
+      use PF_TestSuite, only: TestSuite
+!$    use PF_TestMethod, only: TestMethod
       type (TestSuite) :: suite
 
       suite = TestSuite('Test_TestBasicOpenMP')
@@ -41,7 +41,7 @@ contains
 
    ! run on 4 threads.
    subroutine testRunWithOpenMP()
-      use PF_Assert_mod, only: assertAll
+      use PF_Assert, only: assertAll
 
       !$ integer :: omp_get_thread_num
       integer, parameter :: N = 4
@@ -66,9 +66,9 @@ contains
    ! as the number that were thrown.   Of course actually crashing is a more
    ! likely failure mode than a mismatch in the count.
    subroutine testSerializeExceptions()
-      use PF_Params_mod, only : i32
-      use PF_ExceptionList_mod, only: getNumExceptions, clearAll, throw
-      use PF_Assert_mod, only: AssertEqual
+      use PF_Params, only : i32
+      use PF_ExceptionList, only: getNumExceptions, clearAll, throw
+      use PF_Assert, only: AssertEqual
 
       !$ integer :: omp_get_thread_num
       integer, parameter :: N = 8 ! threads
@@ -93,5 +93,5 @@ contains
 
    end subroutine testSerializeExceptions
 
-end module Test_BasicOpenMP_mod
+end module Test_BasicOpenMP
 

--- a/tests/core-tests/Test_DisableTest.pf
+++ b/tests/core-tests/Test_DisableTest.pf
@@ -1,4 +1,4 @@
-module Test_DisableTest_mod
+module Test_DisableTest
    use FUnit
    implicit none
 
@@ -40,4 +40,4 @@ contains
    subroutine test_disable_annotation()
    end subroutine test_disable_annotation
 
-end module Test_DisableTest_mod
+end module Test_DisableTest

--- a/tests/core-tests/Test_DotPattern.pf
+++ b/tests/core-tests/Test_DotPattern.pf
@@ -1,10 +1,10 @@
-module Test_DotPattern_mod
-   use PF_Exception_mod
-   use PF_ExceptionList_mod
-   use PF_DotPattern_mod
-   use PF_MatchObject_mod
-   use PF_Assert_mod
-   use Pf_SourceLocation_mod
+module Test_DotPattern
+   use PF_Exception
+   use PF_ExceptionList
+   use PF_DotPattern
+   use PF_MatchObject
+   use PF_Assert
+   use Pf_SourceLocation
 
 
    @suite(name='DotPattern_suite')
@@ -58,4 +58,4 @@ contains
       
    end subroutine test_match_various
    
-end module Test_DotPattern_mod
+end module Test_DotPattern

--- a/tests/core-tests/Test_Exception.F90
+++ b/tests/core-tests/Test_Exception.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_Exception_mod
+!  MODULE: Test_Exception
 !
 !> @brief
 !! <BriefDescription>
@@ -22,14 +22,14 @@
 !
 !-------------------------------------------------------------------------------
 
-module Test_Exception_mod
-   use PF_TestSuite_mod
-   use PF_ExceptionList_mod
-   use PF_Exception_mod, only: Exception
-   use PF_Assert_mod, only: assertEqual
-   use PF_Assert_mod, only: assertTrue
-   use PF_Assert_mod, only: assertFalse
-   use PF_SourceLocation_mod
+module Test_Exception
+   use PF_TestSuite
+   use PF_ExceptionList
+   use PF_Exception, only: Exception
+   use PF_Assert, only: assertEqual
+   use PF_Assert, only: assertTrue
+   use PF_Assert, only: assertFalse
+   use PF_SourceLocation
    implicit none
    private
 
@@ -38,8 +38,8 @@ module Test_Exception_mod
 contains
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestMethod_mod, only: TestMethod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestMethod, only: TestMethod
 
       type (TestSuite) :: suite
 
@@ -186,8 +186,8 @@ contains
 
    ! !INTERFACE:
    subroutine testCatchFail()
-      use PF_Exception_mod, only: Exception
-      use PF_ExceptionList_mod, only: ExceptionList
+      use PF_Exception, only: Exception
+      use PF_ExceptionList, only: ExceptionList
       !EOP
       !BOC
       type (ExceptionList) :: list
@@ -452,7 +452,7 @@ contains
    end subroutine testCatchNextButPreserveC
 
    subroutine testGetLineNumberNoInfo()
-      use PF_Exception_mod, only: UNKNOWN_LINE_NUMBER
+      use PF_Exception, only: UNKNOWN_LINE_NUMBER
       type (Exception) :: anException
 
       anException = Exception()
@@ -471,7 +471,7 @@ contains
    end subroutine testGetLineNumber
 
    subroutine testGetFileNameNoInfo()
-      use PF_Exception_mod, only: UNKNOWN_FILE_NAME
+      use PF_Exception, only: UNKNOWN_FILE_NAME
       type (Exception) :: anException
 
       anException = Exception()
@@ -500,4 +500,4 @@ contains
 
    end subroutine testThrowWithLineAndFile
 
-end module test_Exception_mod
+end module test_Exception

--- a/tests/core-tests/Test_ExceptionList.pf
+++ b/tests/core-tests/Test_ExceptionList.pf
@@ -1,8 +1,8 @@
-module newTest_Exception_mod
-   use PF_Assert_mod
-   use PF_SourceLocation_mod
-   use PF_Exception_mod, only: Exception
-   use PF_ExceptionList_mod
+module newTest_Exception
+   use PF_Assert
+   use PF_SourceLocation
+   use PF_Exception, only: Exception
+   use PF_ExceptionList
    implicit none
 
    @suite(name='ExceptionList_suite')
@@ -35,4 +35,4 @@ contains
    end subroutine test_catch_fail
    
    
-end module newtest_Exception_mod
+end module newtest_Exception

--- a/tests/core-tests/Test_FixtureTestCase.F90
+++ b/tests/core-tests/Test_FixtureTestCase.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_FixtureTestCase_mod
+!  MODULE: Test_FixtureTestCase
 !
 !> @brief
 !! <BriefDescription>
@@ -21,9 +21,9 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_FixtureTestCase_mod
-   use PF_TestSuite_mod
-   use PF_TestResult_mod, only: TestResult
+module Test_FixtureTestCase
+   use PF_TestSuite
+   use PF_TestResult, only: TestResult
    implicit none
    private
 
@@ -32,8 +32,8 @@ module Test_FixtureTestCase_mod
 contains
 
    function suite() result(aSuite)
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestMethod_mod, only: TestMethod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestMethod, only: TestMethod
       type (TestSuite) :: aSuite
 
       aSuite = TestSuite('Test_FixtureTestCase')
@@ -44,25 +44,25 @@ contains
            &   TestMethod('testRunWithFixture', &
            &                  testRunWithFixture))
       call aSuite%addTest( &
-           &   TestMethod('testBrokenTestCase', &
-           &                  testBrokenTestCase))
+           &   TestMethod('testBrokenTest', &
+           &                  testBrokenTest))
       call aSuite%addTest( &
-           &   TestMethod('testBrokenSetUpCase', &
-           &                  testBrokenSetUpCase))
+           &   TestMethod('testBrokenSetUp', &
+           &                  testBrokenSetUp))
 
    end function suite
 
    subroutine testRunWithFixture()
-      use PF_TestCase_mod
-      use FixtureTestCase_mod, only: FixtureTestCase, newFixtureTestCase
-      use FixtureTestCase_mod, only: delete
-      use PF_SerialContext_mod
-      use PF_Assert_mod, only: assertEqual
-      type (FixtureTestCase) :: aTest
+      use PF_TestCase
+      use FixtureTestCase, only: FixtureTest, newFixtureTest
+      use FixtureTestCase, only: delete
+      use PF_SerialContext
+      use PF_Assert, only: assertEqual
+      type (FixtureTest) :: aTest
       type (TestResult) :: aTestResult
 
       aTestResult = TestResult()
-      aTest = newFixtureTestCase()
+      aTest = newFixtureTest()
       call aTest%setSurrogate()
       call aTest%run(aTestResult, SerialContext())
       call assertEqual('setUp run tearDown', aTest%runLog)
@@ -70,12 +70,12 @@ contains
 
    end subroutine testRunWithFixture
 
-   subroutine testBrokenTestCase()
-      use PF_TestCase_mod
-      use BrokenTestCase_mod, only: BrokenTestCase
-      use PF_Assert_mod, only: assertEqual
-      use PF_SerialContext_mod
-      type (BrokenTestCase) :: test
+   subroutine testBrokenTest()
+      use PF_TestCase
+      use BrokenTestCase, only: BrokenTest
+      use PF_Assert, only: assertEqual
+      use PF_SerialContext
+      type (BrokenTest) :: test
       type (TestResult) :: aTestResult
 
       call test%setSurrogate()
@@ -86,14 +86,14 @@ contains
       call assertEqual('setUp broken run tearDown', test%runLog)
       call assertEqual(1, aTestResult%failureCount())
 
-   end subroutine testBrokenTestCase
+   end subroutine testBrokenTest
 
-   subroutine testBrokenSetUpCase()
-      use PF_TestCase_mod
-      use BrokenSetUpCase_mod, only: BrokenSetUpCase
-      use PF_Assert_mod, only: assertEqual
-      use PF_SerialContext_mod
-      type (BrokenSetUpCase) :: test
+   subroutine testBrokenSetUp()
+      use PF_TestCase
+      use BrokenSetUpCase, only: BrokenSetUp
+      use PF_Assert, only: assertEqual
+      use PF_SerialContext
+      type (BrokenSetUp) :: test
       type (TestResult) :: aTestResult
 
       call test%setSurrogate()
@@ -103,7 +103,7 @@ contains
       call assertEqual('broken setUp', test%runLog)
       call assertEqual(1, aTestResult%failureCount())
 
-   end subroutine testBrokenSetUpCase
+   end subroutine testBrokenSetUp
 
-end module Test_FixtureTestCase_mod
+end module Test_FixtureTestCase
 

--- a/tests/core-tests/Test_GlobPattern.pf
+++ b/tests/core-tests/Test_GlobPattern.pf
@@ -1,6 +1,6 @@
-module Test_GlobPattern_mod
+module Test_GlobPattern
    use FUnit
-   use PF_GlobPattern_mod
+   use PF_GlobPattern
    implicit none
 
    @suite(name='GlobPattern_suite')
@@ -136,4 +136,4 @@ contains
       
    end function check
 
-end module Test_GlobPattern_mod
+end module Test_GlobPattern

--- a/tests/core-tests/Test_LiteralPattern.pf
+++ b/tests/core-tests/Test_LiteralPattern.pf
@@ -1,10 +1,10 @@
-module Test_LiteralPattern_mod
-   use PF_Exception_mod
-   use PF_ExceptionList_mod
-   use PF_LiteralPattern_mod
-   use PF_MatchObject_mod
-   use PF_Assert_mod
-   use Pf_SourceLocation_mod
+module Test_LiteralPattern
+   use PF_Exception
+   use PF_ExceptionList
+   use PF_LiteralPattern
+   use PF_MatchObject
+   use PF_Assert
+   use Pf_SourceLocation
 
 
    @suite(name='LiteralPattern_suite')
@@ -59,4 +59,4 @@ contains
       
    end subroutine test_match_various
    
-end module Test_LiteralPattern_mod
+end module Test_LiteralPattern

--- a/tests/core-tests/Test_MockCall.F90
+++ b/tests/core-tests/Test_MockCall.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_MockCall_mod
+!  MODULE: Test_MockCall
 !
 !> @brief
 !! <BriefDescription>
@@ -22,9 +22,9 @@
 !
 !-------------------------------------------------------------------------------
 
-module Test_MockCall_mod
-   use PF_TestSuite_mod
-   use PF_MockCall_mod
+module Test_MockCall
+   use PF_TestSuite
+   use PF_MockCall
    implicit none
    private
 
@@ -35,8 +35,8 @@ contains
 !#define ADD(method) call suite%addTest(TestMethod(REFLECT(method)))
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestMethod_mod, only: TestMethod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestMethod, only: TestMethod
       type (TestSuite) :: suite
 
       suite = TestSuite('Test_MockCall')
@@ -51,7 +51,7 @@ contains
    end function suite
 
    subroutine testExpectOneIntegerArgument
-      use PF_Assert_mod
+      use PF_Assert
       type (MockCall) :: mCall
       class (*), pointer :: q
       integer, target :: one = 1
@@ -68,7 +68,7 @@ contains
    end subroutine testExpectOneIntegerArgument
 
    subroutine testFailExpectOneIntegerArgument
-      use PF_Assert_mod
+      use PF_Assert
       type (MockCall) :: mCall
       class (*), pointer :: q
 
@@ -86,4 +86,4 @@ contains
       call assertExceptionRaised()
    end subroutine testFailExpectOneIntegerArgument
 
-end module Test_MockCall_mod
+end module Test_MockCall

--- a/tests/core-tests/Test_MockRepository.F90
+++ b/tests/core-tests/Test_MockRepository.F90
@@ -3,7 +3,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_MockRepository_mod
+!  MODULE: Test_MockRepository
 !
 !> @brief
 !! <BriefDescription>
@@ -24,7 +24,7 @@
 !-------------------------------------------------------------------------------
 
 
-module SUT_mod
+module pf_SUT
    implicit none
    private
 
@@ -43,11 +43,11 @@ contains
       _UNUSED_DUMMY(this)
    end subroutine method1
 
-end module SUT_mod
+end module PF_SUT
 
-module MockSUT_mod
-   use PF_MockRepository_mod
-   use SUT_mod
+module pf_MockSUT
+   use PF_MockRepository
+   use pf_SUT
    implicit none
    private
 
@@ -74,8 +74,8 @@ contains
 
 !TODO - make FINAL routine once gfortran supports it
    subroutine verifyMocking(this)
-      use PF_Exception_mod
-      use PF_ExceptionList_mod
+      use PF_Exception
+      use PF_ExceptionList
       class (MockSUT), intent(inout) :: this
 
       if (associated(this%mocker)) then
@@ -89,17 +89,17 @@ contains
       call this%mocker%hasCalled(this, 'method1')
    end subroutine method1
 
-end module MockSUT_mod
+end module pf_MockSUT
 
-module Test_MockRepository_mod
-   use PF_TestSuite_mod
-   use PF_MockRepository_mod
-   use PF_Exception_mod
-   use PF_ExceptionList_mod
-   use PF_Assert_mod
+module Test_MockRepository
+   use PF_TestSuite
+   use PF_MockRepository
+   use PF_Exception
+   use PF_ExceptionList
+   use PF_Assert
 
-   use SUT_mod
-   use MockSUT_mod
+   use pf_SUT
+   use pf_MockSUT
    implicit none
    private
 
@@ -112,8 +112,8 @@ contains
 !#define ADD(method) call suite%addTest(newTestMethod(REFLECT(method)))
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestMethod_mod, only: TestMethod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestMethod, only: TestMethod
       type (TestSuite) :: suite
 
       suite = TestSuite('Test_MockRepository')
@@ -205,4 +205,4 @@ contains
 
    end subroutine testExpectMethod_CalledDifferentMethod
 
-end module Test_MockRepository_mod
+end module Test_MockRepository

--- a/tests/core-tests/Test_NameFilter.pf
+++ b/tests/core-tests/Test_NameFilter.pf
@@ -1,9 +1,9 @@
-module Test_NameFilter_mod
-   use PF_Exception_mod
-   use PF_ExceptionList_mod
-   use PF_RegularExpression_mod
-   use PF_Assert_mod
-   use Pf_SourceLocation_mod
+module Test_NameFilter
+   use PF_Exception
+   use PF_ExceptionList
+   use PF_RegularExpression
+   use PF_Assert
+   use Pf_SourceLocation
 
    @suite(name='NameFilter_suite')
    
@@ -11,8 +11,8 @@ contains
 
    @test
    subroutine test_matches_exact()
-     use pf_TestMethod_mod
-     use pf_NameFilter_mod
+     use pf_TestMethod
+     use pf_NameFilter
      type(TestMethod) :: method
      type(NameFilter) :: filter
 
@@ -24,8 +24,8 @@ contains
 
    @test
    subroutine test_does_not_match_exact()
-     use pf_TestMethod_mod
-     use pf_NameFilter_mod
+     use pf_TestMethod
+     use pf_NameFilter
      type(TestMethod) :: method
      type(NameFilter) :: filter
 
@@ -38,4 +38,4 @@ contains
    subroutine was_run()
    end subroutine was_run
 
-end module Test_NameFilter_mod
+end module Test_NameFilter

--- a/tests/core-tests/Test_Norms.pf
+++ b/tests/core-tests/Test_Norms.pf
@@ -1,16 +1,16 @@
-module Test_Norms_mod
-   use pf_AssertReal_0d_mod
-   use pf_AssertReal_1d_mod
-   use pf_AssertReal_2d_mod
+module Test_Norms
+   use pf_AssertReal_0d
+   use pf_AssertReal_1d
+   use pf_AssertReal_2d
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
    use, intrinsic :: iso_fortran_env, only: REAL128
-   use pf_StringUtilities_mod
-   use pf_SourceLocation_mod
-   use pf_Exceptionlist_mod
+   use pf_StringUtilities
+   use pf_SourceLocation
+   use pf_Exceptionlist
    use FUnit, only: SourceLocation, throw, anyExceptions, AssertExceptionRaised
-   use pf_Norms_0d_mod
-   use pf_Norms_1d_mod
-   use pf_Norms_2d_mod
+   use pf_Norms_0d
+   use pf_Norms_1d
+   use pf_Norms_2d
 
    @suite(name='Norm_suite')
 
@@ -167,4 +167,4 @@ contains
    end subroutine Test_L1Norm_1d_complex
    
    
-end module Test_Norms_mod
+end module Test_Norms

--- a/tests/core-tests/Test_RegularExpression.pf
+++ b/tests/core-tests/Test_RegularExpression.pf
@@ -1,9 +1,9 @@
-module Test_RegularExpression_mod
-   use PF_Exception_mod
-   use PF_ExceptionList_mod
-   use PF_RegularExpression_mod
-   use PF_Assert_mod
-   use Pf_SourceLocation_mod
+module Test_RegularExpression
+   use PF_Exception
+   use PF_ExceptionList
+   use PF_RegularExpression
+   use PF_Assert
+   use Pf_SourceLocation
 
    @suite(name='RegularExpression_suite')
    
@@ -66,4 +66,4 @@ contains
    end subroutine test_asterisk
 
    
-end module Test_RegularExpression_mod
+end module Test_RegularExpression

--- a/tests/core-tests/Test_RepeatPattern.pf
+++ b/tests/core-tests/Test_RepeatPattern.pf
@@ -1,11 +1,11 @@
-module Test_RepeatPattern_mod
-   use PF_Exception_mod
-   use PF_ExceptionList_mod
-   use PF_RepeatPattern_mod
-   use PF_MatchObject_mod
-   use PF_Assert_mod
-   use PF_SourceLocation_mod
-   use PF_LiteralPattern_mod
+module Test_RepeatPattern
+   use PF_Exception
+   use PF_ExceptionList
+   use PF_RepeatPattern
+   use PF_MatchObject
+   use PF_Assert
+   use PF_SourceLocation
+   use PF_LiteralPattern
    implicit none
 
    @suite(name='RepeatPattern_suite')
@@ -71,4 +71,4 @@ contains
    end subroutine test_match_multichar
    
    
-end module Test_RepeatPattern_mod
+end module Test_RepeatPattern

--- a/tests/core-tests/Test_RobustRunner.F90
+++ b/tests/core-tests/Test_RobustRunner.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_RobustRunner_mod
+!  MODULE: Test_RobustRunner
 !
 !> @brief
 !! <BriefDescription>
@@ -21,9 +21,9 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_RobustRunner_mod
-   use PF_Test_mod
-   use PF_RobustRunner_mod
+module Test_RobustRunner
+   use PF_Test
+   use PF_RobustRunner
    implicit none
    private
 
@@ -32,8 +32,8 @@ module Test_RobustRunner_mod
 contains
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestMethod_mod, only: TestMethod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestMethod, only: TestMethod
       type (TestSuite) :: suite
 
       suite = TestSuite('RobustRunner')
@@ -47,13 +47,13 @@ contains
 
    subroutine testRunVariety()
       use, intrinsic :: iso_fortran_env
-      use robustTestSuite_mod, only: remoteSuite => suite
-      use PF_SerialContext_mod, only: THE_SERIAL_CONTEXT
-      use PF_TestSuite_mod
-      use PF_TestResult_mod
-      use PF_Assert_mod
-      use PF_TestListener_mod
-      use PF_ResultPrinter_mod
+      use robustTestSuite, only: remoteSuite => suite
+      use PF_SerialContext, only: THE_SERIAL_CONTEXT
+      use PF_TestSuite
+      use PF_TestResult
+      use PF_Assert
+      use PF_TestListener
+      use PF_ResultPrinter
 
       type (RobustRunner) :: runner
       type (TestSuite) :: suite
@@ -80,4 +80,4 @@ contains
 
    end subroutine testRunVariety
 
-end module Test_RobustRunner_mod
+end module Test_RobustRunner

--- a/tests/core-tests/Test_SimpleTestCase.F90
+++ b/tests/core-tests/Test_SimpleTestCase.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_SimpleTestCase_mod
+!  MODULE: Test_SimpleTestCase
 !
 !> @brief
 !! <BriefDescription>
@@ -21,8 +21,8 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_SimpleTestCase_mod
-   use PF_TestSuite_mod, only: TestSuite
+module Test_SimpleTestCase
+   use PF_TestSuite, only: TestSuite
    implicit none
    private
 
@@ -32,7 +32,7 @@ contains
 
 !#define ADD(method) call suite%addTest(TestMethod(REFLECT(method)))
    function suite()
-      use PF_TestMethod_mod, only: TestMethod
+      use PF_TestMethod, only: TestMethod
       type (TestSuite) :: suite
 
       suite = TestSuite('Test_SimpleTestCase')
@@ -47,7 +47,7 @@ contains
    end function suite
 
    function internalSuite()
-      use PF_TestMethod_mod, only: TestMethod
+      use PF_TestMethod, only: TestMethod
       type (TestSuite) :: internalSuite
 
       internalSuite = TestSuite('Test_TestCase')
@@ -58,13 +58,13 @@ contains
    end function internalSuite
 
    subroutine testWorks()
-      use PF_TestCase_mod
-      use PF_TestSuite_mod
-      use PF_TestResult_mod, only: TestResult, TestResult
-      use SimpleTestCase_mod, only: newSimpleTestCase, SimpleTestCase
-      use SimpleTestCase_mod, only: method1, method2
-      use PF_Assert_mod, only: assertEqual
-      use PF_SerialContext_mod
+      use PF_TestCase
+      use PF_TestSuite
+      use PF_TestResult, only: TestResult, TestResult
+      use pf_SimpleTestCase, only: newSimpleTestCase, SimpleTestCase
+      use pf_SimpleTestCase, only: method1, method2
+      use PF_Assert, only: assertEqual
+      use PF_SerialContext
 
       type (TestResult) :: aTestResult
       type (SimpleTestCase) :: aTest
@@ -81,13 +81,13 @@ contains
    end subroutine testWorks
 
    subroutine testFails()
-      use PF_TestCase_mod
-      use PF_TestSuite_mod
-      use PF_TestResult_mod, only: TestResult, TestResult
-      use SimpleTestCase_mod, only: newSimpleTestCase, SimpleTestCase
-      use SimpleTestCase_mod, only: method1
-      use PF_Assert_mod, only: assertEqual
-      use PF_SerialContext_mod
+      use PF_TestCase
+      use PF_TestSuite
+      use PF_TestResult, only: TestResult, TestResult
+      use pf_SimpleTestCase, only: newSimpleTestCase, SimpleTestCase
+      use pf_SimpleTestCase, only: method1
+      use PF_Assert, only: assertEqual
+      use PF_SerialContext
 
       type (TestResult) :: aTestResult
       type (SimpleTestCase) :: aTest
@@ -100,10 +100,10 @@ contains
    end subroutine testFails
 
    subroutine testRunSuite()
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestResult_mod, only: TestResult, TestResult
-      use PF_Assert_mod, only: assertEqual
-      use PF_SerialContext_mod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestResult, only: TestResult, TestResult
+      use PF_Assert, only: assertEqual
+      use PF_SerialContext
       type (TestResult) :: aTestResult
       type (TestSuite) :: aSuite
 
@@ -120,8 +120,8 @@ contains
     ! (to avoid user types being ABSTRACT), but it should never be used.
     ! This test ensures that the default throws an exception.
     subroutine testRunMethodShouldFail()
-       use PF_TestCase_mod
-       use PF_Assert_mod
+       use PF_TestCase
+       use PF_Assert
 
        type, extends(TestCase) :: TempTestCase
        end type TempTestCase
@@ -132,5 +132,5 @@ contains
        call assertExceptionRaised('TestCase::runMethod() must be overridden.')
     end subroutine testRunMethodShouldFail
 
-end module Test_SimpleTestCase_mod
+end module Test_SimpleTestCase
 

--- a/tests/core-tests/Test_StringUtilities.F90
+++ b/tests/core-tests/Test_StringUtilities.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_StringUtilities_mod
+!  MODULE: Test_StringUtilities
 !
 !> @brief
 !! <BriefDescription>
@@ -21,9 +21,9 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_StringUtilities_mod
-   use PF_StringUtilities_mod, only: toString
-   use PF_Assert_mod
+module Test_StringUtilities
+   use PF_StringUtilities, only: toString
+   use PF_Assert
    implicit none
    private
 
@@ -32,8 +32,8 @@ module Test_StringUtilities_mod
 contains
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestMethod_mod, only: TestMethod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestMethod, only: TestMethod
       type (TestSuite) :: suite
 
       suite = TestSuite('StringUtilities')
@@ -97,4 +97,4 @@ contains
       call assertEqual('-1234567.',toString(-1234567.))
    end subroutine testToString_realNegative
 
-end module Test_StringUtilities_mod
+end module Test_StringUtilities

--- a/tests/core-tests/Test_TapListener.pf
+++ b/tests/core-tests/Test_TapListener.pf
@@ -1,8 +1,8 @@
-module Test_TapListener_mod
+module Test_TapListener
    use FUnit
-   use pf_ExceptionList_mod
-   use pf_Exception_mod
-   use pf_TapListener_mod
+   use pf_ExceptionList
+   use pf_Exception
+   use pf_TapListener
    implicit none
 
    @suite(name='TapListener_suite')
@@ -94,4 +94,4 @@ contains
    end subroutine test_addFailure_withmessage
 
    
-end module Test_TapListener_mod
+end module Test_TapListener

--- a/tests/core-tests/Test_TestMethod.F90
+++ b/tests/core-tests/Test_TestMethod.F90
@@ -1,7 +1,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_TestMethod_mod
+!  MODULE: Test_TestMethod
 !
 !> @brief
 !! <BriefDescription>
@@ -20,7 +20,7 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_TestMethod_mod
+module Test_TestMethod
    implicit none
    private
 
@@ -29,8 +29,8 @@ module Test_TestMethod_mod
 contains
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestMethod_mod, only: TestMethod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestMethod, only: TestMethod
       type (TestSuite) :: suite
 
       suite = TestSuite('Test_TestMethod')
@@ -39,13 +39,13 @@ contains
    end function suite
 
    subroutine testMethodWasRun()
-      use PF_TestCase_mod
-      use PF_TestResult_mod, only: TestResult, TestResult
-      use PF_TestMethod_mod, only: TestMethod, TestMethod
-      use PF_Assert_mod, only: assertEqual
-      use PF_SerialContext_mod
-      use PF_Exception_mod
-      use PF_ExceptionList_mod
+      use PF_TestCase
+      use PF_TestResult, only: TestResult, TestResult
+      use PF_TestMethod, only: TestMethod, TestMethod
+      use PF_Assert, only: assertEqual
+      use PF_SerialContext
+      use PF_Exception
+      use PF_ExceptionList
       type (TestMethod) :: method
       type (TestResult) :: aResult
 
@@ -57,9 +57,9 @@ contains
    end subroutine testMethodWasRun
 
    subroutine testWasRun()
-      use PF_ExceptionList_mod, only: throw
+      use PF_ExceptionList, only: throw
       call throw('wasRun')
    end subroutine testWasRun
 
-end module Test_TestMethod_mod
+end module Test_TestMethod
 

--- a/tests/core-tests/Test_TestResult.F90
+++ b/tests/core-tests/Test_TestResult.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_TestResult_mod
+!  MODULE: Test_TestResult
 !
 !> @brief
 !! <BriefDescription>
@@ -21,9 +21,9 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_TestResult_mod
-   use PF_TestCase_mod
-   use PF_TestResult_mod, only: TestResult
+module Test_TestResult
+   use PF_TestCase
+   use PF_TestResult, only: TestResult
    implicit none
    private
 
@@ -32,9 +32,9 @@ module Test_TestResult_mod
 contains
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestCase_mod
-      use PF_TestMethod_mod, only: TestMethod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestCase
+      use PF_TestMethod, only: TestMethod
       type (TestSuite) :: suite
 
       suite = TestSuite('TestResultSuite')
@@ -62,10 +62,10 @@ contains
    end function suite
 
    subroutine testGetNumRun()
-      use PF_Assert_mod, only: assertEqual
-      use PF_TestResult_mod, only: TestResult
-      use PF_TestCase_mod
-      use SimpleTestCase_mod
+      use PF_Assert, only: assertEqual
+      use PF_TestResult, only: TestResult
+      use PF_TestCase
+      use pf_SimpleTestCase
       type (TestResult) :: aResult
       type (SimpleTestCase) :: tstCase
 
@@ -85,12 +85,12 @@ contains
    end subroutine testGetNumRun
 
    subroutine testGetNumFailed()
-      use PF_Assert_mod, only: assertEqual
-      use PF_Exception_mod, only: Exception
-      use PF_ExceptionList_mod, only: ExceptionList
-      use SimpleTestCase_mod, only: SimpleTestCase
-      use PF_SurrogateTestCase_mod
-      use PF_TestCase_mod
+      use PF_Assert, only: assertEqual
+      use PF_Exception, only: Exception
+      use PF_ExceptionList, only: ExceptionList
+      use pf_SimpleTestCase, only: SimpleTestCase
+      use PF_SurrogateTestCase
+      use PF_TestCase
 
       type (TestResult) :: aResult
       type (ExceptionList) :: list
@@ -113,11 +113,11 @@ contains
    end subroutine testGetNumFailed
 
    subroutine testAddListenerStart()
-      use PF_TestListener_mod
-      use PF_SurrogateTestCase_mod
-      use MockListener_mod
-      use PF_Assert_mod
-      use SimpleTestCase_mod
+      use PF_TestListener
+      use PF_SurrogateTestCase
+      use pf_MockListener
+      use PF_Assert
+      use pf_SimpleTestCase
       type (TestResult) :: result
       type (MockListener), target :: listener
       
@@ -136,12 +136,12 @@ contains
    end subroutine testAddListenerStart
 
    subroutine testAddListenerEnd()
-      use PF_TestListener_mod
-      use MockListener_mod
-      use PF_Assert_mod
-      use SimpleTestCase_mod
-      use PF_SurrogateTestCase_mod
-      use PF_TestCase_mod
+      use PF_TestListener
+      use pf_MockListener
+      use PF_Assert
+      use pf_SimpleTestCase
+      use PF_SurrogateTestCase
+      use PF_TestCase
 
       type (TestResult) :: result
       type (MockListener), target :: listener
@@ -158,14 +158,14 @@ contains
    end subroutine testAddListenerEnd
 
    subroutine testAddListenerFailure()
-      use PF_TestListener_mod
-      use MockListener_mod
-      use PF_Assert_mod
-      use PF_Exception_mod
-      use PF_ExceptionList_mod
-      use SimpleTestCase_mod
-      use PF_SurrogateTestCase_mod
-      use PF_TestCase_mod
+      use PF_TestListener
+      use pf_MockListener
+      use PF_Assert
+      use PF_Exception
+      use PF_ExceptionList
+      use pf_SimpleTestCase
+      use PF_SurrogateTestCase
+      use PF_TestCase
       
       type (TestResult) :: result
       type (MockListener), target :: listener
@@ -186,4 +186,4 @@ contains
 
    end subroutine testAddListenerFailure
 
-end module Test_TestResult_mod
+end module Test_TestResult

--- a/tests/core-tests/Test_TestSuite.F90
+++ b/tests/core-tests/Test_TestSuite.F90
@@ -3,7 +3,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_TestSuite_mod
+!  MODULE: Test_TestSuite
 !
 !> @brief
 !! <BriefDescription>
@@ -22,10 +22,10 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_TestSuite_mod
-   use PF_TestSuite_mod, only: TestSuite
-   use PF_TestResult_mod
-   use PF_Assert_mod, only: assertEqual
+module Test_TestSuite
+   use PF_TestSuite, only: TestSuite
+   use PF_TestResult
+   use PF_Assert, only: assertEqual
    implicit none
    private
 
@@ -42,8 +42,8 @@ module Test_TestSuite_mod
 contains
 
    function suite()
-      use PF_TestMethod_mod, only: TestMethod
-      use PF_TestSuite_mod, only: TestSuite, TestSuite
+      use PF_TestMethod, only: TestMethod
+      use PF_TestSuite, only: TestSuite, TestSuite
       type (TestSuite) :: suite
 
       suite = TestSuite('TestSuiteSuite')
@@ -75,10 +75,10 @@ contains
    end function suite
 
    subroutine testCountTestCases()
-      use PF_TestSuite_mod, only: TestSuite, TestSuite
-      use SimpleTestCase_mod, only: newSimpleTestCase
-      use SimpleTestCase_mod, only: method1, method2
-      use PF_TestSuite_mod, only: TestSuite, TestSuite
+      use PF_TestSuite, only: TestSuite, TestSuite
+      use pf_SimpleTestCase, only: newSimpleTestCase
+      use pf_SimpleTestCase, only: method1, method2
+      use PF_TestSuite, only: TestSuite, TestSuite
       type (TestSuite) :: suite
 
       suite = TestSuite('aSuite')
@@ -91,7 +91,7 @@ contains
    end subroutine testCountTestCases
 
    subroutine testCountTestCasesNestedA()
-      use PF_TestSuite_mod, only: TestSuite, TestSuite
+      use PF_TestSuite, only: TestSuite, TestSuite
 
       type (TestSuite) :: innerSuite
       type (TestSuite) :: outerSuite
@@ -104,8 +104,8 @@ contains
    end subroutine testCountTestCasesNestedA
 
    subroutine testCountTestCasesNestedB()
-      use PF_TestSuite_mod, only: TestSuite, TestSuite
-      use SimpleTestCase_mod, only: SimpleTestCase
+      use PF_TestSuite, only: TestSuite, TestSuite
+      use pf_SimpleTestCase, only: SimpleTestCase
       type (TestSuite) :: innerSuite
       type (TestSuite) :: outerSuite
 
@@ -134,8 +134,8 @@ contains
    !          -> Test2
    !
    subroutine testCountTestCasesNestedC()
-      use PF_TestSuite_mod, only: TestSuite, TestSuite
-      use SimpleTestCase_mod, only: SimpleTestCase
+      use PF_TestSuite, only: TestSuite, TestSuite
+      use pf_SimpleTestCase, only: SimpleTestCase
       type (TestSuite) :: suiteA, suiteB, suiteC, topSuite
       type (SimpleTestCase) :: aTest
 
@@ -162,11 +162,11 @@ contains
    end subroutine testCountTestCasesNestedC
 
    subroutine testGetTestCases()
-      use PF_Test_mod
-      use PF_TestVector_mod
-      use PF_TestCase_mod
-      use PF_TestMethod_mod
-      use PF_SerialContext_mod
+      use PF_Test
+      use PF_TestVector
+      use PF_TestCase
+      use PF_TestMethod
+      use PF_SerialContext
 
       type (TestSuite) :: top
       type (TestSuite) :: childA, childB
@@ -204,8 +204,8 @@ contains
 
 
    subroutine test_filter_simple()
-     use pf_NameFilter_mod
-     use pf_TestMethod_mod, only: TestMethod
+     use pf_NameFilter
+     use pf_TestMethod, only: TestMethod
      type (TestSuite) :: all_tests
      type (TestSuite) :: filtered_tests
 
@@ -225,8 +225,8 @@ contains
    end subroutine test_filter_simple
 
    subroutine test_filter_nested()
-     use pf_NameFilter_mod
-     use pf_TestMethod_mod, only: TestMethod
+     use pf_NameFilter
+     use pf_TestMethod, only: TestMethod
      type(TestSuite) :: all_tests
      type(TestSuite) :: subsuite
      type(TestSuite) :: filtered_tests
@@ -262,9 +262,9 @@ contains
    end subroutine myTestMethod
 
    recursive subroutine run(this, test, context)
-      use PF_TestCase_mod
-      use PF_SurrogateTestCase_mod
-      use PF_ParallelContext_mod
+      use PF_TestCase
+      use PF_SurrogateTestCase
+      use PF_ParallelContext
       class (Verbose), intent(inout) :: this
       class (SurrogateTestCase), intent(inout) :: test
       class (ParallelContext), intent(in) :: context
@@ -274,4 +274,4 @@ contains
 
    end subroutine run
 
-end module Test_TestSuite_mod
+end module Test_TestSuite

--- a/tests/core-tests/Test_UnixProcess.F90
+++ b/tests/core-tests/Test_UnixProcess.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_UnixProcess_mod
+!  MODULE: Test_UnixProcess
 !
 !> @brief
 !! <BriefDescription>
@@ -21,11 +21,11 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_UnixProcess_mod
-   use PF_TestSuite_mod
-   use PF_Assert_mod
-   use PF_ExceptionList_mod
-   use PF_UnixProcess_mod
+module Test_UnixProcess
+   use PF_TestSuite
+   use PF_Assert
+   use PF_ExceptionList
+   use PF_UnixProcess
    implicit none
    private
 
@@ -34,8 +34,8 @@ module Test_UnixProcess_mod
 contains
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestMethod_mod, only: TestMethod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestMethod, only: TestMethod
       type (TestSuite) :: suite
 
       suite = TestSuite('UnixProcess')
@@ -94,4 +94,4 @@ contains
       
    end subroutine testGetLine2
 
-end module Test_UnixProcess_mod
+end module Test_UnixProcess

--- a/tests/core-tests/Test_XmlPrinter.F90
+++ b/tests/core-tests/Test_XmlPrinter.F90
@@ -25,7 +25,7 @@
 !
 !-------------------------------------------------------------------------------
 !#include "reflection.h"
-module Test_XmlPrinter_mod
+module Test_XmlPrinter
    implicit none
    private
 
@@ -34,11 +34,11 @@ module Test_XmlPrinter_mod
 contains
 
    function suite()
-      use PF_TestCase_mod
-      use PF_TestMethod_mod, only: TestMethod
-      use PF_Test_mod
-      use PF_TestResult_mod
-      use PF_TestSuite_mod, only: TestSuite
+      use PF_TestCase
+      use PF_TestMethod, only: TestMethod
+      use PF_Test
+      use PF_TestResult
+      use PF_TestSuite, only: TestSuite
       type (TestSuite) :: suite
 
       suite = TestSuite('TestXmlPrinterSuite')
@@ -52,14 +52,14 @@ contains
    end function suite
 
    subroutine testValidXml()
-      use PF_Assert_mod, only: assertEqual
-      use PF_Exception_mod, only: Exception
-      use PF_ExceptionList_mod
-      use PF_TestCase_mod
-      use SimpleTestCase_mod, only: SimpleTestCase
-      use PF_SurrogateTestCase_mod
-      use PF_TestResult_mod, only: TestResult, TestResult
-      use PF_XmlPrinter_mod, only: XmlPrinter, newXmlPrinter
+      use PF_Assert, only: assertEqual
+      use PF_Exception, only: Exception
+      use PF_ExceptionList
+      use PF_TestCase
+      use pf_SimpleTestCase, only: SimpleTestCase
+      use PF_SurrogateTestCase
+      use PF_TestResult, only: TestResult, TestResult
+      use PF_XmlPrinter, only: XmlPrinter, newXmlPrinter
 
       type (TestResult) :: aResult
       type (SimpleTestCase), target :: aTest, aTest2
@@ -122,8 +122,8 @@ contains
    end subroutine testValidXml
 
    subroutine compareXMLFileToExpectation(xmlFile)
-     use PF_Assert_mod, only: assertEqual
-     use PF_Assert_mod, only: assertTrue
+     use PF_Assert, only: assertEqual
+     use PF_Assert, only: assertTrue
      use iso_fortran_env, only: iostat_end
 
      character(len=200), intent(in) :: xmlFile
@@ -174,4 +174,4 @@ contains
    end subroutine compareXMLFileToExpectation
 
 
-end module Test_XmlPrinter_mod
+end module Test_XmlPrinter

--- a/tests/core-tests/robustTestSuite.F90
+++ b/tests/core-tests/robustTestSuite.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: robustTestSuite_mod
+!  MODULE: robustTestSuite
 !
 !> @brief
 !! <BriefDescription>
@@ -21,7 +21,7 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module robustTestSuite_mod
+module robustTestSuite
    use FUnit
    implicit none
    private
@@ -31,8 +31,8 @@ module robustTestSuite_mod
 contains
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestMethod_mod, only: TestMethod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestMethod, only: TestMethod
       type (TestSuite) :: suite
 
       suite = TestSuite('robustTestSuite')
@@ -61,7 +61,7 @@ contains
    end subroutine testRunSucceeds
 
    subroutine testRunMultipleExceptions()
-     use PF_Assert_mod
+     use PF_Assert
      ! do nothing
      call assertTrue(1 == 2)
      call assertTrue(1 == 3)
@@ -69,7 +69,7 @@ contains
    end subroutine testRunMultipleExceptions
 
    subroutine testRunAssertFailure()
-      use PF_Assert_mod
+      use PF_Assert
       ! do nothing
       call assertTrue(1 == 2)
    end subroutine testRunAssertFailure
@@ -91,4 +91,4 @@ contains
       end do
    end subroutine testRunHangs
 
-end module robustTestSuite_mod
+end module robustTestSuite

--- a/tests/core-tests/serialRemoteProgram.F90
+++ b/tests/core-tests/serialRemoteProgram.F90
@@ -6,7 +6,7 @@ program main
    use FUnit, only: ParallelContext
    use FUnit, only: SerialContext
    use FUnit, only: stub
-   use robustTestSuite_mod
+   use robustTestSuite
    implicit none
 
 !!$   call initialize(useMPI=.false.)

--- a/tests/core-tests/serial_tests.F90
+++ b/tests/core-tests/serial_tests.F90
@@ -21,28 +21,28 @@ contains
       use FUnit, only: TestRunner, TestRunner
       use FUnit, only: SerialContext
 
-      use Test_StringUtilities_mod, only: StringUtilitiesSuite => suite    ! (1)
-      use Test_UnixProcess_mod, only: unixProcessSuite => suite                ! (1)
-      use Test_Exception_mod, only: exceptionSuite => suite                ! (2)
-      use Test_AssertBasic_mod, only: assertBasicSuite => suite            !
-      use Test_Assert_mod, only: assertSuite => suite                      ! (3)
+      use Test_StringUtilities, only: StringUtilitiesSuite => suite    ! (1)
+      use Test_UnixProcess, only: unixProcessSuite => suite                ! (1)
+      use Test_Exception, only: exceptionSuite => suite                ! (2)
+      use Test_AssertBasic, only: assertBasicSuite => suite            !
+      use Test_Assert, only: assertSuite => suite                      ! (3)
 
-!!$      use Test_AssertComplex_mod, only: assertComplexSuite => suite              ! (5)
+!!$      use Test_AssertComplex, only: assertComplexSuite => suite              ! (5)
 
-      use Test_TestResult_mod, only: testResultSuite => suite              ! (6)
-      use Test_TestSuite_mod, only: testTestSuiteSuite => suite                ! (7)
+      use Test_TestResult, only: testResultSuite => suite              ! (6)
+      use Test_TestSuite, only: testTestSuiteSuite => suite                ! (7)
 
-      use Test_TestMethod_mod, only: testTestMethodSuite => suite  ! (8)
-      use Test_SimpleTestCase_mod, only: testSimpleTestCaseSuite => suite          ! (9)
-      use Test_FixtureTestCase_mod, only: testFixtureTestCaseSuite => suite        ! (10)
+      use Test_TestMethod, only: testTestMethodSuite => suite  ! (8)
+      use Test_SimpleTestCase, only: testSimpleTestCaseSuite => suite          ! (9)
+      use Test_FixtureTestCase, only: testFixtureTestCaseSuite => suite        ! (10)
 
-      use Test_BasicOpenMP_mod, only: testBasicOpenMpSuite => suite  ! (8)
+      use Test_BasicOpenMP, only: testBasicOpenMpSuite => suite  ! (8)
 
-      use Test_MockCall_mod, only: testMockCallSuite => suite      ! (11)
-      use Test_MockRepository_mod, only: testMockRepositorySuite => suite      ! (11)
-      use Test_XmlPrinter_mod, only: testXmlPrinterSuite => suite
+      use Test_MockCall, only: testMockCallSuite => suite      ! (11)
+      use Test_MockRepository, only: testMockRepositorySuite => suite      ! (11)
+      use Test_XmlPrinter, only: testXmlPrinterSuite => suite
 
-      use Test_RobustRunner_mod, only: testRobustRunnerSuite => suite
+      use Test_RobustRunner, only: testRobustRunnerSuite => suite
 
       use iso_fortran_env, only: OUTPUT_UNIT
 

--- a/tests/mpi-tests/Test_MPI_stub.pf
+++ b/tests/mpi-tests/Test_MPI_stub.pf
@@ -1,4 +1,4 @@
-module Test_MPI_stub_mod
+module Test_MPI_stub
    use pfunit
 
 contains
@@ -9,4 +9,4 @@ contains
 
    end subroutine stub_mpi_test
 
-end module Test_MPI_stub_mod
+end module Test_MPI_stub

--- a/tests/mpi-tests/Test_MpiContext.F90
+++ b/tests/mpi-tests/Test_MpiContext.F90
@@ -1,7 +1,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_MpiContext_mod
+!  MODULE: Test_MpiContext
 !
 !> @brief
 !! <BriefDescription>
@@ -20,12 +20,12 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_MpiContext_mod
-   use PF_ParallelContext_mod
-   use PF_TestCase_mod
-   use PF_MpiTestCase_mod
-   use PF_MpiTestMethod_mod
-   use PF_Assert_mod
+module Test_MpiContext
+   use PF_ParallelContext
+   use PF_TestCase
+   use PF_MpiTestCase
+   use PF_MpiTestMethod
+   use PF_Assert
    implicit none
    private
 
@@ -34,7 +34,7 @@ module Test_MpiContext_mod
 contains
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
+      use PF_TestSuite, only: TestSuite
 
       type (TestSuite) :: suite
 
@@ -87,6 +87,6 @@ contains
       call assertTrue(qOut)
    end subroutine testAllReduce_some
 
-end module Test_MpiContext_mod
+end module Test_MpiContext
 
 

--- a/tests/mpi-tests/Test_MpiException.F90
+++ b/tests/mpi-tests/Test_MpiException.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_MpiException_mod
+!  MODULE: Test_MpiException
 !
 !> @brief
 !! <BriefDescription>
@@ -21,11 +21,11 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_MpiException_mod
-   use PF_Test_mod
-   use PF_TestCase_mod
-   use PF_ExceptionList_mod
-   use PF_MpiTestMethod_mod
+module Test_MpiException
+   use PF_Test
+   use PF_TestCase
+   use PF_ExceptionList
+   use PF_MpiTestMethod
    implicit none
 
    private
@@ -35,8 +35,8 @@ module Test_MpiException_mod
 contains
 
    function suite()
-      use PF_TestSuite_mod, only: TestSuite
-      use PF_TestMethod_mod, only: TestMethod!, TestMethod
+      use PF_TestSuite, only: TestSuite
+      use PF_TestMethod, only: TestMethod!, TestMethod
 
       type (TestSuite) :: suite
 
@@ -59,8 +59,8 @@ contains
    end function suite
 
    subroutine test_anyExceptions_none(this)
-      use PF_Assert_mod
-      use PF_ParallelContext_mod
+      use PF_Assert
+      use PF_ParallelContext
       class (MpiTestMethod), intent(inout) :: this
       class (ParallelContext), allocatable :: context
 
@@ -82,8 +82,8 @@ contains
    end subroutine test_anyExceptions_none
 
    subroutine test_getNumExceptions(this)
-      use PF_Assert_mod
-      use PF_ParallelContext_mod
+      use PF_Assert
+      use PF_ParallelContext
       class (MpiTestMethod), intent(inout) :: this
 
       call assertEqual(0, getNumExceptions(this%getContext()))
@@ -104,8 +104,8 @@ contains
    end subroutine test_getNumExceptions
 
    subroutine test_gather(this)
-      use PF_Assert_mod
-      use PF_ParallelContext_mod
+      use PF_Assert
+      use PF_ParallelContext
       class (MpiTestMethod), intent(inout) :: this
 
       select case (this%getProcessRank()) 
@@ -134,4 +134,4 @@ contains
 
    end subroutine test_gather
 
-end module Test_MpiException_mod
+end module Test_MpiException

--- a/tests/mpi-tests/Test_MpiParameterizedTestCase.F90
+++ b/tests/mpi-tests/Test_MpiParameterizedTestCase.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_MpiParameterizedTestCase_mod
+!  MODULE: Test_MpiParameterizedTestCase
 !
 !> @brief
 !! <BriefDescription>
@@ -21,11 +21,11 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_MpiParameterizedTestCase_mod
-   use PF_Test_mod
-   use PF_TestCase_mod
-   use PF_MpiTestCase_mod
-   use PF_MpiTestParameter_mod
+module Test_MpiParameterizedTestCase
+   use PF_Test
+   use PF_TestCase
+   use PF_MpiTestCase
+   use PF_MpiTestParameter
    implicit none
    private
 
@@ -56,7 +56,7 @@ module Test_MpiParameterizedTestCase_mod
 contains
 
    function suite()
-     use PF_TestSuite_mod, only: TestSuite
+     use PF_TestSuite, only: TestSuite
       type (TestSuite) :: suite
 
       type (ExtendedTestParameter) :: testParameter
@@ -100,7 +100,7 @@ contains
     end function toString
 
    subroutine testRunOn2PEs(this)
-      use PF_Assert_mod, only: assertEqual
+      use PF_Assert, only: assertEqual
       class (Test_MpiTestCase), intent(inout) :: this
 
       call assertEqual(2, this%getNumProcesses())
@@ -110,7 +110,7 @@ contains
    ! ensure that the extra parameter is correctly captured in the 
    ! testParameter component of the base class.
    subroutine testToString(this)
-      use PF_Assert_mod, only: assertEqual
+      use PF_Assert, only: assertEqual
       class (Test_MpiTestCase), intent(inout) :: this
 
       call assertEqual('2', this%testParameter%toString())
@@ -123,4 +123,4 @@ contains
    end subroutine runMethod
 
 
-end module Test_MpiParameterizedTestCase_mod
+end module Test_MpiParameterizedTestCase

--- a/tests/mpi-tests/Test_MpiTestCase.F90
+++ b/tests/mpi-tests/Test_MpiTestCase.F90
@@ -2,7 +2,7 @@
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
-!  MODULE: Test_MpiTestCase_mod
+!  MODULE: Test_MpiTestCase
 !
 !> @brief
 !! <BriefDescription>
@@ -21,62 +21,62 @@
 ! 21 Mar 2015 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
-module Test_MpiTestCase_mod
+module Test_MpiTestCase
    use mpi
-   use PF_Test_mod
-   use PF_TestCase_mod
-   use PF_MpiTestCase_mod
-   use PF_MpiTestParameter_mod
+   use PF_Test
+   use PF_TestCase
+   use PF_MpiTestCase
+   use PF_MpiTestParameter
    implicit none
    private
 
    public :: suite
-   public :: newTest_MpiTestCase
-   public :: Test_MpiTestCase
+   public :: newTestMpiTestCase
+   public :: TestMpiTestCase
 
-   type, extends(MpiTestCase) :: Test_MpiTestCase
+   type, extends(MpiTestCase) :: TestMpiTestCase
       character(len=:), allocatable, public :: runLog
       procedure(method), pointer :: testMethod => null()
    contains
       procedure :: runMethod
-   end type Test_MpiTestCase
+   end type TestMpiTestCase
 
    abstract interface
       subroutine method(this)
-        import Test_MpiTestCase
-        class (Test_MpiTestCase), intent(inout) :: this
+        import TestMpiTestCase
+        class (TestMpiTestCase), intent(inout) :: this
       end subroutine method
    end interface
    
 contains
 
    function suite()
-     use PF_TestSuite_mod, only: TestSuite
+     use PF_TestSuite, only: TestSuite
       type (TestSuite) :: suite
 
-      suite = TestSuite('Test_MpiTestCase')
+      suite = TestSuite('TestMpiTestCase')
 
-      call suite%addTest(newTest_MpiTestCase('testWasRun', &
+      call suite%addTest(newTestMpiTestCase('testWasRun', &
            &                                  testWasRun, numProcesses=1))
-      call suite%addTest(newTest_MpiTestCase('testRunOn2Processors', &
+      call suite%addTest(newTestMpiTestCase('testRunOn2Processors', &
            &                                  testRunOn2Processors, numProcesses=2))
-      call suite%addTest(newTest_MpiTestCase('testFailOn1', &
+      call suite%addTest(newTestMpiTestCase('testFailOn1', &
            &                                  testFailOn1, numProcesses=3))
-      call suite%addTest(newTest_MpiTestCase('testFailOn2', &
+      call suite%addTest(newTestMpiTestCase('testFailOn2', &
            &                                  testFailOn2, numProcesses=3))
-      call suite%addTest(newTest_MpiTestCase('testTooFewProcs', &
+      call suite%addTest(newTestMpiTestCase('testTooFewProcs', &
            &                                  testTooFewProcs, numProcesses=4))
 
-!      call suite%addTest(newTest_MpiTestCase(REFLECT(testWasRun), numProcesses=1))
-!      call suite%addTest(newTest_MpiTestCase(REFLECT(testRunOn2Processors), numProcesses=2))
-!      call suite%addTest(newTest_MpiTestCase(REFLECT(testFailOn1), numProcesses=3))
-!      call suite%addTest(newTest_MpiTestCase(REFLECT(testFailOn2), numProcesses=3))
-!      call suite%addTest(newTest_MpiTestCase(REFLECT(testTooFewProcs), numProcesses=4))
+!      call suite%addTest(newTestMpiTestCase(REFLECT(testWasRun), numProcesses=1))
+!      call suite%addTest(newTestMpiTestCase(REFLECT(testRunOn2Processors), numProcesses=2))
+!      call suite%addTest(newTestMpiTestCase(REFLECT(testFailOn1), numProcesses=3))
+!      call suite%addTest(newTestMpiTestCase(REFLECT(testFailOn2), numProcesses=3))
+!      call suite%addTest(newTestMpiTestCase(REFLECT(testTooFewProcs), numProcesses=4))
       
    end function suite
 
-   function newTest_MpiTestCase(name, userMethod, numProcesses) result(this)
-      type(Test_MpiTestCase) :: this
+   function newTestMpiTestCase(name, userMethod, numProcesses) result(this)
+      type(TestMpiTestCase) :: this
       character(len=*), intent(in) :: name
       procedure(method) :: userMethod
       integer, intent(in) :: numProcesses
@@ -86,11 +86,11 @@ contains
       this%testMethod => userMethod
       call this%setTestParameter(MpiTestParameter(numProcesses))
 
-    end function newTest_MpiTestCase
+    end function newTestMpiTestCase
 
    subroutine testWasRun(this)
-      use PF_Assert_mod, only: assertEqual
-      class (Test_MpiTestCase), intent(inout) :: this
+      use PF_Assert, only: assertEqual
+      class (TestMpiTestCase), intent(inout) :: this
 
       this%runLog = ' ' ! empty
       call wasRun(this%runLog, this%getMpiCommunicator())
@@ -99,8 +99,8 @@ contains
    end subroutine testWasRun
 
    subroutine testRunOn2Processors(this)
-      use PF_Assert_mod, only: assertEqual
-      class (Test_MpiTestCase), intent(inout) :: this
+      use PF_Assert, only: assertEqual
+      class (TestMpiTestCase), intent(inout) :: this
 
       integer :: numProcesses, ier
       call Mpi_Comm_Size(this%getMpiCommunicator(), numProcesses, ier)
@@ -109,8 +109,8 @@ contains
    end subroutine testRunOn2Processors
 
    subroutine brokenProcess1(this)
-      use PF_ExceptionList_mod
-      class (Test_MpiTestCase), intent(inout) :: this
+      use PF_ExceptionList
+      class (TestMpiTestCase), intent(inout) :: this
 
       if (this%context%processRank() == 1) then
          call throw('Intentional fail on process 1.')
@@ -119,8 +119,8 @@ contains
    end subroutine brokenProcess1
 
    subroutine brokenOnProcess2(this)
-      use PF_ExceptionList_mod
-      class (Test_MpiTestCase), intent(inout) :: this
+      use PF_ExceptionList
+      class (TestMpiTestCase), intent(inout) :: this
 
       if (this%context%processRank() == 1 .or. this%context%processRank() == 2) then
          call throw('Intentional fail')
@@ -131,23 +131,23 @@ contains
    ! Test that exception thrown on non root process is
    ! detected on root process in the end.
    subroutine testFailOn1(this)
-      use PF_Assert_mod, only: assertEqual
-      use PF_TestResult_mod
-      use PF_Exception_mod, only: Exception
-      use PF_ExceptionList_mod, only: throw
-      use PF_ExceptionList_mod, only: catch
-      use PF_TestFailure_mod
-      class (Test_MpiTestCase), intent(inout) :: this
+      use PF_Assert, only: assertEqual
+      use PF_TestResult
+      use PF_Exception, only: Exception
+      use PF_ExceptionList, only: throw
+      use PF_ExceptionList, only: catch
+      use PF_TestFailure
+      class (TestMpiTestCase), intent(inout) :: this
 
       integer :: numProcesses, ier
-      type (Test_MpiTestCase) :: brokenTest
+      type (TestMpiTestCase) :: brokenTest
       type (TestResult) :: reslt
       type (TestFailure) :: failure
       type (Exception), pointer :: e
 
 
       reslt = TestResult()
-      brokenTest = newTest_MpiTestCase('brokenProcess1', brokenProcess1, numProcesses = 3)
+      brokenTest = newTestMpiTestCase('brokenProcess1', brokenProcess1, numProcesses = 3)
 
       call brokenTest%run(reslt, this%context)
 
@@ -175,22 +175,22 @@ contains
    ! Test that exception thrown on non root process is
    ! detected on root process in the end.
    subroutine testFailOn2(this)
-      use PF_ExceptionList_mod, only: throw
-      use PF_Assert_mod, only: assertEqual
-      use PF_TestResult_mod
-      use PF_Exception_mod, only: Exception
-      use PF_ExceptionList_mod, only: catch
-      use PF_TestFailure_mod
-      class (Test_MpiTestCase), intent(inout) :: this
+      use PF_ExceptionList, only: throw
+      use PF_Assert, only: assertEqual
+      use PF_TestResult
+      use PF_Exception, only: Exception
+      use PF_ExceptionList, only: catch
+      use PF_TestFailure
+      class (TestMpiTestCase), intent(inout) :: this
 
       integer :: numProcesses, ier
-      type (Test_MpiTestCase) :: brokenTest
+      type (TestMpiTestCase) :: brokenTest
       type (TestResult) :: reslt
       type (TestFailure) :: failure
       type (Exception), pointer :: e
 
       reslt = TestResult()
-      brokenTest = newTest_MpiTestCase('brokenOnProcess2', brokenOnProcess2, numProcesses = 3)
+      brokenTest = newTestMpiTestCase('brokenOnProcess2', brokenOnProcess2, numProcesses = 3)
       call brokenTest%run(reslt, this%context)
 
       if (this%context%isRootProcess()) then
@@ -216,17 +216,17 @@ contains
    ! Purposefully request more processes than are available. 
    ! detected on root process in the end.
    subroutine testTooFewProcs(this)
-      use PF_ExceptionList_mod, only: throw
-      use PF_Assert_mod, only: assertEqual
-      use PF_TestResult_mod
-      use PF_Exception_mod, only: Exception
-      use PF_ExceptionList_mod, only: catch
-      use PF_ExceptionList_mod, only: anyExceptions
-      use PF_TestFailure_mod
-      class (Test_MpiTestCase), intent(inout) :: this
+      use PF_ExceptionList, only: throw
+      use PF_Assert, only: assertEqual
+      use PF_TestResult
+      use PF_Exception, only: Exception
+      use PF_ExceptionList, only: catch
+      use PF_ExceptionList, only: anyExceptions
+      use PF_TestFailure
+      class (TestMpiTestCase), intent(inout) :: this
 
       integer :: numProcesses, ier
-      type (Test_MpiTestCase) :: brokenTest
+      type (TestMpiTestCase) :: brokenTest
       type (TestResult) :: reslt
       type (TestFailure) :: failure
       integer, parameter :: TOO_MANY_PES = 5
@@ -236,7 +236,7 @@ contains
       character(len=:), allocatable :: expectedMessage
 
       reslt = TestResult()
-      brokenTest = newTest_MpiTestCase('brokenOnProcess2', brokenOnProcess2, numProcesses = TOO_MANY_PES)
+      brokenTest = newTestMpiTestCase('brokenOnProcess2', brokenOnProcess2, numProcesses = TOO_MANY_PES)
       call brokenTest%run(reslt, this%context)
 
       if (this%context%isRootProcess()) then
@@ -257,7 +257,7 @@ contains
    end subroutine testTooFewProcs
 
    recursive subroutine runMethod(this)
-      class(Test_MpiTestCase), intent(inOut) :: this
+      class(TestMpiTestCase), intent(inOut) :: this
       call this%testMethod()
    end subroutine runMethod
 
@@ -273,9 +273,9 @@ contains
    end subroutine wasRun
 
    subroutine delete_(this)
-      type (Test_MpiTestCase), intent(inOut) :: this
+      type (TestMpiTestCase), intent(inOut) :: this
       nullify(this%testMethod)
    end subroutine delete_
 
-end module Test_MpiTestCase_mod
+end module Test_MpiTestCase
 

--- a/tests/mpi-tests/parallelRemoteProgram.F90
+++ b/tests/mpi-tests/parallelRemoteProgram.F90
@@ -5,7 +5,7 @@ program main
    use FUnit, only: TestSuite
    use FUnit, only: ParallelContext
    use FUnit, only: SerialContext, newSerialContext
-   use robustTestSuite_mod
+   use robustTestSuite
    implicit none
 
 !!$   call initialize(useMPI=.false.)

--- a/tests/mpi-tests/parallel_tests.F90
+++ b/tests/mpi-tests/parallel_tests.F90
@@ -22,10 +22,10 @@ contains
       use pfunit, only: MpiContext
       use pfunit, only: ParallelContext
 
-      use Test_MpiContext_mod, only: MpiContextSuite => suite
-      use Test_MpiException_mod, only: MpiExceptionSuite => suite
-      use Test_MpiTestCase_mod, only: MpiTestCaseSuite => suite
-      use Test_MpiParameterizedTestCase_mod, only: MpiParameterizedTestCaseSuite => suite
+      use Test_MpiContext, only: MpiContextSuite => suite
+      use Test_MpiException, only: MpiExceptionSuite => suite
+      use Test_MpiTestCase, only: MpiTestCaseSuite => suite
+      use Test_MpiParameterizedTestCase, only: MpiParameterizedTestCaseSuite => suite
       use iso_fortran_env, only: OUTPUT_UNIT
 
       type (TestSuite) :: allTests

--- a/tests/mpi-tests/testSuites.inc
+++ b/tests/mpi-tests/testSuites.inc
@@ -1,1 +1,1 @@
-   ADD_TEST_SUITE(Test_MPI_stub_mod_suite)
+   ADD_TEST_SUITE(Test_MPI_stub_suite)


### PR DESCRIPTION
There are two many inconsistent conventions for module suffixes across
projects.   Note - We do not use suffixes for other program units.