### PR TITLE
Fixes #108.  CMake options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,16 +4,18 @@
 #
 # Package specific command line options:
 #
-#     -DSKIP_MPI=YES                   Skip build of MPI features even if
-#                                      MPI is found.
-#
 #     -DMAX_ASSERT_RANK=<max_rank>     Limit overloaded interfaces to
 #                                      rank <= max_rank
+#
+#     -DSKIP_MPI=YES                   Skip build of MPI features even if
+#                                      MPI is found.
 #
 #     -SKIP_OPENMP=YES                 Skip build of OpenMP features even if
 #                                      OpenMP is found
 #
-#     -SKIP_HAMCREST=YES               Skip build of Hamcrest features
+#     -SKIP_FHAMCREST=YES              Skip build of Hamcrest features
+#
+#     -SKIP_ROBUST=YES                 Skip build of RobustRunner
 #
 #
 # Usage:
@@ -37,12 +39,15 @@ enable_testing()
 # unless the user explicitly sets CMAKE_INSTALL_PREFIX in the cache.
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set (CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/installed" CACHE PATH "default install path" FORCE )
+    message(STATUS "*** Setting default install prefix to ${CMAKE_INSTALL_PREFIX}.")
+    message(STATUS "*** Override with -DCMAKE_INSTALL_PREFIX=<path>.")
 endif()
 
-OPTION(USE_OPENMP "Use OPENMP for parallel runs" NO)
-set(MPI OFF CACHE BOOL "Build with MPI support.")
-set(OPENMP OFF CACHE BOOL "Build with OpenMP support.")
-set(MAX_ASSERT_RANK 5 CACHE STRING "Maximum array rank for generated code.")
+set (MAX_ASSERT_RANK 5 CACHE STRING "Maximum array rank for generated code.")
+set (SKIP_MPI NO CACHE BOOL "Skip building MPI support.")
+set (SKIP_OPENMP NO CACHE BOOL "Skip OpenMP compiler options.")
+set (SKIP_FHAMCREST NO CACHE BOOL "Skip building fHamcrest support")
+set (SKIP_ESMF YES CACHE BOOL "Skip building ESMF support")
 
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PFUNIT_SOURCE_DIR}/cmake" "${PFUNIT_SOURCE_DIR}/include")
@@ -61,6 +66,8 @@ if (NOT SKIP_MPI)
   find_package (MPI QUIET)
   if (MPI_Fortran_FOUND)
     message (STATUS "MPI enabled")
+  else ()
+    message (STATUS "MPI not found; building without MPI")
   endif()    
 endif()
 
@@ -68,28 +75,23 @@ endif()
 
 
 # Fortran OpenMP support is not yet integrated into the CMake distribution.
-if (USE_OPENMP)
-  find_package(OpenMP_Fortran REQUIRED)
-  if(OPENMP_FORTRAN_FOUND)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_Fortran_FLAGS}")
-    set(CMAKE_Fortran_LINKER_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_Fortran_FLAGS}")
-    message( STATUS "OpenMP enabled")
+if (NOT SKIP_OPENMP)
+  find_package(OpenMP QUIET)
+  if (OpenMP_Fortran_FOUND)
+    message (STATUS "OpenMP enabled")
+  else (OpenMP_Fortran_FOUND)
+    message (STATUS "OpenMP not found - skipping openmp support.")
   endif()
 endif()
 
 
-# A bit ugly, but main use case install ESMF in a non-canonical manner.
-set (ESMF OFF CACHE BOOL "Build with ESMF support.")
-if (ESMF)
+# ESMF options are still under development ...
+if (NOT SKIP_ESMF)
   set (ESMF_LIBRARIES "" CACHE PATH "Path to ESMF libraries")
   set (ESMF_INCLUDE "" CACHE PATH "Path to ESMF include dir")
   set (NETCDF_INCLUDE "" CACHE PATH "Path to NETCD include dir")
+  set (ESMF_FOUND)
 endif ()
-
-
-if (USE_ROBUST)
-    add_definitions(-DUSE_ROBUST)
-endif()
 
 
 set(CMAKE_SHARED_LIBRARY_LINK_Fortran_FLAGS "")
@@ -100,10 +102,8 @@ set (dest "PFUNIT-${PFUNIT_VERSION_MAJOR}.${PFUNIT_VERSION_MINOR}")
 
 # Code to silence warnings from RANLIB on OSX
 # From https://stackoverflow.com/questions/4929255/building-static-libraries-on-mac-using-cmake-and-gcc
