### PR TITLE
Allow passing test arguments to pFUnit tests.

### DIFF
--- a/include/add_pfunit_ctest.cmake
+++ b/include/add_pfunit_ctest.cmake
@@ -16,6 +16,7 @@
 #                   EXTRA_INITIALIZE ...
 #                   EXTRA_FINALIZE ...
 #                   MAX_PES 5
+#                   TEST_ARGS ...
 #                   )
 #
 # TEST_SOURCES items with relative paths are treated as relative to
@@ -44,7 +45,7 @@ include (add_pfunit_sources)
 
 function (add_pfunit_ctest test_package_name)
   set (oneValueArgs REGISTRY MAX_PES EXTRA_USE EXTRA_INITIALIZE EXTRA_FINALIZE)
-  set (multiValueArgs TEST_SOURCES OTHER_SOURCES LINK_LIBRARIES)
+  set (multiValueArgs TEST_SOURCES OTHER_SOURCES LINK_LIBRARIES TEST_ARGS)
   cmake_parse_arguments (PF_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   set (test_sources_f90)
@@ -127,13 +128,13 @@ function (add_pfunit_ctest test_package_name)
     endif()
     add_test (NAME ${test_package_name}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND ${MPIEXEC} ${MPIEXEC_PREFLAGS} ${MPIEXEC_NUMPROC_FLAG} ${PF_TEST_MAX_PES} ${CMAKE_CURRENT_BINARY_DIR}/${test_package_name}
+      COMMAND ${MPIEXEC} ${MPIEXEC_PREFLAGS} ${MPIEXEC_NUMPROC_FLAG} ${PF_TEST_MAX_PES} ${CMAKE_CURRENT_BINARY_DIR}/${test_package_name} ${PF_TEST_TEST_ARGS}
       )
   else()
     target_link_libraries (${test_package_name} ${PFUNIT_SERIAL_LIBRARIES})
     add_test (NAME ${test_package_name}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND ${test_package_name}
+      COMMAND ${test_package_name} ${PF_TEST_TEST_ARGS}
       )
   endif()
 

--- a/include/add_pfunit_test.cmake
+++ b/include/add_pfunit_test.cmake
@@ -14,7 +14,9 @@
 #                set (TEST_SOURCES
 #                   testMyLib.pf
 #                    )
-#                add_pfunit_test (myTests "${TEST_SOURCES} "" "")
+#                set (TEST_ARGS --xml --output ${CMAKE_BINARY_DIR}/testMyLib.xml)
+#
+#                add_pfunit_test (myTests "${TEST_SOURCES} "" "" TEST_ARGS ${TEST_ARGS})
 #                target_link_libraries (myTests myLibrary) #Assuming "myLibrary" is already defined
 #
 #                Compile the tests:   make myTests
@@ -26,6 +28,8 @@ function (add_pfunit_test test_package_name test_sources extra_sources extra_sou
         message (WARNING "No test sources defined for '${test_package_name}', ignoring...")
         return ()
     endif (NOT test_sources)
+
+    cmake_parse_arguments(PF_TEST "" "" TEST_ARGS ${ARGN})
 
     #################################################
     # Preprocessing                                 #
@@ -125,7 +129,7 @@ function (add_pfunit_test test_package_name test_sources extra_sources extra_sou
     #################################################
     add_test (NAME ${test_package_name}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMAND ${test_package_name}
+        COMMAND ${test_package_name} ${PF_TEST_TEST_ARGS}
         )
     set_property (TEST ${test_package_name}
         PROPERTY FAIL_REGULAR_EXPRESSION "Encountered 1 or more failures/errors during testing"


### PR DESCRIPTION
When using add_pfunit_test or add_pfunit_ctest, allow the user to pass test arguments. 

We use this for generating XML output of the tests that can be read by the CI we use, to report back the successful and failed tests in the CI web interface.