### PR TITLE
fix: allow for long subroutine names in allocate

### DIFF
--- a/bin/funit/pFUnitParser.py
+++ b/bin/funit/pFUnitParser.py
@@ -809,7 +809,7 @@ class Parser():
         self.outputFile.write('\nend function ' + self.suiteName + '\n\n')
 
     def addSimpleTestMethod(self, testMethod):
-        args = "'" + testMethod['name'] + "', " + testMethod['name']
+        args = "'" + testMethod['name'] + "', &\n      " + testMethod['name']
         if 'setUp' in testMethod:
             args += ', ' + 'setUp='+testMethod['setUp']
         elif 'setUp' in self.userTestCase:
@@ -833,7 +833,7 @@ class Parser():
 
     def addMpiTestMethod(self, testMethod):
         for npes in testMethod['npRequests']:
-            args = "'" + testMethod['name'] + "', " + testMethod['name'] + ", " + str(npes)
+            args = "'" + testMethod['name'] + "', &\n      " + testMethod['name'] + ", " + str(npes)
             if 'setUp' in testMethod:
                 args += ', ' + testMethod['setUp']
             elif 'setUp' in self.userTestCase:

--- a/tests/funit-core/CMakeLists.txt
+++ b/tests/funit-core/CMakeLists.txt
@@ -43,7 +43,8 @@ set(pf_tests
   Test_TapListener.pf
   Test_NameFilter.pf
   Test_RegularExpression.pf
-  Test_TestMethod_before.pf)
+  Test_TestMethod_before.pf
+  Test_Long_Subroutine_Name.pf)
 
 set (new_test_srcs)
 set (test_srcs

--- a/tests/funit-core/Test_Long_Subroutine_Name.pf
+++ b/tests/funit-core/Test_Long_Subroutine_Name.pf
@@ -1,0 +1,27 @@
+
+module Test_Long_Subroutine_Name
+   use FUnit
+   implicit none
+   
+   @suite(name='AssertLongSubroutine_suite')
+
+contains
+
+   real function add(x, y) result (sum)
+      implicit none
+      real, intent(in) :: x
+      real, intent(in) :: y
+
+      sum = x + y
+
+   end function add
+
+   @test
+   subroutine test_Really_Really_Really_Really_Really_Really_LongLongName_max()
+      implicit none
+
+      @assertEqual(3., add(1.,2.))
+      
+   end subroutine test_Really_Really_Really_Really_Really_Really_LongLongName_max
+
+end module Test_Long_Subroutine_Name


### PR DESCRIPTION
Create a subroutine test with the maximum fortran 2003 length (63 characters) and compile without errors.

Resolves #294 