### PR TITLE
Now use single macro for preprocessing pfunit tests sources.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ set(OPENMP OFF CACHE BOOL "Build with OpenMP support.")
 set(MAX_ASSERT_RANK 5 CACHE STRING "Maximum array rank for generated code.")
 
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PFUNIT_SOURCE_DIR}/cmake" "${PFUNIT_SOURCE_DIR}/include")
 include(CheckCompilerCapabilities)
 
 #-----------------------------------

--- a/include/PreprocessMacro.cmake
+++ b/include/PreprocessMacro.cmake
@@ -1,43 +1,46 @@
-set (PFUNIT_PREPROCESSOR python $ENV{PFUNIT}/bin/pFUnitParser.py)
-set (PFUNIT_SUFFIX "\\.pfunit")
+set (PFUNIT_PREPROCESSOR python ${PFUNIT_SOURCE_DIR}/bin/pFUnitParser.py)
+
 # - Pass a list of files through the pFUnit macro processor
 #
-# ADD_PFUNIT_SOURCES( OUTVAR source1 ... sourceN )
+# ADD_PFUNIT_SOURCES( out_var source1 ... sourceN )
 #
-#    OUTVAR    A list containing all the output file names, suitable
+#    out_var    A list containing all the output file names, suitable
 #                    to be passed to add_executable or add_library.
 #
-# If the source files have a .m4 suffix it is stripped from the output
+# The suffix of the source files are stripped from the output
 # file name. The output files are placed in the same relative location
 # to CMAKE_CURRENT_BINARY_DIR as they are to CMAKE_CURRENT_SOURCE_DIR.
 #
 # Example:
 #    add_pfunit_sources( SRCS src/test1.cxx.pfunit src/test2.cxx.pfunit )
 #    add_executable( test ${SRCS} )
-function( ADD_PFUNIT_SOURCES OUTVAR )
-     set( outfiles )
-     foreach( f ${ARGN} )
+function( ADD_PFUNIT_SOURCES out_var )
+     set( out_files )
+     foreach( file ${ARGN} )
          # first we might need to make the input file absolute
-         get_filename_component( f "${f}" ABSOLUTE )
+         get_filename_component( abs_file "${file}" ABSOLUTE )
          # get the relative path of the file to the current source dir
-         file( RELATIVE_PATH baseFile "${CMAKE_CURRENT_SOURCE_DIR}" "${f}" )
-         # strip the .pfunit off the end if present
-         string( REGEX REPLACE "${PFUNIT_SUFFIX}" ".F90" outFile "${CMAKE_CURRENT_BINARY_DIR}/${baseFile}" )
+         file( RELATIVE_PATH rel_file "${CMAKE_CURRENT_SOURCE_DIR}" "${abs_file}" )
+
+         # replace the extension with .F90 to determine the output file name
+	 get_filename_component (extension ${file} EXT)
+         string( REGEX REPLACE "${extension}" ".F90" out_file "${CMAKE_CURRENT_BINARY_DIR}/${rel_file}" )
          # append the output file to the list of outputs
-         list( APPEND outfiles "${outFile}" )
+         list( APPEND out_files "${out_file}" )
          # create the output directory if it doesn't exist
-         get_filename_component( dir "${outFile}" PATH )
+         get_filename_component( dir "${out_file}" PATH )
          if( NOT IS_DIRECTORY "${dir}" )
              file( MAKE_DIRECTORY "${dir}" )
          endif( NOT IS_DIRECTORY "${dir}" )
          # now add the custom command to generate the output file
