### PR TITLE
CMake: Fix for source-compilation tests not caching variables

### DIFF
--- a/cmake/CheckFortranSource.cmake
+++ b/cmake/CheckFortranSource.cmake
@@ -1,5 +1,5 @@
-macro (CHECK_FORTRAN_SOURCE_RUN file var)
-  if (NOT DEFINED var)
+function (CHECK_FORTRAN_SOURCE_RUN file var)
+  if (NOT DEFINED ${var})
     try_run (
       run compile
       ${CMAKE_BINARY_DIR}
@@ -9,27 +9,26 @@ macro (CHECK_FORTRAN_SOURCE_RUN file var)
       )
 
     # Successful runs return "0", which is opposite of CMake sense of "if":
-    if (NOT run)
-      string(STRIP "${${var}}" ${var})
-      if (NOT CMAKE_REQUIRED_QUIET)
-        message(STATUS "Performing Test ${var}: SUCCESS (value=${${var}})")
-      endif ()
-
-      add_definitions(-D${var}=${${var}})
-
-    else ()
-
+    if (NOT compile OR run)
       if (NOT CMAKE_REQUIRED_QUIET)
         message(STATUS "Performing Test ${var}: FAILURE")
       endif ()
+      return()
+    endif()
 
+    string(STRIP "${${var}}" ${var})
+    if (NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Performing Test ${var}: SUCCESS (value=${${var}})")
     endif ()
+    set(${var} ${${var}} CACHE STRING "" FORCE)
+
   endif()
-endmacro (CHECK_FORTRAN_SOURCE_RUN)
+  add_definitions(-D${var}=${${var}})
+endfunction (CHECK_FORTRAN_SOURCE_RUN)
 
 
-macro (CHECK_FORTRAN_SOURCE_COMPILE file var)
-  if (NOT DEFINED var)
+function (CHECK_FORTRAN_SOURCE_COMPILE file var)
+  if (NOT DEFINED ${var})
     try_compile (
       code_compiles
       ${CMAKE_BINARY_DIR}
@@ -37,21 +36,19 @@ macro (CHECK_FORTRAN_SOURCE_COMPILE file var)
       CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=${CMAKE_REQUIRED_DEFINITIONS}"
       )
 
-    if (${code_compiles})
-
-      set(${var} SUCCESS)
-      if (NOT CMAKE_REQUIRED_QUIET)
-        message (STATUS "Performing Test ${var}: SUCCESS")
-      endif ()
-
-      add_definitions(-D${var})
-
-    else ()
-
+    if (NOT ${code_compiles})
       if (NOT CMAKE_REQUIRED_QUIET)
         message (STATUS "Performing Test ${var}: BUILD FAILURE")
       endif ()
-
+      return()
     endif()
+
+    set(${var} SUCCESS)
+    if (NOT CMAKE_REQUIRED_QUIET)
+      message (STATUS "Performing Test ${var}: SUCCESS")
+    endif ()
+
+    set(${var} ${${var}} CACHE STRING "" FORCE)
   endif()
-endmacro (CHECK_FORTRAN_SOURCE_COMPILE)
+  add_definitions(-D${var})
+endfunction (CHECK_FORTRAN_SOURCE_COMPILE)


### PR DESCRIPTION
Embarrassingly, I hadn't tested #307 very well and it's not very robust. This fix should work better in all circumstances now