### PR TITLE
Improved use of find_package(MPI).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ before_script:
    - mkdir build
    - cd build
    - cmake --version
-   - cmake .. -DCMAKE_Fortran_COMPILER=${FC} -DCMAKE_INSTALL_PREFIX=${HOME}/Software/pFUnit -DMPI=${USE_MPI}
+   - cmake .. -DCMAKE_Fortran_COMPILER=${FC} -DCMAKE_INSTALL_PREFIX=${HOME}/Software/pFUnit
 
 script:
    # Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,22 @@
 # DOCUMENTATION:
 # ------------------------------------------------------------------------ #
 #
-# Command line options:
-#     USE_MPI=YES                             ! defaults to NO
-#     USE_OPENMP=YES                          ! defaults to NO
-#     USE_ROBUST=YES                          ! defaults to NO
-#     MAX_ASSERT_RANK=<max array rank for generated code>
-#                                             ! defaults to 5 or
+# Package specific command line options:
+#
+#     -DSKIP_MPI=YES                   Skip build of MPI features even if
+#                                      MPI is found.
+#
+#     -DMAX_ASSERT_RANK=<max_rank>     Limit overloaded interfaces to
+#                                      rank <= max_rank
+#
+#     -SKIP_OPENMP=YES                 Skip build of OpenMP features even if
+#                                      OpenMP is found
+#
+#     -SKIP_HAMCREST=YES               Skip build of Hamcrest features
+#
 #
 # Usage:
-#   cmake -DMPI=YES <path-to-source>
+#   cmake <path-to-source> [<options>]
 #
 # ------------------------------------------------------------------------ #
 cmake_minimum_required(VERSION 3.8.0)
@@ -50,27 +57,11 @@ if(NOT found)
 endif()
 
 
-if (MPI)
-  find_package(MPI REQUIRED)
-  if(MPI_Fortran_FOUND)
-    if(MPI_FORTRAN_COMPILE_FLAGS)
-      set(CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS} ${MPI_Fortran_COMPILE_FLAGS})
-    endif()
-    if(MPI_Fortran_INCLUDE_PATH)
-      include_directories(${MPI_Fortran_INCLUDE_PATH})
-    endif()
-    if(MPI_Fortran_LIBRARIES)
-      set(CMAKE_Fortran_LIBRARIES "${CMAKE_Fortran_LIBRARIES} ${MPI_Fortran_LIBRARIES}")
-    endif()
-    if(MPI_Fortran_LINK_FLAGS)
-      set(CMAKE_Fortran_LINK_FLAGS "${CMAKE_Fortran_LINK_FLAGS} ${MPI_Fortran_LINK_FLAGS}")
-    endif()
-  endif()
-  add_definitions(-DUSE_MPI)
-  if (MPIEXEC MATCHES ".*openmpi*")
-    list(APPEND MPIEXEC_PREFLAGS "--oversubscribe")
-  endif()
-  message( STATUS "MPI enabled")
+if (NOT SKIP_MPI)
+  find_package (MPI QUIET)
+  if (MPI_Fortran_FOUND)
+    message (STATUS "MPI enabled")
+  endif()    
 endif()
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory (core)
 add_subdirectory (hamcrest)
 
-if (MPI)
+if (MPI_Fortran_FOUND)
   add_subdirectory (mpi)
 endif ()
 

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -16,7 +16,8 @@ set (mpi_srcs
 
   )
 add_library(pfunit STATIC ${srcs} ${mpi_srcs})
-target_link_libraries (pfunit PUBLIC funit)
+target_link_libraries (pfunit PUBLIC funit ${CMAKE_Fortran_LIBRARIES})
+target_include_directories(pfunit PUBLIC ${MPI_Fortran_INCLUDE_PATH})
 set_target_properties (pfunit PROPERTIES Fortran_MODULE_DIRECTORY ${PFUNIT_BINARY_DIR}/mod)
 
 if (mismatch)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(core-tests)
 add_subdirectory(hamcrest-tests)
 
-if (MPI)
+if (MPI_Fortran_FOUND)
   add_subdirectory(mpi-tests)
 endif ()

--- a/tests/mpi-tests/CMakeLists.txt
+++ b/tests/mpi-tests/CMakeLists.txt
@@ -53,6 +53,9 @@ target_link_libraries(new_ptests.x new_ptests)
 
 # Fix for openmpi 1.8.8 which complains about forking due to selftests of
 # robust runner.
+if (MPIEXEC MATCHES ".*openmpi*")
+  list(APPEND MPIEXEC_PREFLAGS "--oversubscribe")
+endif()
 if (MPIEXEC MATCHES ".*openmpi/1.8.8/.*")
   set (MPIEXEC_PREFLAGS ${MPIEXEC_PREFLAGS} --mca mpi_warn_on_fork 0)
 endif ()


### PR DESCRIPTION
Build now uses find_package() and builds with MPI if installation is
found.  -DSKIP_MPI=YES can be used to override if MPI is _not_
desired.

Note that this is _NOT_ backward compatible with pFUnit 3.x.