### PR TITLE
Fixes #154 - EXTERNAL required

### DIFF
--- a/include/driver.F90
+++ b/include/driver.F90
@@ -27,12 +27,18 @@ program main
    procedure(), pointer :: extra_finalize
    
 #ifdef PFUNIT_EXTRA_INITIALIZE
+#  ifndef PFUNIT_EXTRA_USE
+   external :: PFUNIT_EXTRA_INITIALIZE
+#  endif
    extra_initialize => PFUNIT_EXTRA_INITIALIZE
 #else
    extra_initialize => stub
 #endif
 
 #ifdef PFUNIT_EXTRA_FINALIZE
+#  ifndef PFUNIT_EXTRA_USE
+   external :: PFUNIT_EXTRA_FINALIZE
+#  endif
    extra_finalize => PFUNIT_EXTRA_FINALIZE
 #else
    extra_finalize => stub


### PR DESCRIPTION
The new approach in pFUnit 4.0 for the driver, treats optional
initialize() and finalize() as procedure pointer targets via
PFUNIT_EXTRA_INITIALIZE and PFUNIT_EXTRA_FINALIZE.  Within driver, a
procedure pointer is declared with an implicit interface, but this
approach requires that the target procedure have the EXTERNAL
attribute or be accessed through a module.

Unfortunately, one cannot simply always add EXTERNAL, because that it
conflicts if the user also uses PFUNIT_EXTRA_USE.   So users must not
mix and match.   Either the INITIALIZE and FINALIZE methods are given
through a module or they are external.

empty