### PR TITLE
fix: verbose ctests

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `--verbose option` is now passed through by ctest runner
 - Fix GitHub CI workflow by pinning to CMake 3.24.3
 
 ## [4.6.1] - 2022-11-15

--- a/include/add_pfunit_ctest.cmake
+++ b/include/add_pfunit_ctest.cmake
@@ -134,13 +134,13 @@ function (add_pfunit_ctest test_package_name)
     endif()
     add_test (NAME ${test_package_name}
       WORKING_DIRECTORY ${workdir}
-      COMMAND ${MPIEXEC} ${MPIEXEC_PREFLAGS} ${MPIEXEC_NUMPROC_FLAG} ${PF_TEST_MAX_PES} ${CMAKE_CURRENT_BINARY_DIR}/${test_package_name}
+      COMMAND ${MPIEXEC} ${MPIEXEC_PREFLAGS} ${MPIEXEC_NUMPROC_FLAG} ${PF_TEST_MAX_PES} ${CMAKE_CURRENT_BINARY_DIR}/${test_package_name} --verbose
       )
   else()
     target_link_libraries (${test_package_name} ${PFUNIT_SERIAL_LIBRARIES})
     add_test (NAME ${test_package_name}
       WORKING_DIRECTORY ${workdir}
-      COMMAND ${test_package_name}
+      COMMAND ${test_package_name} --verbose
       )
   endif()
 


### PR DESCRIPTION
made tests added with add_pfunit_ctest verbose, s.t. --verbose is effectively passed through by ctest.