### PR TITLE
Fix error message for array AssertRelativelyEqual

### DIFF
--- a/src/funit/asserts/Assert_Real.tmpl
+++ b/src/funit/asserts/Assert_Real.tmpl
@@ -957,7 +957,7 @@ contains
 #else
       if (.not. all(abs(actual - expected) <= tolerance*abs(expected))) then
          ! index of first difference is
-         i = maxloc(merge(1,0, .not. abs(actual-expected) <= tolerance))
+         i = maxloc(merge(1,0, .not. abs(actual-expected) <= tolerance*abs(expected)))
          e = expected({actual.multi_index})
          a = actual({actual.multi_index})
       else


### PR DESCRIPTION
This fixes a minor error in the AssertRelativelyEqual macro.  In the array case, if the assertion failed, the test used to find the first mismatched index was different from the test that determined pass/fail.  This generally led to an incorrect array index being reported.  With this PR the second test is changed to match the first, and errors now report correctly.

Tested against intel/19.0.4 and gcc/7.4.0.