### PR TITLE
Bugfixes for fhamcrest tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 *.zip
 build/
 include/configuration.mk
+/cmake-build-debug/
+/.idea/

--- a/src/funit/fhamcrest/BaseDescription.F90
+++ b/src/funit/fhamcrest/BaseDescription.F90
@@ -321,7 +321,7 @@ contains
       complex(kind=REAL32), intent(in) :: value
 
       character(128) :: buffer
-      write(buffer,'(g0)') value
+      write(buffer,'("(",g0,",",g0,")")') value
       string = trim(buffer)
     end function description_of_complex32
 
@@ -331,7 +331,7 @@ contains
       complex(kind=REAL64), intent(in) :: value
 
       character(128) :: buffer
-      write(buffer,'(g0)') value
+      write(buffer,'("(",g0,",",g0,")")') value
       string = trim(buffer)
     end function description_of_complex64
 
@@ -342,7 +342,7 @@ contains
       complex(kind=REAL128), intent(in) :: value
 
       character(128) :: buffer
-      write(buffer,'(g0)') value
+      write(buffer,'("(",g0,",",g0,")")') value
       string = trim(buffer)
     end function description_of_complex128
 

--- a/src/funit/fhamcrest/IsEqual.F90
+++ b/src/funit/fhamcrest/IsEqual.F90
@@ -21,7 +21,7 @@ module pf_IsEqual
      procedure :: describe_to
      procedure :: describe_mismatch
 
-     procedure :: matches_list
+     procedure :: matches_array_1d
      procedure :: matches_array_2d
      procedure :: matches_array_3d
      procedure :: matches_intrinsic
@@ -101,7 +101,7 @@ contains
 
     select type (e => this%expected_value)
     type is (ArrayWrapper_1d)
-       matches = this%matches_list(e%items, actual_value)
+       matches = this%matches_array_1d(e%items, actual_value)
     type is (ArrayWrapper_2d)
        matches = this%matches_array_2d(e%items, actual_value)
     type is (ArrayWrapper_3d)
@@ -115,7 +115,7 @@ contains
   end function matches
 
 
-  logical function matches_list(this, expected_items, actual_value)
+  logical function matches_array_1d(this, expected_items, actual_value)
     class(IsEqual), intent(in) :: this
     class(*), intent(in) :: expected_items(:)
     class(*), intent(in) :: actual_value
@@ -132,17 +132,19 @@ contains
           do i = 1, n_items
              m = equal_to(expected_items(i))
              if (.not. m%matches(a%items(i))) then
-                matches_list = .false.
+                matches_array_1d = .false.
                 return
              end if
           end do
-          matches_list = .true.
+          matches_array_1d = .true.
        else
-          matches_list = .false. ! differing number of elements
+          matches_array_1d = .false. ! differing number of elements
        end if
+    class default
+       matches_array_1d = .false. ! differing types
     end select
 
-  end function matches_list
+  end function matches_array_1d
 
 
   logical function matches_array_2d(this, expected_items, actual_value)
@@ -171,6 +173,8 @@ contains
        else
           matches_array_2d = .false. ! differing shape/size
        end if
+    class default
+       matches_array_2d = .false. ! differing types
     end select
 
   end function matches_array_2d
@@ -204,6 +208,8 @@ contains
        else
           matches_array_3d = .false. ! differing shape/size
        end if
+    class default
+       matches_array_3d = .false. ! differing types
     end select
 
   end function matches_array_3d

