### PR TITLE
fix: allow first test to be disabled

### DIFF
--- a/bin/funit/pFUnitParser.py
+++ b/bin/funit/pFUnitParser.py
@@ -622,6 +622,8 @@ class AtDisable(Action):
 
     def action(self, m, line):
         print("Processing disable:")
+        if not hasattr(self.parser,'current_method'):
+            self.parser.current_method = {}
         self.parser.current_method['disable'] = True
         self.parser.commentLine(line)
                 

--- a/tests/funit-core/CMakeLists.txt
+++ b/tests/funit-core/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(other_shared PUBLIC funit)
 set(pf_tests
   Test_ExceptionList.pf
   Test_DisableTest.pf
+  Test_DisableFirstTest.pf
   Test_AssertString.pf
   Test_Assert_Integer.pf
   Test_AssertGreaterThan_Integer.pf

--- a/tests/funit-core/Test_DisableFirstTest.pf
+++ b/tests/funit-core/Test_DisableFirstTest.pf
@@ -1,0 +1,13 @@
+module Test_DisableFirstTest
+  use FUnit
+  implicit none
+
+  @suite(name='DisableFirst_suite')
+
+contains
+
+  @disable
+  subroutine first_test_disable_annotation()
+  end subroutine first_test_disable_annotation
+
+end module Test_DisableFirstTest


### PR DESCRIPTION
AtDisable fails because `current_method` attribute is missing when the first test in a module is disabled using `@disable` 

Maybe this is not an issue, or maybe I am using pfunit incorrectly.

These changes make it so the pFUnitParser.py doesn't fail when it sees a `@disable` by itself 