### PR TITLE
CMake: Don't rerun source-compilation tests if they've already run

### DIFF
--- a/cmake/CheckFortranSource.cmake
+++ b/cmake/CheckFortranSource.cmake
@@ -1,57 +1,57 @@
 macro (CHECK_FORTRAN_SOURCE_RUN file var)
+  if (NOT DEFINED var)
+    try_run (
+      run compile
+      ${CMAKE_BINARY_DIR}
+      ${file}
+      CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=${CMAKE_REQUIRED_DEFINITIONS}"
+      RUN_OUTPUT_VARIABLE ${var}
+      )
 
-  try_run (
-    run compile
-    ${CMAKE_BINARY_DIR}
-    ${file}
-    CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=${CMAKE_REQUIRED_DEFINITIONS}"
-    RUN_OUTPUT_VARIABLE ${var}
-    )
+    # Successful runs return "0", which is opposite of CMake sense of "if":
+    if (NOT run)
+      string(STRIP "${${var}}" ${var})
+      if (NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "Performing Test ${var}: SUCCESS (value=${${var}})")
+      endif ()
 
-  # Successful runs return "0", which is opposite of CMake sense of "if":
-  if (NOT run)
-    string(STRIP "${${var}}" ${var})
-    if (NOT CMAKE_REQUIRED_QUIET)
-      message(STATUS "Performing Test ${var}: SUCCESS (value=${${var}})")
+      add_definitions(-D${var}=${${var}})
+
+    else ()
+
+      if (NOT CMAKE_REQUIRED_QUIET)
+        message(STATUS "Performing Test ${var}: FAILURE")
+      endif ()
+
     endif ()
-    
-    add_definitions(-D${var}=${${var}})
-    
-  else ()
-    
-    if (NOT CMAKE_REQUIRED_QUIET)
-      message(STATUS "Performing Test ${var}: FAILURE")
-    endif ()
-    
-  endif ()
-
+  endif()
 endmacro (CHECK_FORTRAN_SOURCE_RUN)
 
 
 macro (CHECK_FORTRAN_SOURCE_COMPILE file var)
+  if (NOT DEFINED var)
+    try_compile (
+      code_compiles
+      ${CMAKE_BINARY_DIR}
+      ${file}
+      CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=${CMAKE_REQUIRED_DEFINITIONS}"
+      )
 
-  try_compile (
-    code_compiles
-    ${CMAKE_BINARY_DIR}
-    ${file}
-    CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=${CMAKE_REQUIRED_DEFINITIONS}"
-    )
+    if (${code_compiles})
 
-  if (${code_compiles})
-
-    set(${var} SUCCESS)
-    if (NOT CMAKE_REQUIRED_QUIET)
-      message (STATUS "Performing Test ${var}: SUCCESS")
-    endif ()
-
-    add_definitions(-D${var})
-
-  else ()
-
+      set(${var} SUCCESS)
       if (NOT CMAKE_REQUIRED_QUIET)
-	message (STATUS "Performing Test ${var}: BUILD FAILURE")
+        message (STATUS "Performing Test ${var}: SUCCESS")
       endif ()
 
-  endif()
+      add_definitions(-D${var})
 
+    else ()
+
+      if (NOT CMAKE_REQUIRED_QUIET)
+        message (STATUS "Performing Test ${var}: BUILD FAILURE")
+      endif ()
+
+    endif()
+  endif()
 endmacro (CHECK_FORTRAN_SOURCE_COMPILE)


### PR DESCRIPTION
One issue with using pfunit via `add_subdirectory` in CMake is that there are some compiler-feature tests that rerun every time CMake needs to re-configure the project. This basically just makes them run only once (although fargparse needs a similar update I think).

One issue is that this probably breaks things if the user changes compiler that has different default kind sizes. In that case, the build directory needs to be cleared and the project reconfigured.