### PR TITLE
CMake: Add option to use MPI F08 module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ option (SKIP_ROBUST "Skip building RobustRunner" NO)
 option (SKIP_ESMF "Skip building ESMF support" YES)
 option (ENABLE_TESTS "Build pFUnit tests" ${MAIN_PROJECT})
 option (ENABLE_BUILD_DOXYGEN "Attempt to build doxygen documentation" NO)
-
+option (ENABLE_MPI_F08 "Use the 'mpi_f08' module." NO)
 
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake" "${PROJECT_SOURCE_DIR}/include")
@@ -85,9 +85,16 @@ if (NOT SKIP_MPI)
   find_package (MPI QUIET)
   if (MPI_Fortran_FOUND)
     message (STATUS "MPI enabled")
+    if (ENABLE_MPI_F08)
+      if (NOT MPI_Fortran_HAVE_F08_MODULE)
+        message (FATAL_ERROR "MPI F08 module requested but not available")
+      else()
+        message (STATUS "MPI F08 module enabled")
+      endif()
+    endif()
   else ()
     message (STATUS "MPI not found; building without MPI")
-  endif()    
+  endif()
 endif()
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Added
+
+- CMake option to use `mpi_f08` interfaces:
+```
+    option (ENABLE_MPI_F08 "Use the 'mpi_f08' module." NO)
+```
+
 ## [4.3.0] - 2022-04-20
 
 ### Fixed

--- a/include/pf_mpi_defines.fh
+++ b/include/pf_mpi_defines.fh
@@ -1,0 +1,11 @@
+! Compatibility macros for `mpi` and `mpi_f08` modules
+
+#if PF_USE_MPI_F08
+#  define PF_MPI_MODULE mpi_f08
+#  define PF_MPI_COMM_TYPE MPI_Comm
+#  define PF_MPI_GROUP_TYPE MPI_Group
+#else
+#  define PF_MPI_MODULE mpi
+#  define PF_MPI_COMM_TYPE integer
+#  define PF_MPI_GROUP_TYPE integer
+#endif

--- a/src/pfunit/CMakeLists.txt
+++ b/src/pfunit/CMakeLists.txt
@@ -8,6 +8,16 @@ if (BUILD_SHARED_LIBS)
   list(APPEND pfunit_targets pfunit_shared)
 endif ()
 
