### PR TITLE
Protect REAL128 in Assert_Complex

### DIFF
--- a/cmake/CheckCompilerCapabilities.cmake
+++ b/cmake/CheckCompilerCapabilities.cmake
@@ -50,7 +50,7 @@ foreach (kind 32 64 80 128 256)
   try_compile (
     code_compiles
     ${CMAKE_BINARY_DIR}
-    ${PROJECT_SOURCE_DIR}/cmake/Trial_sources/REAL_KIND.F90
+    ${PROJECT_SOURCE_DIR}/cmake/Trial_sources/REAL_KIND_IEEE_SUPPORT.F90
     CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=${CMAKE_REQUIRED_DEFINITIONS}")
   
   if (code_compiles)
@@ -61,6 +61,3 @@ foreach (kind 32 64 80 128 256)
   endif ()
 
 endforeach()
-
-
-

--- a/src/funit/asserts/Assert_Complex.tmpl
+++ b/src/funit/asserts/Assert_Complex.tmpl
@@ -99,7 +99,6 @@ module pf_AssertComplex_{rank}d
 #ifdef _ISO_REAL64
    use, intrinsic :: iso_fortran_env, only: REAL64
    use, intrinsic :: iso_fortran_env, only: REAL128
-#endif
    use pf_KeywordEnforcer
    use pf_SourceLocation
    use pf_AssertUtilities

--- a/src/funit/asserts/Assert_Complex.tmpl
+++ b/src/funit/asserts/Assert_Complex.tmpl
@@ -98,8 +98,6 @@ module pf_AssertComplex_{rank}d
 #endif
 #ifdef _ISO_REAL64
    use, intrinsic :: iso_fortran_env, only: REAL64
-#endif
-#ifdef _ISO_REAL128
    use, intrinsic :: iso_fortran_env, only: REAL128
 #endif
    use pf_KeywordEnforcer

--- a/src/funit/asserts/Assert_Complex.tmpl
+++ b/src/funit/asserts/Assert_Complex.tmpl
@@ -94,9 +94,15 @@
 #include "unused_dummy.fh"
 
 module pf_AssertComplex_{rank}d
+#ifdef _ISO_REAL32
    use, intrinsic :: iso_fortran_env, only: REAL32
+#endif
+#ifdef _ISO_REAL64
    use, intrinsic :: iso_fortran_env, only: REAL64
+#endif
+#ifdef _ISO_REAL128
    use, intrinsic :: iso_fortran_env, only: REAL128
+#endif
    use pf_KeywordEnforcer
    use pf_SourceLocation
    use pf_AssertUtilities
@@ -347,4 +353,3 @@ end module pf_AssertComplex_{rank}d
 
 
    
-

--- a/src/funit/asserts/Assert_Complex.tmpl
+++ b/src/funit/asserts/Assert_Complex.tmpl
@@ -94,7 +94,6 @@
 #include "unused_dummy.fh"
 
 module pf_AssertComplex_{rank}d
-#ifdef _ISO_REAL32
    use, intrinsic :: iso_fortran_env, only: REAL32
 #endif
 #ifdef _ISO_REAL64

--- a/src/funit/asserts/Assert_Complex.tmpl
+++ b/src/funit/asserts/Assert_Complex.tmpl
@@ -95,8 +95,6 @@
 
 module pf_AssertComplex_{rank}d
    use, intrinsic :: iso_fortran_env, only: REAL32
-#endif
-#ifdef _ISO_REAL64
    use, intrinsic :: iso_fortran_env, only: REAL64
    use, intrinsic :: iso_fortran_env, only: REAL128
    use pf_KeywordEnforcer


### PR DESCRIPTION
Enables compilation with nvhpc (tested with 22.3).

Maybe related to discussion in #337.