--- a/tests/fhamcrest/CMakeLists.txt
+++ b/tests/fhamcrest/CMakeLists.txt
@@ -10,6 +10,7 @@ set(pf_tests
   Test_AnyOf.pf
   Test_AllOf.pf
   Test_Every.pf
+  Test_IsEqual.pf
   Test_IsEqual_extended.pf
   Test_StringContains.pf
   Test_StringStartsWith.pf
@@ -27,19 +28,26 @@ add_library(fhamcrest_tests  ${test_srcs})
 target_link_libraries(fhamcrest_tests funit)
 
 configure_file(${CMAKE_SOURCE_DIR}/include/driver.F90 driver.F90)
-add_executable (fhamcrest_tests.x driver.F90)
+add_executable (fhamcrest_tests_old.x driver.F90)
 set_source_files_properties(driver.F90 PROPERTIES COMPILE_DEFINITIONS _TEST_SUITES="testSuites.inc")
 set_source_files_properties(driver.F90 PROPERTIES OBJECT_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/testSuites.inc)
-target_link_libraries(fhamcrest_tests.x fhamcrest_tests)
+target_link_libraries(fhamcrest_tests_old.x fhamcrest_tests)
 
 
 
-add_test(NAME fhamcrest_tests
-  COMMAND fhamcrest_tests.x
+add_test(NAME fhamcrest_tests_old
+  COMMAND fhamcrest_tests_old.x
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
-add_dependencies(build-tests fhamcrest_tests.x)
-set_property (TEST fhamcrest_tests
+add_dependencies(build-tests fhamcrest_tests_old.x)
+set_property (TEST fhamcrest_tests_old
     PROPERTY FAIL_REGULAR_EXPRESSION "Encountered 1 or more failures/errors during testing"
     )
+
+add_pfunit_ctest(fhamcrest_tests.x
+        TEST_SOURCES ${pf_tests}
+        LINK_LIBRARIES other_shared
+        REGISTRY testSuites.inc
+        )
+add_dependencies(build-tests fhamcrest_tests.x)
 

--- a/tests/fhamcrest/Test_IsEqual.pf
+++ b/tests/fhamcrest/Test_IsEqual.pf
@@ -1,0 +1,320 @@
+module Test_IsEqual
+   use iso_fortran_env
+
+   use funit
+   implicit none
+
+   @suite(name='Hamcrest_IsEqual')
+contains
+   @test
+   subroutine test_is_equal_intrinsic_logical()
+      ! logical
+      call assert_that(.true., is(equal_to(.true.)))
+      call assert_that(.false., is(equal_to(.false.)))
+      call assert_that(.true., is(equal_to(.false.)))
+      @assertExceptionRaised()
+      call assert_that(.false., is(equal_to(.true.)))
+      @assertExceptionRaised()
+   end subroutine test_is_equal_intrinsic_logical
+
+   @test
+   subroutine test_is_equal_intrinsic_integer()
+      ! integer
+      call assert_that(1, is(equal_to(1)))
+      call assert_that(2, is(equal_to(2)))
+      call assert_that(1, is(equal_to(2)))
+      @assertExceptionRaised()
+      call assert_that(2, is(equal_to(1)))
+      @assertExceptionRaised()
+
+      ! INT32
+      call assert_that(1_INT32, is(equal_to(1_INT32)))
+      call assert_that(2_INT32, is(equal_to(2_INT32)))
+      call assert_that(1_INT32, is(equal_to(2_INT32)))
+      @assertExceptionRaised()
+      call assert_that(2_INT32, is(equal_to(1_INT32)))
+      @assertExceptionRaised()
+
+      ! INT64
+      call assert_that(1_INT64, is(equal_to(1_INT64)))
+      call assert_that(2_INT64, is(equal_to(2_INT64)))
+      call assert_that(1_INT64, is(equal_to(2_INT64)))
+      @assertExceptionRaised()
+      call assert_that(2_INT64, is(equal_to(1_INT64)))
+      @assertExceptionRaised()
+   end subroutine test_is_equal_intrinsic_integer
+
+   @test
+   subroutine test_is_equal_intrinsic_real()
+      ! real
+      call assert_that(1., is(equal_to(1.)))
+      call assert_that(2., is(equal_to(2.)))
+      call assert_that(1., is(equal_to(2.)))
+      @assertExceptionRaised()
+      call assert_that(2., is(equal_to(1.)))
+      @assertExceptionRaised()
+
+      ! double
+      call assert_that(1.d0, is(equal_to(1.d0)))
+      call assert_that(2.d0, is(equal_to(2.d0)))
+      call assert_that(1.d0, is(equal_to(2.d0)))
+      @assertExceptionRaised()
+      call assert_that(2.d0, is(equal_to(1.d0)))
+      @assertExceptionRaised()
+
+      ! REAL32
+      call assert_that(1_REAL32, is(equal_to(1_REAL32)))
+      call assert_that(2_REAL32, is(equal_to(2_REAL32)))
+      call assert_that(1_REAL32, is(equal_to(2_REAL32)))
+      @assertExceptionRaised()
+      call assert_that(2_REAL32, is(equal_to(1_REAL32)))
+      @assertExceptionRaised()
+
+      ! REAL64
+      call assert_that(1_REAL64, is(equal_to(1_REAL64)))
+      call assert_that(2_REAL64, is(equal_to(2_REAL64)))
+      call assert_that(1_REAL64, is(equal_to(2_REAL64)))
+      @assertExceptionRaised()
+      call assert_that(2_REAL64, is(equal_to(1_REAL64)))
+      @assertExceptionRaised()
+
+!      ! REAL128
+!      call assert_that(1_REAL128, is(equal_to(1_REAL128)))
+!      call assert_that(2_REAL128, is(equal_to(2_REAL128)))
+!      call assert_that(1_REAL128, is(equal_to(2_REAL128)))
+!      @assertExceptionRaised()
+!      call assert_that(2_REAL128, is(equal_to(1_REAL128)))
+!      @assertExceptionRaised()
+   end subroutine test_is_equal_intrinsic_real
+
+   @test
+   subroutine test_is_equal_intrinsic_complex()
+      complex(kind=REAL32) :: a_s = (1.0, 2.0)
+      complex(kind=REAL32) :: b_s = (3.0, 4.0)
+
+      complex(kind=REAL32) :: a_d = (1.d0, 2.d0)
+      complex(kind=REAL32) :: b_d = (3.d0, 4.d0)
+
+      complex(kind=REAL32) :: a_32 = (1_REAL32, 2_REAL32)
+      complex(kind=REAL32) :: b_32 = (3_REAL32, 4_REAL32)
+
+      complex(kind=REAL64) :: a_64 = (1_REAL64, 2_REAL64)
+      complex(kind=REAL64) :: b_64 = (3_REAL64, 4_REAL64)
+
+      ! complex single
+      call assert_that(a_s, is(equal_to(a_s)))
+      call assert_that(b_s, is(equal_to(b_s)))
+      call assert_that(a_s, is(equal_to(b_s)))
+      @assertExceptionRaised()
+      call assert_that(b_s, is(equal_to(a_s)))
+      @assertExceptionRaised()
+
+      ! complex double
+      call assert_that(a_d, is(equal_to(a_d)))
+      call assert_that(b_d, is(equal_to(b_d)))
+      call assert_that(a_d, is(equal_to(b_d)))
+      @assertExceptionRaised()
+      call assert_that(b_d, is(equal_to(a_d)))
+      @assertExceptionRaised()
+
+      ! complex REAL32
+      call assert_that(a_32, is(equal_to(a_32)))
+      call assert_that(b_32, is(equal_to(b_32)))
+      call assert_that(a_32, is(equal_to(b_32)))
+      @assertExceptionRaised()
+      call assert_that(b_32, is(equal_to(a_32)))
+      @assertExceptionRaised()
+
+      ! complex REAL64
+      call assert_that(a_64, is(equal_to(a_64)))
+      call assert_that(b_64, is(equal_to(b_64)))
+      call assert_that(a_64, is(equal_to(b_64)))
+      @assertExceptionRaised()
+      call assert_that(b_64, is(equal_to(a_64)))
+      @assertExceptionRaised()
+   end subroutine test_is_equal_intrinsic_complex
+
+   @test
+   subroutine test_is_equal_intrinsic_str()
+      character(len=*), parameter :: test0 = 'test'
+      character(len=*), parameter :: test1 = '    test'
+      character(len=*), parameter :: test2 = 'test    '
+
+      call assert_that(test0, is(equal_to(test0)))
+      call assert_that(test1, is(equal_to(test1)))
+      call assert_that(test2, is(equal_to(test2)))
+
+      call assert_that(test0, is(equal_to(test1)))
+      @assertExceptionRaised()
+      call assert_that(test0, is(equal_to(test2)))
+      @assertExceptionRaised()
+      call assert_that(test1, is(equal_to(test0)))
+      @assertExceptionRaised()
+      call assert_that(test1, is(equal_to(test2)))
+      @assertExceptionRaised()
+      call assert_that(test2, is(equal_to(test0)))
+      @assertExceptionRaised()
+      call assert_that(test2, is(equal_to(test1)))
+      @assertExceptionRaised()
+   end subroutine test_is_equal_intrinsic_str
+
+   @test
+   subroutine test_is_equal_array_1d()
+      integer              :: int32_array(3)
+      integer(kind=INT64)  :: int64_array(3)
+      real(kind=REAL32)    :: real32_array(3)
+      real(kind=REAL64)    :: real64_array(3)
+      complex(kind=REAL32) :: complex32_array(3)
+      complex(kind=REAL64) :: complex64_array(3)
+
+      int32_array     = reshape([1, 2, 3], shape(int32_array))
+      int64_array     = int32_array
+      real32_array    = int32_array
+      real64_array    = int32_array
+      complex32_array = int32_array
+      complex64_array = int32_array
+
+      call assert_that(int32_array, is(equal_to(int32_array)))
+      call assert_that(int64_array, is(equal_to(int64_array)))
+      call assert_that(real32_array, is(equal_to(real32_array)))
+      call assert_that(real64_array, is(equal_to(real64_array)))
+      call assert_that(complex32_array, is(equal_to(complex32_array)))
+      call assert_that(complex64_array, is(equal_to(complex64_array)))
+
+      call assert_that(['a', 'b'], is(equal_to(['a', 'b'])))
+
+      call assert_that(1, is(equal_to(int32_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(int64_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(real32_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(real64_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(complex32_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(complex64_array)))
+      @assertExceptionRaised()
+   end subroutine test_is_equal_array_1d
+
+   @test
+   subroutine test_is_equal_array_2d()
+      integer              :: int32_array(2,2)
+      integer(kind=INT64)  :: int64_array(2,2)
+      real(kind=REAL32)    :: real32_array(2,2)
+      real(kind=REAL64)    :: real64_array(2,2)
+      complex(kind=REAL32) :: complex32_array(2,2)
+      complex(kind=REAL64) :: complex64_array(2,2)
+
+      int32_array     = reshape([1, 2, 3, 4], shape(int32_array))
+      int64_array     = int32_array
+      real32_array    = int32_array
+      real64_array    = int32_array
+      complex32_array = int32_array
+      complex64_array = int32_array
+
+      call assert_that(int32_array, is(equal_to(int32_array)))
+      call assert_that(int64_array, is(equal_to(int64_array)))
+      call assert_that(real32_array, is(equal_to(real32_array)))
+      call assert_that(real64_array, is(equal_to(real64_array)))
+      call assert_that(complex32_array, is(equal_to(complex32_array)))
+      call assert_that(complex64_array, is(equal_to(complex64_array)))
+
+      call assert_that(['a', 'b'], is(equal_to(['a', 'b'])))
+
+      call assert_that(1, is(equal_to(int32_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(int64_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(real32_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(real64_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(complex32_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(complex64_array)))
+      @assertExceptionRaised()
+
+      call assert_that([1,2,3], is(equal_to(int32_array)))
+      @assertExceptionRaised()
+      call assert_that([1,2,3], is(equal_to(int64_array)))
+      @assertExceptionRaised()
+      call assert_that([1,2,3], is(equal_to(real32_array)))
+      @assertExceptionRaised()
+      call assert_that([1,2,3], is(equal_to(real64_array)))
+      @assertExceptionRaised()
+      call assert_that([1,2,3], is(equal_to(complex32_array)))
+      @assertExceptionRaised()
+      call assert_that([1,2,3], is(equal_to(complex64_array)))
+      @assertExceptionRaised()
+   end subroutine test_is_equal_array_2d
+
+   @test
+   subroutine test_is_equal_array_3d()
+      integer              :: int32_array(2,2,2)
+      integer(kind=INT64)  :: int64_array(2,2,2)
+      real(kind=REAL32)    :: real32_array(2,2,2)
+      real(kind=REAL64)    :: real64_array(2,2,2)
+      complex(kind=REAL32) :: complex32_array(2,2,2)
+      complex(kind=REAL64) :: complex64_array(2,2,2)
+
+      integer :: int_2D(2,2)
+
+      int32_array     = reshape([1, 2, 3, 4, 5, 6, 7, 8], shape(int32_array))
+      int64_array     = int32_array
+      real32_array    = int32_array
+      real64_array    = int32_array
+      complex32_array = int32_array
+      complex64_array = int32_array
+
+      int_2D = reshape([1, 2, 3, 4], shape(int_2D))
+
+      call assert_that(int32_array, is(equal_to(int32_array)))
+      call assert_that(int64_array, is(equal_to(int64_array)))
+      call assert_that(real32_array, is(equal_to(real32_array)))
+      call assert_that(real64_array, is(equal_to(real64_array)))
+      call assert_that(complex32_array, is(equal_to(complex32_array)))
+      call assert_that(complex64_array, is(equal_to(complex64_array)))
+
+      call assert_that(['a', 'b'], is(equal_to(['a', 'b'])))
+
+      call assert_that(1, is(equal_to(int32_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(int64_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(real32_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(real64_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(complex32_array)))
+      @assertExceptionRaised()
+      call assert_that(1, is(equal_to(complex64_array)))
+      @assertExceptionRaised()
+
+      call assert_that([1,2,3], is(equal_to(int32_array)))
+      @assertExceptionRaised()
+      call assert_that([1,2,3], is(equal_to(int64_array)))
+      @assertExceptionRaised()
+      call assert_that([1,2,3], is(equal_to(real32_array)))
+      @assertExceptionRaised()
+      call assert_that([1,2,3], is(equal_to(real64_array)))
+      @assertExceptionRaised()
+      call assert_that([1,2,3], is(equal_to(complex32_array)))
+      @assertExceptionRaised()
+      call assert_that([1,2,3], is(equal_to(complex64_array)))
+      @assertExceptionRaised()
+
+      call assert_that(int_2D, is(equal_to(int32_array)))
+      @assertExceptionRaised()
+      call assert_that(int_2D, is(equal_to(int64_array)))
+      @assertExceptionRaised()
+      call assert_that(int_2D, is(equal_to(real32_array)))
+      @assertExceptionRaised()
+      call assert_that(int_2D, is(equal_to(real64_array)))
+      @assertExceptionRaised()
+      call assert_that(int_2D, is(equal_to(complex32_array)))
+      @assertExceptionRaised()
+      call assert_that(int_2D, is(equal_to(complex64_array)))
+      @assertExceptionRaised()
+   end subroutine test_is_equal_array_3d
+end module Test_IsEqual

--- a/tests/fhamcrest/testSuites.inc
+++ b/tests/fhamcrest/testSuites.inc
@@ -7,6 +7,8 @@
    ADD_TEST_SUITE(Hamcrest_StringEndsWith)
    ADD_TEST_SUITE(Hamcrest_IsArrayWithSize)
 
+   ADD_TEST_SUITE(Hamcrest_IsEqual)
+
    ADD_TEST_SUITE(Hamcrest_IsNear)
    ADD_TEST_SUITE(Hamcrest_IsRelativelyNear)
 


### PR DESCRIPTION
This fixes #233 (equal_to passing when it should be failing) and #234 (complex number formating) in the fhamcrest tests.

It also adds a test suite that covers these tests and most of the pf_IsEqual module, and updates the fhamcrest tests CMakeLists.txt to use the pfunit_add_ctest.