### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,12 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-10.15]
         compiler: [gfortran-8, gfortran-9]
+      # fail-fast is set to 'true' here which is good for production, but when
+      # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails
+      # GitHub Actions will stop any other test immediately. So good for production, bad
+      # when trying to figure something out. For more info see:
+      # https://www.edwardthomson.com/blog/github_actions_6_fail_fast_matrix_workflows.html
+      fail-fast: true
     env:
       FC: ${{ matrix.compiler }}
       LANGUAGE: en_US.UTF-8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,58 @@
+name: CI Tests
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15]
+        compiler: [gfortran-8, gfortran-9]
+    env:
+      FC: ${{ matrix.compiler }}
+      LANGUAGE: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+      LC_TYPE: en_US.UTF-8
+      OMPI_ALLOW_RUN_AS_ROOT: 1
+      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+      OMPI_MCA_btl_vader_single_copy_mechanism: none
+
+    name: ${{ matrix.os }} / ${{ matrix.compiler }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Cache MPI
+        id: cache-mpi
+        uses: actions/cache@v2
+        with:
+          path: ~/local/openmpi
+          key: mpi-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}
+      - name: Build MPI
+        if: steps.cache-mpi.outputs.cache-hit != 'true'
+        run: |
+          sh ${GITHUB_WORKSPACE}/tools/travis-install-mpi.sh openmpi 4.0.4
+      - name: Set MPI Environment
+        run: |
+          echo "::add-path::${HOME}/local/openmpi/bin"
+          echo "::set-env name=LD_LIBRARY_PATH::${HOME}/local/openmpi/lib"
+          echo "::set-env name=DYLD_LIBRARY_PATH::${HOME}/local/openmpi/lib"
+      - name: Versions
+        run: |
+          ${FC} --version
+          mpirun --version
+          mpifort --show
+      - name: Build pFUnit
+        run: |
+          mkdir -p build
+          cd build
+          cmake .. -DCMAKE_Fortran_COMPILER=${FC}
+      - name: Run Tests
+        run: |
+          cd build
+          make -j
+          make -j tests
+          ctest -j --output-on-failure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-10.15]
         compiler: [gfortran-8, gfortran-9]
+
       # fail-fast is set to 'true' here which is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails
       # GitHub Actions will stop any other test immediately. So good for production, bad

--- a/tools/travis-install-mpi.sh
+++ b/tools/travis-install-mpi.sh
@@ -14,7 +14,7 @@ then
    wget --no-check-certificate https://download.open-mpi.org/release/open-mpi/v${MPI_VER%.*}/${MPI_IMPL}-${MPI_VER}.tar.bz2
    tar xjf ${MPI_IMPL}-${MPI_VER}.tar.bz2 && rm ${MPI_IMPL}-${MPI_VER}.tar.bz2
    cd ${MPI_IMPL}-${MPI_VER}
-   ./configure --prefix=${HOME}/local/${MPI_IMPL} --disable-wrapper-rpath --disable-wrapper-runpath
+   ./configure --prefix=${HOME}/local/${MPI_IMPL} --disable-wrapper-rpath --disable-wrapper-runpath --with-hwloc=internal --with-libevent=internal
    make -j $(nproc)
    make install-strip
    cd .. && rm -r ${MPI_IMPL}-${MPI_VER}


### PR DESCRIPTION
This commit adds GitHub Actions to pFUnit. 

There are a few interesting things here. First, due to the fact that [GitHub Actions virtual environments](https://github.com/actions/virtual-environments) are a bit more complete than most (see below to for links for each OS), there is no need to install almost anything. Even gfortran is included by default and [GitHub seems amenable to updating the images pretty quickly](https://github.com/actions/virtual-environments#software-guidelines) with issues to update them.

The only extra install was Open MPI as the `apt` or `brew` version would always run into issues as `mpi.mod` must/should be compiled per compiler. So, [actions/cache](https://github.com/actions/cache) was used to cache Open MPI builds. Note that the cache key is currently:
```yaml
key: mpi-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}
```

Currently the tests are as follows:

* OS
  * [ubuntu-18.04](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md)
  * [ubuntu-20.04](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu2004-README.md)
  * [macos-10.15](https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md)
* Fortran Compiler
  * gfortran-8
  * gfortran-9