+# Header-only target so we can add MPI defines to both pfunit-core and
+# pfunit. These are definitions that allow compatibility between the
+# `mpi` and `mpi_f08` modules.
+add_library (pfunit-mpi-defines INTERFACE)
+target_include_directories (pfunit-mpi-defines INTERFACE
+  $<BUILD_INTERFACE:${PFUNIT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${dest}/include>
+)
+target_compile_definitions (pfunit-mpi-defines INTERFACE PF_USE_MPI_F08=${ENABLE_MPI_F08})
+
 add_subdirectory (core)
 
 foreach(pfunit_target ${pfunit_targets})
@@ -24,7 +34,8 @@ foreach(pfunit_target ${pfunit_targets})
   target_sources (${pfunit_target} PRIVATE $<TARGET_OBJECTS:pfunit-core>)
   target_sources (${pfunit_target} PRIVATE pFUnit.F90 pfunit_main.F90)
   target_link_libraries (${pfunit_target} PUBLIC funit ${MPI_Fortran_LIBRARIES})
+  target_link_libraries (${pfunit_target} PRIVATE pfunit-mpi-defines)
 
   install (DIRECTORY  ${CMAKE_CURRENT_BINARY_DIR}/mod/ DESTINATION ${dest}/include)
-  install (TARGETS ${pfunit_target} EXPORT PFUNIT DESTINATION ${dest}/lib)
+  install (TARGETS ${pfunit_target} pfunit-mpi-defines EXPORT PFUNIT DESTINATION ${dest}/lib)
 endforeach()

--- a/src/pfunit/core/CMakeLists.txt
+++ b/src/pfunit/core/CMakeLists.txt
@@ -7,6 +7,7 @@ set (srcs
 
 add_library (pfunit-core OBJECT ${srcs})
 target_link_libraries (pfunit-core PUBLIC funit ${MPI_Fortran_LIBRARIES})
+target_link_libraries (pfunit-core PRIVATE pfunit-mpi-defines)
 
 target_include_directories (pfunit-core PUBLIC ${MPI_Fortran_INCLUDE_PATH})
 
@@ -21,4 +22,3 @@ set_target_properties (pfunit-core PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_C
 if (mismatch)
   set_source_files_properties(MpiContext.F90 PROPERTIES COMPILE_FLAGS ${mismatch})
 endif()
-

--- a/src/pfunit/core/MpiContext.F90
+++ b/src/pfunit/core/MpiContext.F90
@@ -21,17 +21,19 @@
 ! 07 Nov 2013 - Added the prologue for the compliance with Doxygen. 
 !
 !-------------------------------------------------------------------------------
+#include "pf_mpi_defines.fh"
+
 module PF_MpiContext
    use PF_ParallelContext
    use PF_ExceptionList, only: throw
-   use mpi
+   use PF_MPI_MODULE
    implicit none
    private
    public :: MpiContext
 
    type, extends(ParallelContext) :: MpiContext
       private
-      integer :: mpiCommunicator = MPI_COMM_NULL
+      type (PF_MPI_COMM_TYPE) :: mpiCommunicator = MPI_COMM_NULL
       integer :: root = 0
    contains
       procedure :: isActive
@@ -69,7 +71,7 @@ contains
    ! Make a duplicate of the communicator for internal use
    function newMpiContext_comm(communicator) result(context)
       type (MpiContext) :: context
-      integer, intent(in) :: communicator
+      type (PF_MPI_COMM_TYPE), intent(in) :: communicator
       integer :: ier
 
       call MPI_Comm_dup(communicator, context%mpiCommunicator, ier)
@@ -119,8 +121,8 @@ contains
 
       integer, parameter :: NUM_SUBGROUPS = 1
       integer :: ranges(3,1)
-      integer :: originalGroup, newGroup
-      integer :: newCommunicator
+      type (PF_MPI_GROUP_TYPE) :: originalGroup, newGroup
+      type (PF_MPI_COMM_TYPE) :: newCommunicator
       integer :: ier
       integer npes
 
@@ -165,7 +167,7 @@ contains
    end subroutine barrier
 
    function getMpiCommunicator(this) result(mpiCommunicator)
-      integer :: mpiCommunicator
+      type (PF_MPI_COMM_TYPE) :: mpiCommunicator
       class (MpiContext), intent(in) :: this
       mpiCommunicator = this%mpiCommunicator
    end function getMpiCommunicator

--- a/src/pfunit/core/MpiTestCase.F90
+++ b/src/pfunit/core/MpiTestCase.F90
@@ -1,4 +1,5 @@
 #include "unused_dummy.fh"
+#include "pf_mpi_defines.fh"
 
 !-------------------------------------------------------------------------------
 ! NASA/GSFC Advanced Software Technology Group
@@ -24,7 +25,7 @@
 !-------------------------------------------------------------------------------
 
 module PF_MpiTestCase
-   use mpi
+   use PF_MPI_MODULE
    use PF_MpiContext
    use PF_TestCase
    use PF_AbstractTestParameter
@@ -112,7 +113,7 @@ contains
    end subroutine runBare
 
    function getMpiCommunicator(this) result(mpiCommunicator)
-      integer :: mpiCommunicator
+      type (PF_MPI_COMM_TYPE) :: mpiCommunicator
       class (MpiTestCase), intent(in) :: this
       mpiCommunicator = this%context%getMpiCommunicator()
    end function getMpiCommunicator

--- a/src/pfunit/core/pFUnit.F90
+++ b/src/pfunit/core/pFUnit.F90
@@ -1,3 +1,5 @@
+#include "pf_mpi_defines.fh"
+
 !-------------------------------------------------------------------------------
 ! NASA/GSFC Advanced Software Technology Group
 !-------------------------------------------------------------------------------
@@ -63,7 +65,7 @@ end module pFUnit_private
 module pFUnit
    use FUnit_private
    use pFUnit_private
-   use mpi
+   use PF_MPI_MODULE
    implicit none
    
    public :: initialize
@@ -109,7 +111,7 @@ contains
 
 
    subroutine finalize(extra_finalize, successful)
-      use mpi
+      use PF_MPI_MODULE
 #ifdef NAG
       use f90_unix_proc, only: exit
 #endif

--- a/src/pfunit/pFUnit.F90
+++ b/src/pfunit/pFUnit.F90
@@ -1,3 +1,5 @@
+#include "pf_mpi_defines.fh"
+
 !-------------------------------------------------------------------------------
 ! NASA/GSFC Advanced Software Technology Group
 !-------------------------------------------------------------------------------
@@ -69,7 +71,7 @@ module pFUnit
    use FUnit, funit_context => get_context
    use FUnit, funit_stub => stub
    use pFUnit_private
-   use mpi
+   use PF_MPI_MODULE
    implicit none
    
    public :: initialize
@@ -119,7 +121,7 @@ contains
 
 
    subroutine finalize(extra_finalize, successful)
-      use mpi
+      use PF_MPI_MODULE
 #ifdef NAG
       use f90_unix_proc, only: exit
 #endif

--- a/tests/pfunit/Test_MpiTestCase.F90
+++ b/tests/pfunit/Test_MpiTestCase.F90
@@ -1,3 +1,5 @@
+#include "pf_mpi_defines.fh"
+
 !#include "reflection.h"
 !-------------------------------------------------------------------------------
 ! NASA/GSFC, Advanced Software Technology Group
@@ -22,7 +24,7 @@
 !
 !-------------------------------------------------------------------------------
 module Test_MpiTestCase
-   use mpi
+   use PF_MPI_MODULE
    use PF_Test
    use PF_TestCase
    use PF_MpiTestCase
@@ -255,7 +257,7 @@ contains
 
    subroutine wasRun(runLog, mpiCommunicator)
       character(len=:), allocatable, intent(inout) :: runLog
-      integer, intent(in) :: mpiCommunicator
+      type (PF_MPI_COMM_TYPE), intent(in) :: mpiCommunicator
       
       integer :: ier
 


### PR DESCRIPTION
Closes #34 

Rather than the `pf_mpi_defines.fh` header, we could instead use add all the definitions directly to the `pf-mpi-defines` target for the same effect. The differences is that with the header we keep the set of "exposed" preprocessor macros minimal.

Note that this also relies on the F2008 ability to do `type (integer)` so that we can do the slightly nicer `type (PF_MPI_COMM_TYPE)`. It is possible to have the macro be `PF_MPI_COMM_TYPE=type(MPI_Comm)/integer` and use `PF_MPI_COMM_TYPE` directly in the code instead.