-         add_custom_command( OUTPUT "${outFile}"
-             COMMAND ${PFUNIT_PREPROCESSOR} "${f}" "${outFile}"
-             DEPENDS "${f}"
+         add_custom_command( OUTPUT "${out_file}"
+             COMMAND ${PFUNIT_PREPROCESSOR} "${abs_file}" "${out_file}"
+             DEPENDS "${abs_file}"
+	     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
              )
-     endforeach( f )
+     endforeach ( )
      # set the output list in the calling scope
-     set( ${OUTVAR} ${outfiles} PARENT_SCOPE )
+     set( ${out_var} ${${out_var}} ${out_files} PARENT_SCOPE )
 endfunction( ADD_PFUNIT_SOURCES )
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+include (PreprocessMacro)
+
 add_subdirectory(core-tests)
 add_subdirectory(hamcrest-tests)
 

--- a/tests/core-tests/CMakeLists.txt
+++ b/tests/core-tests/CMakeLists.txt
@@ -8,12 +8,16 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 configure_file( junit-4.xsd junit-4.xsd COPYONLY )
 
-set(OTHER_SOURCES
-  MakeNaN.F90 MakeInf.F90 MockListener.F90
-  BrokenTestCase.F90 BrokenSetUpCase.F90
-  FixtureTestCase.F90)
+set (other_sources
+  MakeNaN.F90
+  MakeInf.F90
+  MockListener.F90
+  BrokenTestCase.F90
+  BrokenSetUpCase.F90
+  FixtureTestCase.F90
+  )
 
-add_library(other_shared ${OTHER_SOURCES})
+add_library(other_shared ${other_sources})
 target_link_libraries(other_shared funit)
 
 set(pf_tests
@@ -37,22 +41,21 @@ set(pf_tests
   Test_NameFilter.pf
   Test_RegularExpression.pf)
 
-set(new_tests)
-foreach (file ${pf_tests})
-  get_filename_component(basename ${file} NAME_WE)
-  set(f90_src ${basename}.F90)
-  add_custom_command (
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${f90_src}
-    COMMAND python
-    ARGS ${PFUNIT_SOURCE_DIR}/bin/pFUnitParser.py ${CMAKE_CURRENT_SOURCE_DIR}/${file} ${f90_src}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${file}
-    )
-  list(APPEND new_tests ${f90_src})
-endforeach()
-  
+set (new_test_srcs)
+#foreach (file ${pf_tests})
+#  get_filename_component(basename ${file} NAME_WE)
+#  set(f90_src ${basename}.F90)
+#  add_custom_command (
+#    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${f90_src}
+#    COMMAND python
+#    ARGS ${PFUNIT_SOURCE_DIR}/bin/pFUnitParser.py ${CMAKE_CURRENT_SOURCE_DIR}/${file} ${f90_src}
+#    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+#    DEPENDS ${file}
+#    )
+#  list(APPEND new_tests ${f90_src})
+#endforeach()
 
-set(SERIAL_TEST_SRCS
+set (test_srcs
   Test_Assert.F90
   Test_AssertBasic.F90
   SimpleTestCase.F90
@@ -70,23 +73,25 @@ set(SERIAL_TEST_SRCS
   Test_TestSuite.F90
   )
 
-  list (APPEND SERIAL_TEST_SRCS
-    Test_UnixProcess.F90
-    Test_RobustRunner.F90
-    robustTestSuite.F90
-    )
+list (APPEND test_srcs
+  Test_UnixProcess.F90
+  Test_RobustRunner.F90
+  robustTestSuite.F90
+  )
 
-list(APPEND SERIAL_TEST_SRCS Test_BasicOpenMP.F90)
+list(APPEND test_srcs Test_BasicOpenMP.F90)
 
-add_library(funit_tests EXCLUDE_FROM_ALL STATIC ${SERIAL_TEST_SRCS})
+
+add_library (funit_tests EXCLUDE_FROM_ALL STATIC ${test_srcs})
 target_link_libraries(funit_tests other_shared)
 
-add_library(new_stests EXCLUDE_FROM_ALL ${new_tests})
+add_pfunit_sources (new_test_srcs ${pf_tests})
+
+add_library(new_stests EXCLUDE_FROM_ALL ${new_test_srcs})
 target_link_libraries(new_stests other_shared)
 add_executable (new_tests.x EXCLUDE_FROM_ALL ${PFUNIT_SOURCE_DIR}/include/driver.F90)
 set_source_files_properties(${PFUNIT_SOURCE_DIR}/include/driver.F90 PROPERTIES COMPILE_DEFINITIONS _TEST_SUITES="testSuites.inc")
 target_link_libraries(new_tests.x new_stests funit)
-
 
 
 add_executable (funit_tests.x EXCLUDE_FROM_ALL serial_tests.F90)
@@ -95,11 +100,6 @@ target_link_libraries(funit_tests.x funit_tests funit)
 set(REMOTE_EXE remote.x)
 add_executable (${REMOTE_EXE} EXCLUDE_FROM_ALL serialRemoteProgram.F90)
 target_link_libraries(${REMOTE_EXE} funit funit_tests)
-#  if (MPI)
-#    target_link_libraries(${REMOTE_EXE} ${MPI_Fortran_LIBRARIES} )
-#  endif()
-# Note for pfunit_2.1.0:  following line has no counterpart in
-#  "master" branch, i.e. > pfunit_2.1.0...
 add_dependencies(tests ${REMOTE_EXE})
 
 

--- a/tests/hamcrest-tests/CMakeLists.txt
+++ b/tests/hamcrest-tests/CMakeLists.txt
@@ -21,22 +21,12 @@ set(pf_tests
 )
 
 
-set(new_tests)
-foreach (file ${pf_tests})
-  get_filename_component(basename ${file} NAME_WE)
-  set(f90_src ${basename}.F90)
-  add_custom_command (
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${f90_src}
-    COMMAND python
-    ARGS ${CMAKE_SOURCE_DIR}/bin/pFUnitParser.py ${CMAKE_CURRENT_SOURCE_DIR}/${file} ${f90_src}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${file}
-    )
-  list(APPEND new_tests ${f90_src})
-endforeach()
-  
-add_library(fhamcrest_tests EXCLUDE_FROM_ALL ${new_tests})
+set(test_srcs)
+add_pfunit_sources (test_srcs ${pf_tests})
+
+add_library(fhamcrest_tests EXCLUDE_FROM_ALL ${test_srcs})
 target_link_libraries(fhamcrest_tests hamcrest)
+
 configure_file(${CMAKE_SOURCE_DIR}/include/driver.F90 driver.F90)
 add_executable (fhamcrest_tests.x EXCLUDE_FROM_ALL driver.F90)
 set_source_files_properties(driver.F90 PROPERTIES COMPILE_DEFINITIONS _TEST_SUITES="testSuites.inc")

--- a/tests/mpi-tests/CMakeLists.txt
+++ b/tests/mpi-tests/CMakeLists.txt
@@ -6,50 +6,34 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 
 
-set (PARALLEL_TEST_SRCS)
-list(APPEND PARALLEL_TEST_SRCS Test_MpiContext.F90)
-list(APPEND PARALLEL_TEST_SRCS Test_MpiException.F90)
-list(APPEND PARALLEL_TEST_SRCS Test_MpiTestCase.F90)
-list(APPEND PARALLEL_TEST_SRCS Test_MpiParameterizedTestCase.F90)
+set (test_srcs
+  Test_MpiContext.F90
+  Test_MpiException.F90
+  Test_MpiTestCase.F90
+  Test_MpiParameterizedTestCase.F90
+  )
 
 set (pf_tests
   Test_MPI_stub.pf
   )
 
-set(new_tests)
-foreach (file ${pf_tests})
-  get_filename_component(basename ${file} NAME_WE)
-  set(f90_src ${basename}.F90)
-  add_custom_command (
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${f90_src}
-    COMMAND python
-    ARGS ${CMAKE_SOURCE_DIR}/bin/pFUnitParser.py ${CMAKE_CURRENT_SOURCE_DIR}/${file} ${f90_src}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${file}
-    )
-  list(APPEND new_tests ${f90_src})
-endforeach()
 
+add_library (pfunittests EXCLUDE_FROM_ALL STATIC ${test_srcs})
+target_link_libraries (pfunittests pfunit funit)
 
-
-add_library(pfunittests EXCLUDE_FROM_ALL STATIC ${PARALLEL_TEST_SRCS})
-target_link_libraries(pfunittests pfunit funit)
-
-configure_file(${CMAKE_SOURCE_DIR}/include/driver.F90 driver.F90)
-set_source_files_properties(driver.F90 PROPERTIES COMPILE_DEFINITIONS _TEST_SUITES="testSuites.inc")
-set_source_files_properties(driver.F90 PROPERTIES OBJECT_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/testSuites.inc)
+configure_file (${CMAKE_SOURCE_DIR}/include/driver.F90 driver.F90)
+set_source_files_properties (driver.F90 PROPERTIES COMPILE_DEFINITIONS _TEST_SUITES="testSuites.inc")
+set_source_files_properties (driver.F90 PROPERTIES OBJECT_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/testSuites.inc)
 
 add_executable (parallel_tests.x EXCLUDE_FROM_ALL parallel_tests.F90)
-target_link_libraries(parallel_tests.x pfunittests pfunit funit ${MPI_Fortran_LIBRARIES})
+target_link_libraries (parallel_tests.x pfunittests pfunit funit ${MPI_Fortran_LIBRARIES})
 
+add_pfunit_sources (new_tests ${pf_tests})
 add_library(new_ptests EXCLUDE_FROM_ALL ${new_tests})
 target_link_libraries(new_ptests pfunit funit ${MPI_Fortran_LIBRARIES})
 add_executable (new_ptests.x EXCLUDE_FROM_ALL driver.F90)
 set_source_files_properties(${CMAKE_SOURCE_DIR}/include/driver.F90 PROPERTIES COMPILE_DEFINITIONS _TEST_SUITES="testSuites.inc")
 target_link_libraries(new_ptests.x new_ptests)
-
-#set(REMOTE_EXE remote.x)
-#add_executable (${REMOTE_EXE} parallelRemoteProgram.F90)
 
 # Fix for openmpi 1.8.8 which complains about forking due to selftests of
 # robust runner.


### PR DESCRIPTION
Note that this macro is inconsistent with the one in the cmake config
file for external projects and additional thought is needed.