### PR TITLE
Bugfix/workaround for gfortran 10.x

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.11] - 2020-08-04
+
+### Fixed
+- Added flag that allows GFortran 10.x to compile with argument mismatches
+  in MPI layer.  This apparently is only an issue for some MPI flavors, with
+  others importing the correct interface variability via ```use mpi```.
+
+
 ## [4.1.10] - 2020-07-29
+
 ### Fixed
 - Fixed problem under WSL+Gfortran-9 in which -O0 crashed pFUnit self tests.
 	

--- a/cmake/GNU.cmake
+++ b/cmake/GNU.cmake
@@ -1,8 +1,9 @@
 # Compiler specific flags for GNU Fortran compiler
 
-set(traceback "-fbacktrace")
-set(check_all "-fbounds-check")
-set(cpp "-cpp")
+set (traceback "-fbacktrace")
+set (check_all "-fbounds-check")
+set (cpp "-cpp")
+set (MISMATCH "-fallow-argument-mismatch")
 
 string(REGEX MATCH "Microsoft" WSL ${CMAKE_HOST_SYSTEM_VERSION})
 if (WSL)
@@ -11,6 +12,9 @@ else ()
   set(opt "-O0")
 endif ()
 
-set(CMAKE_Fortran_FLAGS "-g ${cpp} ${opt} ${traceback}  -ffree-line-length-512")
+set(CMAKE_Fortran_FLAGS "-g ${cpp} ${opt} ${traceback} -ffree-line-length-512")
+if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+  set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${MISMATCH}")
+endif ()
 
 add_definitions(-D_GNU)

--- a/src/pfunit/core/MpiContext.F90
+++ b/src/pfunit/core/MpiContext.F90
@@ -27,7 +27,6 @@ module PF_MpiContext
    use mpi
    implicit none
    private
-
    public :: MpiContext
 
    type, extends(ParallelContext) :: MpiContext
@@ -179,7 +178,7 @@ contains
       integer :: ier
       integer :: tmp
 
-      call mpi_allreduce(value, tmp, 1, MPI_INTEGER, MPI_SUM, &
+      call MPI_Allreduce(value, tmp, 1, MPI_INTEGER, MPI_SUM, &
            &     this%mpiCommunicator, ier)
       sum_global = tmp
       


### PR DESCRIPTION
- Added flag that allows GFortran 10.x to compile with argument mismatches
  in MPI layer.  This apparently is only an issue for some MPI flavors, with
  others importing the correct interface variability via ```use mpi```.

@amklinv-nnl
