### PR TITLE
Pin CI to use CMake 3.24.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,6 +127,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      # There is a bug between pFUnit and CMake 3.25.0 which is in ubuntu-latest.
+      # For now, we grab CMake 3.24.3
+      - name: Get specific version CMake, v3.24.3
+        uses: lukka/get-cmake@v3.24.3
       - name: Install Intel compilers
         run: |
           cd /tmp
@@ -143,6 +147,7 @@ jobs:
           ${FC} --version
           ${CC} --version
           mpirun --version
+          cmake --version
       - name: Build pFUnit
         run: |
           mkdir -p build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,10 @@ jobs:
         if: matrix.os == 'ubuntu-22.04' && matrix.compiler == 'gfortran-12'
         run: |
           sudo apt-get install gfortran-12 -y
+      # There is a bug between pFUnit and CMake 3.25.0 which is in ubuntu-latest.
+      # For now, we grab CMake 3.24.3
+      - name: Get specific version CMake, v3.24.3
+        uses: lukka/get-cmake@v3.24.3
       - name: Compiler Versions
         run: |
           ${FC} --version
@@ -92,11 +96,13 @@ jobs:
           mkdir -p build
           cd build
           cmake ..
-          make -j$(nproc)
+          make
+          #make -j$(nproc)
       - name: Build Tests
         run: |
           cd build
-          make -j$(nproc) build-tests
+          make build-tests
+          #make -j$(nproc) build-tests
       - name: Run Tests
         run: |
           cd build

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix GitHub CI workflow by pinning to CMake 3.24.3
+
 ## [4.6.1] - 2022-11-15
 
 ### Fixed


### PR DESCRIPTION
This PR pins pFUnit to use CMake 3.24.3. This is in response to a current bug between CMake 3.25.0 and pFUnit, see https://gitlab.kitware.com/cmake/cmake/-/issues/24203