### PR TITLE
Fix errant CMake for MPI found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project (PFUNIT
-  VERSION 4.2.4
+  VERSION 4.2.5
   LANGUAGES Fortran C)
 
 # Determine if pFUnit is built as a subproject (using
@@ -206,12 +206,12 @@ if (NOT MAIN_PROJECT)
 
   if (BUILD_SHARED_LIBS)
     set (PFUNIT_LIBRARIES PFUNIT::funit_shared PARENT_SCOPE)
-    if (NOT MPI_Fortran_FOUND)
+    if (MPI_Fortran_FOUND)
       set(PFUNIT_LIBRARIES ${PFUNIT_LIBRARIES} PFUNIT::pfunit_shared PARENT_SCOPE)
     endif()
   else()
     set (PFUNIT_LIBRARIES PFUNIT::funit PARENT_SCOPE)
-    if (NOT MPI_Fortran_FOUND)
+    if (MPI_Fortran_FOUND)
       set(PFUNIT_LIBRARIES ${PFUNIT_LIBRARIES} PFUNIT::pfunit PARENT_SCOPE)
     endif()
   endif()

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.5] - 2022-04-06
+
+### Fixed
+
+- Fix erroneous CMake logic from 4.2.4
+
 ## [4.2.4] - 2022-03-18
 
 ### Fixed


### PR DESCRIPTION
This PR fixes a CMake logic bug spotted by @d7919. I didn't spot the fact we went from a "not negative" to a "yes positive" and my search-replace was bad.

