### PR TITLE
Restore Python2 compatibility in pFUnitParser.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project (PFUNIT
-  VERSION 4.6.0
+  VERSION 4.6.1
   LANGUAGES Fortran C)
 
 # Determine if pFUnit is built as a subproject (using

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.6.0] 2022-11-07
+## [4.6.1] - 2022-11-15
+
+### Fixed
+
+- Restore Python2 compatibility in `pFUnitParser.py` script
+
+## [4.6.0] - 2022-11-07
 
 ### Added
 

--- a/bin/funit/pFUnitParser.py
+++ b/bin/funit/pFUnitParser.py
@@ -8,7 +8,6 @@ import posixpath
 import re
 # from parseBrackets import parseBrackets
 from .parseDirectiveArgs import parseDirectiveArguments
-from pathlib import Path
 
 class MyError(Exception):
     def __init__(self, value):
@@ -700,8 +699,9 @@ class Parser():
         if (not self.suiteName):
             self.suiteName = self.defaultSuiteName
             mname = self.userModuleName
-            base = Path(self.fileName).stem
-            if mname != base:
+            base = splitext(basename(self.fileName))[0]
+            # As Fortran is not case-sensitive with module names, we use a case-insensitive match
+            if mname.lower() != base.lower():
                 raise Exception("pFUnit preprocessor: module name (" + mname + ") and file name (" + base + ") do not match.")
 
         if ('testParameterType' in self.userTestCase and (not 'constructor' in self.userTestCase)):

--- a/bin/funit/pFUnitParser.py
+++ b/bin/funit/pFUnitParser.py
@@ -702,7 +702,7 @@ class Parser():
             base = splitext(basename(self.fileName))[0]
             # As Fortran is not case-sensitive with module names, we use a case-insensitive match
             if mname.lower() != base.lower():
-                raise Exception("pFUnit preprocessor: module name (" + mname + ") and file name (" + base + ") do not match.")
+                raise Exception("pFUnit preprocessor: module name (" + mname + ") and file name (" + base + ") do not match (ignoring case).")
 
         if ('testParameterType' in self.userTestCase and (not 'constructor' in self.userTestCase)):
             self.userTestCase['constructor'] = self.userTestCase['testParameterType']


### PR DESCRIPTION
`pFUnitParser.py` was inadvertently make Python3 only with the use of the `pathlib` module. While we should all move to Python 3 (and pFUnit 5 might make that a requirement), for now, we return Python2 compatibility by using `os.path` mechanisms.

Also, we make the new matching test case-insensitive. Note as this is done with `.lower()` this is not Unicode safe, but Fortran doesn't really support Unicode in module names, so we are okay.