### PR TITLE
Fixes #329

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,10 +142,12 @@ if (ENABLE_TESTS)
   enable_testing()
   add_custom_target(build-tests)
 
-  add_custom_target(tests
-    COMMAND ${CMAKE_CTEST_COMMAND}
-    EXCLUDE_FROM_ALL)
-  add_dependencies(tests build-tests)
+  if (NOT TARGET tests)
+    add_custom_target(tests
+      COMMAND ${CMAKE_CTEST_COMMAND}
+      EXCLUDE_FROM_ALL)
+    add_dependencies(tests build-tests)
+  endif ()
 
   add_subdirectory (tests EXCLUDE_FROM_ALL)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  - Fix for OpenMP handling in `PFUNITCmake.cmake`. If you skip OpenMP, it is no
    longer a dependency
- - Allow GFortran to use longer lines.  (Impacts some upstream use cases.)
  - Updated external modules that contain bugfixes.
+ - Fixed cmake logic that fails on enabling tests if using submodules.
+ - Allow GFortran to use longer lines.  (Impacts some upstream use cases.)
 
 ### Changed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,12 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.2.2] - 2021-09-17
+## [4.2.2] - 2021-11-15
 
 ### Fixed
-
  - Fix for OpenMP handling in `PFUNITCmake.cmake`. If you skip OpenMP, it is no
    longer a dependency
+ - Allow GFortran to use longer lines.  (Impacts some upstream use cases.)
+ - Updated external modules that contain bugfixes.
 
 ### Changed
 

--- a/cmake/GNU.cmake
+++ b/cmake/GNU.cmake
@@ -6,7 +6,7 @@ set (cpp "-cpp")
 set (MISMATCH "-fallow-argument-mismatch")
 set(opt "-O0")
 
-set(common_flags "${cpp} ${opt} -ffree-line-length-512")
+set(common_flags "${cpp} ${opt} -ffree-line-length-none")
 if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
   set (common_flags "${common_flags} ${MISMATCH}")
 endif ()


### PR DESCRIPTION
 - Fix for OpenMP handling in `PFUNITCmake.cmake`. If you skip OpenMP, it is no
   longer a dependency
 - Allow GFortran to use longer lines.  (Impacts some upstream use cases.)
 - Updated external modules that contain bugfixes.

 - Changed `OTHER_SRCS` to `OTHER_SOURCES` in PFUNIT.mk.  The previous spelling
   is deprecated, but preserved to keep backwards compatibility.