### PR TITLE
feat: ctest labels

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added option to set labels to ctests
+
 ### Fixed
 
 - Fix GitHub CI workflow by pinning to CMake 3.24.3

--- a/include/add_pfunit_ctest.cmake
+++ b/include/add_pfunit_ctest.cmake
@@ -15,6 +15,7 @@
 #                   EXTRA_USE ...
 #                   EXTRA_INITIALIZE ...
 #                   EXTRA_FINALIZE ...
+#                   LABELS ...
 #                   MAX_PES 5
 #                   WORKING_DIRECTORY working_directory
 #                   )
@@ -45,7 +46,7 @@ include (add_pfunit_sources)
 
 function (add_pfunit_ctest test_package_name)
   set (oneValueArgs REGISTRY MAX_PES EXTRA_USE EXTRA_INITIALIZE EXTRA_FINALIZE WORKING_DIRECTORY)
-  set (multiValueArgs TEST_SOURCES OTHER_SOURCES LINK_LIBRARIES)
+  set (multiValueArgs TEST_SOURCES OTHER_SOURCES LINK_LIBRARIES LABELS)
   cmake_parse_arguments (PF_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   set (test_sources_f90)
@@ -147,5 +148,11 @@ function (add_pfunit_ctest test_package_name)
   set_property (TEST ${test_package_name}
     PROPERTY FAIL_REGULAR_EXPRESSION "Encountered 1 or more failures/errors during testing"
     )
+
+  if (PF_TEST_LABELS)
+    set_property (TEST ${test_package_name}
+      PROPERTY LABELS ${PF_TEST_LABELS}
+    )
+  endif()
 
 endfunction()


### PR DESCRIPTION
CTests offers the functionality to run only or exclude tests with certain labels with -L and -LE, respectively.

I added the possibility to add labels to CTests via the add_pfunit_ctest function with the new multi-argument option LABELS.
