### PR TITLE
Fixes #136.

### DIFF
--- a/cmake/CheckFortranSource.cmake
+++ b/cmake/CheckFortranSource.cmake
@@ -10,7 +10,7 @@ macro (CHECK_FORTRAN_SOURCE_RUN file var)
 
   # Successful runs return "0", which is opposite of CMake sense of "if":
   if (NOT run)
-    string(STRIP ${${var}} ${var})
+    string(STRIP "${${var}}" ${var})
     if (NOT CMAKE_REQUIRED_QUIET)
       message(STATUS "Performing Test ${var}: SUCCESS (value=${${var}})")
     endif ()


### PR DESCRIPTION
Contribution from @jurnix.

Still not entirely certain why this issue is triggered by an older
gfortran, while still passing all of the checks.   But this at least
eliminates worrisome cmake errors in those cases.