### PR TITLE
Fixes #227 - WSL issue

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+- Fixed problem under WSL+Gfortran-9 in which -O0 crashed pFUnit self tests.
 	
 ## [4.1.9] - 2020-05-29
 

--- a/cmake/GNU.cmake
+++ b/cmake/GNU.cmake
@@ -4,11 +4,13 @@ set(traceback "-fbacktrace")
 set(check_all "-fbounds-check")
 set(cpp "-cpp")
 
+string(REGEX MATCH "Microsoft" WSL ${CMAKE_HOST_SYSTEM_VERSION})
+if (WSL AND CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 10)
+  set(opt "-O2")
+else ()
+  set(opt "-O0")
+endif ()
 
-set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
-set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
-#set(CMAKE_Fortran_FLAGS "-g ${cpp} -O0 ${traceback} ${check_all} -ffree-line-length-512")
-set(CMAKE_Fortran_FLAGS "-g ${cpp} -O0 ${traceback}  -ffree-line-length-512")
-
+set(CMAKE_Fortran_FLAGS "-g ${cpp} ${opt} ${traceback}  -ffree-line-length-512")
 
 add_definitions(-D_GNU)

--- a/cmake/GNU.cmake
+++ b/cmake/GNU.cmake
@@ -5,7 +5,7 @@ set(check_all "-fbounds-check")
 set(cpp "-cpp")
 
 string(REGEX MATCH "Microsoft" WSL ${CMAKE_HOST_SYSTEM_VERSION})
-if (WSL AND CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 10)
+if (WSL)
   set(opt "-O2")
 else ()
   set(opt "-O0")


### PR DESCRIPTION
Under WSL, GFortran-9 would crash immediately when runing some tests.
Exact cause has not been determined, but raising the optimization
level avoids the problem.   GFortran-10 appears to not have the issue.