### PR TITLE
Fixes #180.

### DIFF
--- a/bin/funit/pFUnitParser.py
+++ b/bin/funit/pFUnitParser.py
@@ -806,14 +806,14 @@ class Parser():
     def addSimpleTestMethod(self, testMethod):
         args = "'" + testMethod['name'] + "', " + testMethod['name']
         if 'setUp' in testMethod:
-            args += ', ' + testMethod['setUp']
+            args += ', ' + 'opt_setUp='+testMethod['setUp']
         elif 'setUp' in self.userTestCase:
-            args += ', ' + self.userTestCase['setUp']
+            args += ', ' + 'opt_setUp='+self.userTestCase['setUp']
 
         if 'tearDown' in testMethod:
-            args += ', ' + testMethod['tearDown']
+            args += ', ' + 'opt_tearDown='+testMethod['tearDown']
         elif 'tearDown' in self.userTestCase:
-            args += ', ' + self.userTestCase['tearDown']
+            args += ', ' + 'opt_tearDown='+self.userTestCase['tearDown']
 
         if 'type' in testMethod:
             type =  testMethod['type']

--- a/src/funit/core/TestMethod.F90
+++ b/src/funit/core/TestMethod.F90
@@ -22,6 +22,7 @@
 !-------------------------------------------------------------------------------
 module PF_TestMethod
    use PF_TestCase, only: TestCase
+   use PF_KeywordEnforcer
    implicit none
    private
 
@@ -49,22 +50,30 @@ module PF_TestMethod
 
 contains
 
-   function TestMethod_(name, method) result(this)
+  ! The optional dummy arguments have weird names to prevent backward incompatibility
+  ! issues.
+   function TestMethod_(name, method, unused, opt_setUp, opt_TearDown) result(this)
       type (TestMethod) :: this
       character(len=*), intent(in) :: name
       procedure(empty) :: method
+      class(KeywordEnforcer), optional, intent(in) :: unused
+      procedure(empty), optional :: opt_setUp
+      procedure(empty), optional :: opt_tearDown
 
       call this%setName(name)
       this%userMethod => method
+      this%userSetUp => opt_setUp
+      this%userTearDown => opt_tearDown
 
    end function TestMethod_
 
+   ! This interface (nonoptional dummies)  should be deprecated. (Delete in 5.0)
    function TestMethod_setUpTearDown(name, method, setUp, tearDown) result(this)
       type (TestMethod) :: this
       character(len=*), intent(in) :: name
       procedure(empty) :: method
       procedure(empty) :: setUp
-      procedure(empty) :: tearDown
+      procedure(empty), optional :: tearDown
 
       call this%setName(name)
       this%userMethod => method
@@ -72,6 +81,7 @@ contains
       this%userTearDown => tearDown
 
    end function TestMethod_setUpTearDown
+
 
    recursive subroutine runMethod(this)
       class (TestMethod), intent(inOut) :: this

--- a/tests/funit-core/CMakeLists.txt
+++ b/tests/funit-core/CMakeLists.txt
@@ -41,7 +41,8 @@ set(pf_tests
   Test_RepeatPattern.pf
   Test_TapListener.pf
   Test_NameFilter.pf
-  Test_RegularExpression.pf)
+  Test_RegularExpression.pf
+  Test_TestMethod_before.pf)
 
 set (new_test_srcs)
 set (test_srcs

--- a/tests/funit-core/Test_TestMethod_before.pf
+++ b/tests/funit-core/Test_TestMethod_before.pf
@@ -1,0 +1,22 @@
+! Test suite with @before, but not @after
+
+module Test_TestMethod_before
+  use FUnit
+
+   @suite(name='TestMethod_before')
+
+  logical :: setup_was_run = .false.
+
+contains
+
+  @before
+  subroutine setup()
+    setup_was_run = .true.
+  end subroutine setup
+
+  @test
+  subroutine test1()
+    @assertTrue(setup_was_run)
+  end subroutine test1
+
+end module Test_TestMethod_Before

--- a/tests/funit-core/testSuites.inc
+++ b/tests/funit-core/testSuites.inc
@@ -18,3 +18,5 @@
    ADD_TEST_SUITE(RepeatPattern_suite)
    ADD_TEST_SUITE(NameFilter_suite)
    ADD_TEST_SUITE(RegularExpression_suite)
+   ADD_TEST_SUITE(TestMethod_before)
+   


### PR DESCRIPTION
The constructor for TestMethod now allows setup without teardown and
vice-versa.  The othe overload for this constructor with non-optional
dummy arguments is deprecated, and the dummy argument spelling has
changed to avoid conflicts.  Users should obtain identical results
regardless of whether they use keyword association or not.   But it
is a bit subtle as to why.