-SET(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
-SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
-SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
-SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+SET(CMAKE_Fortran_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+SET(CMAKE_Fortran_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 
 add_subdirectory (extern)
 add_subdirectory (src)

--- a/src/funit/CMakeLists.txt
+++ b/src/funit/CMakeLists.txt
@@ -25,15 +25,20 @@ endif ()
 # funit is the "real" library.
 add_subdirectory (core)
 add_subdirectory (asserts)
-add_subdirectory (fhamcrest)
 add_dependencies (funit funit-core)
 add_dependencies (funit asserts)
-add_dependencies (funit fhamcrest)
+if (NOT SKIP_FHAMCREST)
+  add_subdirectory (fhamcrest)
+  add_dependencies (funit fhamcrest)
+endif ()
 
 target_sources(funit PRIVATE FUnit.F90 funit_main.F90)
 target_sources(funit PRIVATE $<TARGET_OBJECTS:funit-core>)
 target_sources(funit PRIVATE $<TARGET_OBJECTS:asserts>)
 target_sources(funit PRIVATE $<TARGET_OBJECTS:fhamcrest>)
+if (OpenMP_Fortran_FOUND)
+  target_link_libraries (funit PUBLIC OpenMP::OpenMP_Fortran)
+endif ()
 
 
 install (DIRECTORY  ${CMAKE_CURRENT_BINARY_DIR}/mod/ DESTINATION ${dest}/include)

--- a/src/funit/core/CMakeLists.txt
+++ b/src/funit/core/CMakeLists.txt
@@ -69,21 +69,27 @@ set(srcs
   )
 
 # Support for RobustRunner
-list (APPEND srcs
-  Posix.F90
-  File.F90
-  UnixPipeInterfaces.F90
-  UnixProcess.F90
-  TestTimer.F90
-  RobustRunner.F90
-  RemoteRunner.F90
-  RemoteProxyTestCase.F90
-  )
+if (NOT SKIP_ROBUST)
+  list (APPEND srcs
+    Posix.F90
+    File.F90
+    UnixPipeInterfaces.F90
+    UnixProcess.F90
+    TestTimer.F90
+    RobustRunner.F90
+    RemoteRunner.F90
+    RemoteProxyTestCase.F90
+    )
+endif ()
+
 
 add_library (funit-core OBJECT ${srcs})
 set_target_properties (funit-core PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../mod)
 add_dependencies (funit-core generate_posix_parameters)
 target_link_libraries (funit-core PUBLIC external-pfunit)
+if (OpenMP_Fortran_FOUND)
+  target_link_libraries (funit-core PUBLIC OpenMP::OpenMP_Fortran)
+endif ()
 
 target_include_directories (funit-core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../mod>

--- a/src/funit/core/ExceptionList.F90
+++ b/src/funit/core/ExceptionList.F90
@@ -189,7 +189,7 @@ contains
       character(len=*), intent(in) :: message
       type (SourceLocation), optional, intent(in) :: location
 
-      !omp critical
+      !$omp critical
       call global_exception_list%throw(message, location)
       !$omp end critical
 

--- a/src/funit/core/TestFailure.F90
+++ b/src/funit/core/TestFailure.F90
@@ -33,15 +33,4 @@ module PF_TestFailure
       type (ExceptionList) :: exceptions
    end type TestFailure
 
-!!$   interface TestFailure
-!!$      module procedure newTestFailure
-!!$   end interface TestFailure
-!!$
-!!$contains
-!!$
-!!$   function newTestFailure(testName, list)
-!!$      character(len=*), intent(in) :: testName
-!!$      type (Exception), intent(in) :: exceptions(:)
-!!$   end function newTestFailure
-
 end module PF_TestFailure

--- a/src/pfunit/core/MpiContext.F90
+++ b/src/pfunit/core/MpiContext.F90
@@ -1,3 +1,4 @@
+#include "unused_dummy.fh"
 !-------------------------------------------------------------------------------
 ! NASA/GSFC Advanced Software Technology Group
 !-------------------------------------------------------------------------------
@@ -349,6 +350,8 @@ contains
 
    subroutine clean(this)
       type (MpiContext), intent(inout) :: this
+      _UNUSED_DUMMY(this)
+      
 !!$      call debug(__LINE__,__FILE__)
 !!$      call MPI_Comm_free(this%mpiCommunicator, ier)
 !!$      call debug(__LINE__,__FILE__)

--- a/src/pfunit/core/MpiTestCase.F90
+++ b/src/pfunit/core/MpiTestCase.F90
@@ -1,3 +1,5 @@
+#include "unused_dummy.fh"
+
 !-------------------------------------------------------------------------------
 ! NASA/GSFC Advanced Software Technology Group
 !-------------------------------------------------------------------------------
@@ -52,6 +54,7 @@ contains
 
    integer function countTestCases_mpi(this) result(countTestCases)
       class (MpiTestCase), target, intent(in) :: this
+      _UNUSED_DUMMY(this)
       countTestCases = 1
    end function countTestCases_mpi
 
@@ -101,6 +104,7 @@ contains
          ! only report context failure on root PE
          if (.not. this%parentContext%isRootProcess()) then
             discard = catch()
+            if (.false.) print*,discard ! prevent warning from compiler that discard is not used.
          end if
       end if
 

--- a/src/pfunit/core/MpiTestParameter.F90
+++ b/src/pfunit/core/MpiTestParameter.F90
@@ -1,3 +1,4 @@
+#include "unused_dummy.fh"
 module PF_MpiTestParameter
    use PF_AbstractTestParameter
    implicit none
@@ -66,6 +67,8 @@ contains
       class (MpiTestParameter), intent(in) :: this
       character(:), allocatable :: string
 
+      _UNUSED_DUMMY(this)
+      
       string = ''
 
    end function toString

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,9 @@ include (add_pfunit_ctest)
 
 
 add_subdirectory(funit-core)
-add_subdirectory(fhamcrest)
+if (NOT SKIP_FHAMCREST)
+  add_subdirectory(fhamcrest)
+endif ()
 
 if (MPI_Fortran_FOUND)
   add_subdirectory(pfunit)

--- a/tests/funit-core/CMakeLists.txt
+++ b/tests/funit-core/CMakeLists.txt
@@ -61,13 +61,17 @@ set (test_srcs
   Test_TestSuite.F90
   )
 
-list (APPEND test_srcs
-  Test_UnixProcess.F90
-  Test_RobustRunner.F90
-  robustTestSuite.F90
-  )
+if (NOT SKIP_ROBUST)
+  list (APPEND test_srcs
+    Test_UnixProcess.F90
+    Test_RobustRunner.F90
+    robustTestSuite.F90
+    )
+endif ()
 
-list(APPEND test_srcs Test_BasicOpenMP.F90)
+if (OPENMP_FORTRAN_FOUND)
+  list(APPEND test_srcs Test_BasicOpenMP.F90)
+endif ()
 
 
 add_library (funit_tests EXCLUDE_FROM_ALL STATIC ${test_srcs})

--- a/tests/funit-core/serial_tests.F90
+++ b/tests/funit-core/serial_tests.F90
@@ -25,8 +25,6 @@ contains
       use Test_AssertBasic, only: assertBasicSuite => suite            !
       use Test_Assert, only: assertSuite => suite                      ! (3)
 
-!!$      use Test_AssertComplex, only: assertComplexSuite => suite              ! (5)
-
       use Test_TestResult, only: testResultSuite => suite              ! (6)
       use Test_TestSuite, only: testTestSuiteSuite => suite                ! (7)
 
@@ -34,7 +32,8 @@ contains
       use Test_SimpleTestCase, only: testSimpleTestCaseSuite => suite          ! (9)
       use Test_FixtureTestCase, only: testFixtureTestCaseSuite => suite        ! (10)
 
-      use Test_BasicOpenMP, only: testBasicOpenMpSuite => suite  ! (8)
+
+!$    use Test_BasicOpenMP, only: testBasicOpenMpSuite => suite  ! (8)
 
       use Test_MockCall, only: testMockCallSuite => suite      ! (11)
       use Test_MockRepository, only: testMockRepositorySuite => suite      ! (11)
@@ -67,7 +66,7 @@ contains
       ADD(testSimpleTestCaseSuite)
       ADD(testFixtureTestCaseSuite)
 
-      ADD(testBasicOpenMpSuite)
+!$    ADD(testBasicOpenMpSuite)
 
       ADD(testMockCallSuite)
       ADD(testMockRepositorySuite)

--- a/tests/pfunit/Test_MPI_stub.pf
+++ b/tests/pfunit/Test_MPI_stub.pf
@@ -1,3 +1,4 @@
+#include "unused_dummy.fh"
 module Test_MPI_stub
    use pfunit
 
@@ -7,6 +8,7 @@ contains
    subroutine stub_mpi_test(this)
       class (MpiTestMethod), intent(inout) :: this
 
+      _UNUSED_DUMMY(this)
    end subroutine stub_mpi_test
 
 end module Test_MPI_stub

--- a/tests/pfunit/Test_MpiException.F90
+++ b/tests/pfunit/Test_MpiException.F90
@@ -1,4 +1,4 @@
-!#include "reflection.h"
+#include "unused_dummy.fh"
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
 !-------------------------------------------------------------------------------
@@ -36,7 +36,6 @@ contains
 
    function suite()
       use PF_TestSuite, only: TestSuite
-      use PF_TestMethod, only: TestMethod!, TestMethod
 
       type (TestSuite) :: suite
 
@@ -64,6 +63,7 @@ contains
       class (MpiTestMethod), intent(inout) :: this
       class (ParallelContext), allocatable :: context
 
+      _UNUSED_DUMMY(this)
       allocate(context, source=this%getContext())
       call assertFalse(anyExceptions(context))
       

--- a/tests/pfunit/Test_MpiTestCase.F90
+++ b/tests/pfunit/Test_MpiTestCase.F90
@@ -135,11 +135,9 @@ contains
       use PF_TestResult
       use PF_Exception, only: Exception
       use PF_ExceptionList, only: throw
-      use PF_ExceptionList, only: catch
       use PF_TestFailure
       class (TestMpiTestCase), intent(inout) :: this
 
-      integer :: numProcesses, ier
       type (TestMpiTestCase) :: brokenTest
       type (TestResult) :: reslt
       type (TestFailure) :: failure
@@ -175,15 +173,12 @@ contains
    ! Test that exception thrown on non root process is
    ! detected on root process in the end.
    subroutine testFailOn2(this)
-      use PF_ExceptionList, only: throw
       use PF_Assert, only: assertEqual
       use PF_TestResult
       use PF_Exception, only: Exception
-      use PF_ExceptionList, only: catch
       use PF_TestFailure
       class (TestMpiTestCase), intent(inout) :: this
 
-      integer :: numProcesses, ier
       type (TestMpiTestCase) :: brokenTest
       type (TestResult) :: reslt
       type (TestFailure) :: failure
@@ -216,16 +211,13 @@ contains
    ! Purposefully request more processes than are available. 
    ! detected on root process in the end.
    subroutine testTooFewProcs(this)
-      use PF_ExceptionList, only: throw
       use PF_Assert, only: assertEqual
       use PF_TestResult
       use PF_Exception, only: Exception
-      use PF_ExceptionList, only: catch
       use PF_ExceptionList, only: anyExceptions
       use PF_TestFailure
       class (TestMpiTestCase), intent(inout) :: this
 
-      integer :: numProcesses, ier
       type (TestMpiTestCase) :: brokenTest
       type (TestResult) :: reslt
       type (TestFailure) :: failure
@@ -265,7 +257,7 @@ contains
       character(len=:), allocatable, intent(inout) :: runLog
       integer, intent(in) :: mpiCommunicator
       
-      integer :: numProcesses, rank, ier
+      integer :: ier
 
       runLog = 'was run'
       call Mpi_Barrier(mpiCommunicator, ier)

--- a/tests/pfunit/parallel_tests.F90
+++ b/tests/pfunit/parallel_tests.F90
@@ -2,7 +2,6 @@ program main
    use pfunit, only: initialize
    use pfunit, only: finalize
    use pfunit, only: TestResult
-   use pfunit, only: TestListenerVector
    use pfunit, only: stub
 !$$   use pfunit, only: DebugListener
    implicit none
@@ -19,13 +18,11 @@ contains
       use pfunit, only: TestSuite
       use pfunit, only: TestRunner
       use pfunit, only: MpiContext
-      use pfunit, only: ParallelContext
 
       use Test_MpiContext, only: MpiContextSuite => suite
       use Test_MpiException, only: MpiExceptionSuite => suite
       use Test_MpiTestCase, only: MpiTestCaseSuite => suite
       use Test_MpiParameterizedTestCase, only: MpiParameterizedTestCaseSuite => suite
-      use iso_fortran_env, only: OUTPUT_UNIT
 
       type (TestSuite) :: allTests
       type (TestRunner) :: runner


### PR DESCRIPTION
  - Also corrected/updated OpenMP issues.
      Note that OpenMP is not activated for NAG.  The problem is in
      find_package(OpenMP).

  - Eliminated various compiler warnings in MPI subdirs.