### PR TITLE
CMake support for projects that use CMake.

### DIFF
--- a/bin/funit/CMakeLists.txt
+++ b/bin/funit/CMakeLists.txt
@@ -1,2 +1,2 @@
-install(FILES pFUnitParser.py parseDirectiveArgs.py DESTINATION ${dest}/bin/funit)
+install(FILES __init__.py pFUnitParser.py parseDirectiveArgs.py DESTINATION ${dest}/bin/funit)
 

--- a/cmake/PFUNITConfig.cmake.in
+++ b/cmake/PFUNITConfig.cmake.in
@@ -9,9 +9,12 @@
 set (prefix ${CMAKE_CURRENT_LIST_DIR}/../..)
 include ("${prefix}/PFUNIT-@PFUNIT_VERSION_MAJOR@.@PFUNIT_VERSION_MINOR@/cmake/PFUNIT.cmake")
 
-find_package (PythonInterp
-    REQUIRED
-    )
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../include")
+
+find_package (PythonInterp REQUIRED)
+find_package (GFTL REQUIRED)
+find_package (GFTL_SHARED REQUIRED)
+find_package (FARGPARSE REQUIRED)
 
 #set (PFUNIT_FOUND TRUE)
 #set (PFUNIT_VERSION "@PROJECT_VERSION@")
