### PR TITLE
Fixes #170.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,10 @@
+4.1.3   December 10, 2019
+	- Fix bug in add_pfunit_ctest() macro involving path
+	  Only affects using with Intel MPI
+	
+4.1.2   December 07, 2019
+	- Fix minor bug related to OpenMP propagation
+	
 4.1.1   November 10, 2019
 	- Fix for #122 (allow add_pfunit_test() with abs path)
 

--- a/include/add_pfunit_ctest.cmake
+++ b/include/add_pfunit_ctest.cmake
@@ -113,7 +113,7 @@ function (add_pfunit_ctest test_package_name)
     endif()
     add_test (NAME ${test_package_name}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND mpirun ${MPIEXEC_PREFLAGS} -np ${PF_TEST_MAX_PES} ${test_package_name}
+      COMMAND mpirun ${MPIEXEC_PREFLAGS} -np ${PF_TEST_MAX_PES} ${CMAKE_CURRENT_BINARY_DIR}/${test_package_name}
       )
   else()
     target_link_libraries (${test_package_name} funit)


### PR DESCRIPTION
Error was only exposed under some flavors of MPI.

(This should have been labeled as a hotfix.)
