### PR TITLE
Fixes #108. Highlight .pf files as Fortran syntax.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pf linguist-language=fortran


### PR DESCRIPTION
Ideally we could highlight pFUnit annotations - but this appears to be
very difficult.