@@ -20,9 +23,9 @@ find_package (PythonInterp
 #find_library (PFUNIT_LIBRARIES pfunit
 #    PATHS ${CMAKE_CURRENT_LIST_DIR}/lib
 #    NO_DEFAULT_PATH)
-set (PFUNIT_PARSER "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/bin/funitproc")
-set (PFUNIT_DRIVER "${CMAKE_CURRENT_LIST_DIR}/include/driver.F90")
-set (PFUNIT_TESTUTILS "${CMAKE_CURRENT_LIST_DIR}/include/TestUtil.F90")
+set (PFUNIT_PARSER "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../bin/funitproc")
+set (PFUNIT_DRIVER "${CMAKE_CURRENT_LIST_DIR}/../include/driver.F90")
+set (PFUNIT_TESTUTILS "${CMAKE_CURRENT_LIST_DIR}/../include/TestUtil.F90")
 
 
 
@@ -36,7 +39,7 @@ set (PFUNIT_TESTUTILS "${CMAKE_CURRENT_LIST_DIR}/include/TestUtil.F90")
 # Arguments    : - test_package_name: Name of the test package
 #                - test_sources     : List of pf-files to be compiled
 #                - extra_sources    : List of extra Fortran source code used for testing (if none, input empty string "")
-#                - extra_sources    : List of extra C/C++ source code used for testing (if none, input empty string "")
+#                - extra_sources_c    : List of extra C/C++ source code used for testing (if none, input empty string "")
 #
 # Example usage: enable_testing()
 #                set (TEST_SOURCES

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -39,7 +39,7 @@ file_compile_configuration()
 # Perform the install.
 #
 install(
-  FILES driver.F90 PreprocessMacro.cmake
+  FILES driver.F90 add_pfunit_sources.cmake add_pfunit_ctest.cmake
   DESTINATION ${dest}/include
   )
 

--- a/include/add_pfunit_ctest.cmake
+++ b/include/add_pfunit_ctest.cmake
@@ -1,0 +1,102 @@
+# Function     : add_pfunit_ctest 
+#
+# Description  : Helper function for compiling and adding pFUnit tests to the CTest testing framework. Any libraries needed
+#                in testing should be linked to manually.
+#
+# Arguments    : - test_name: Name of the test package
+#
+# Example usage: enable_testing()
+#                add_pfunit_test (myTests
+#                   TEST_SOURCES testMyLib.pf
+#                   OTHER_SOURCES other.F90 yet_another.c
+#                   REGISTRY test_suites.inc             
+#                   LINK_LIBRARIES mylib
+#                   NPES 5
+#                   )
+# Note: If REGISTRY is not provided, then a default testSuites.inc will be created based on the PFUNIT_SOURCES file names.
+#       It is assumed that the module name is the same as the file basename.  
+#       For example, the file testSomething.pf should contain the module testSomething.
+#                
+#
+# Compile the tests:   make myTests
+# Run the tests with CTest: ctest -R myTests --verbose
+#
+
+include (add_pfunit_sources)
+
+function (add_pfunit_ctest test_package_name)
+  set (oneValueArgs REGISTRY NPES)
+  set (multiValueArgs TEST_SOURCES OTHER_SOURCES LINK_LIBRARIES)
+  cmake_parse_arguments (PF_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  set (test_sources_f90)
+  set (test_suites_inc "")
+  foreach (pf_file ${PF_TEST_TEST_SOURCES})
+
+    get_filename_component (basename ${pf_file} NAME_WE)
+    set (f90_file "${basename}.F90")
+    list (APPEND test_sources_f90 ${f90_file})
+    set (test_suites_inc "${test_suites_inc}ADD_TEST_SUITE(${basename}_suite)\n")
+    add_pfunit_sources(test_sources_f90 ${PF_TEST_TEST_SOURCES})
+
+  endforeach()
+
+  add_executable (${test_package_name}
+    ${test_sources_f90}
+    ${PF_TEST_OTHER_SOURCES}
+    ${PFUNIT_DRIVER}
+    )
+
+  if (PF_TEST_REGISTRY)
+    set (test_suite_inc_file ${PF_TEST_REGISTRY})
+  else ()
+    set (should_write_inc_file True)
+    set (test_suite_inc_file "${CMAKE_CURRENT_BINARY_DIR}/${test_package_name}.inc")
+    # Check if .inc file already has been generated. If so, only write new
+    # file if contents has changed. This avoid tests recompiling after reconfiguring cmake.
+    if (EXISTS ${test_suite_inc_file})
+      file (READ ${test_suite_inc_file} existing_file)
+      if (${existing_file} STREQUAL ${test_suites_inc})
+	set (should_write_inc_file False)
+      endif (${existing_file} STREQUAL ${test_suites_inc})
+    endif ()
+
+    if (${should_write_inc_file})
+      file (WRITE ${test_suite_inc_file} ${test_suites_inc})
+    endif (${should_write_inc_file})
+  endif ()
+
+  target_compile_definitions (${test_package_name} PRIVATE -D_TEST_SUITES="${test_suite_inc_file}")
+  target_include_directories (${test_package_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  
+  if (PF_TEST_LINK_LIBRARIES)
+    target_link_libraries (${test_package_name} ${PF_TEST_LINK_LIBRARIES})
+  endif ()
+  target_link_libraries (${test_package_name} funit)
+  if (PF_TEST_NPES)
+    target_link_libraries (${test_package_name} pfunit)
+  endif ()
+
+  #################################################
+  # Define test in CTest system                   #
+ #################################################
+ if (PF_TEST_NPES)
+   if (MPIEXEC MATCHES ".*openmpi*")
+     list(APPEND MPIEXEC_PREFLAGS "--oversubscribe")
+   endif()
+   add_test (NAME ${test_package_name}
+     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+     COMMAND mpirun ${MPIEXEC_PREFLAGS} -np ${PF_TEST_NPES} ${test_package_name}
+     )
+ else()
+   add_test (NAME ${test_package_name}
+     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+     COMMAND ${test_package_name}
+     )
+ endif()
+
+ set_property (TEST ${test_package_name}
+   PROPERTY FAIL_REGULAR_EXPRESSION "Encountered 1 or more failures/errors during testing"
+   )
+
+endfunction()

--- a/include/add_pfunit_sources.cmake
+++ b/include/add_pfunit_sources.cmake
@@ -1,4 +1,4 @@
-set (PFUNIT_PREPROCESSOR python ${PFUNIT_SOURCE_DIR}/bin/funitproc)
+#set (PFUNIT_PREPROCESSOR python ${PFUNIT_SOURCE_DIR}/bin/funitproc)
 
 # - Pass a list of files through the pFUnit macro processor
 #
@@ -34,7 +34,7 @@ function( ADD_PFUNIT_SOURCES out_var )
          endif( NOT IS_DIRECTORY "${dir}" )
          # now add the custom command to generate the output file
          add_custom_command( OUTPUT "${out_file}"
-             COMMAND ${PFUNIT_PREPROCESSOR} "${abs_file}" "${out_file}"
+             COMMAND ${PFUNIT_PARSER} "${abs_file}" "${out_file}"
              DEPENDS "${abs_file}"
 	     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
              )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,9 @@
-include (PreprocessMacro)
+find_package (PythonInterp REQUIRED)
+set (PFUNIT_PARSER "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../bin/funitproc")
+set (PFUNIT_DRIVER "${CMAKE_CURRENT_LIST_DIR}/../include/driver.F90")
+include (add_pfunit_sources)
+include (add_pfunit_ctest)
+
 
 add_subdirectory(funit-core)
 add_subdirectory(fhamcrest)

--- a/tests/funit-core/CMakeLists.txt
+++ b/tests/funit-core/CMakeLists.txt
@@ -44,19 +44,6 @@ set(pf_tests
   Test_RegularExpression.pf)
 
 set (new_test_srcs)
-#foreach (file ${pf_tests})
-#  get_filename_component(basename ${file} NAME_WE)
-#  set(f90_src ${basename}.F90)
-#  add_custom_command (
-#    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${f90_src}
-#    COMMAND python
-#    ARGS ${PFUNIT_SOURCE_DIR}/bin/funitproc ${CMAKE_CURRENT_SOURCE_DIR}/${file} ${f90_src}
-#    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-#    DEPENDS ${file}
-#    )
-#  list(APPEND new_tests ${f90_src})
-#endforeach()
-
 set (test_srcs
   Test_Assert.F90
   Test_AssertBasic.F90
@@ -86,32 +73,38 @@ list(APPEND test_srcs Test_BasicOpenMP.F90)
 add_library (funit_tests EXCLUDE_FROM_ALL STATIC ${test_srcs})
 target_link_libraries(funit_tests other_shared)
 
-add_pfunit_sources (new_test_srcs ${pf_tests})
+#add_pfunit_sources (new_test_srcs ${pf_tests})
 
-add_library(new_stests EXCLUDE_FROM_ALL ${new_test_srcs})
-target_link_libraries(new_stests other_shared)
-add_executable (new_tests.x EXCLUDE_FROM_ALL ${PFUNIT_SOURCE_DIR}/include/driver.F90)
-set_source_files_properties(${PFUNIT_SOURCE_DIR}/include/driver.F90 PROPERTIES COMPILE_DEFINITIONS _TEST_SUITES="testSuites.inc")
-target_link_libraries(new_tests.x new_stests funit)
+#add_library(new_stests EXCLUDE_FROM_ALL ${new_test_srcs})
+#target_link_libraries(new_stests other_shared)
+#add_executable (new_tests.x EXCLUDE_FROM_ALL ${PFUNIT_SOURCE_DIR}/include/driver.F90)
+#set_source_files_properties(${PFUNIT_SOURCE_DIR}/include/driver.F90 PROPERTIES COMPILE_DEFINITIONS _TEST_SUITES="testSuites.inc")
+#target_link_libraries(new_tests.x new_stests funit)
 
 
 add_executable (funit_tests.x EXCLUDE_FROM_ALL serial_tests.F90)
 target_link_libraries(funit_tests.x funit_tests funit)
 
-set(REMOTE_EXE remote.x)
+set (REMOTE_EXE remote.x)
 add_executable (${REMOTE_EXE} EXCLUDE_FROM_ALL serialRemoteProgram.F90)
 target_link_libraries(${REMOTE_EXE} funit funit_tests)
 add_dependencies(tests ${REMOTE_EXE})
 
 
-add_test(NAME new_tests
-  COMMAND new_tests.x
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  )
+add_pfunit_ctest (new_tests.x
+  TEST_SOURCES ${pf_tests}
+  LINK_LIBRARIES other_shared
+  REGISTRY testSuites.inc
+)
+#add_test(NAME new_tests
+#  COMMAND new_tests.x
+#  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+#  )
+
 add_dependencies(tests new_tests.x)
-set_property (TEST new_tests
-    PROPERTY FAIL_REGULAR_EXPRESSION "Encountered 1 or more failures/errors during testing"
-    )
+#set_property (TEST new_tests.x
+#    PROPERTY FAIL_REGULAR_EXPRESSION "Encountered 1 or more failures/errors during testing"
+#    )
 
 add_test(NAME old_tests
   COMMAND funit_tests.x


### PR DESCRIPTION
Created a function add_pfunit_ctest() which takes a number of keyword
arguments and attempts to build an executable and ctest test from a
collection of test sources and additional sources.

Also fixed a few minor issues with the install step that were exposed
when attempting to exercise this new capability.

Note: this version should be considered preliminary.  More options are
needed, and not all existing options have been tested (e.g. MPI).