### PR TITLE
Cmake refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if (NOT SKIP_OPENMP)
     message (STATUS "OpenMP not found - skipping openmp support.")
   endif()
   # Kludge to workaround cmake+NAG+openmp linkage problem
-  if (CMAKE_Fortran_COMPILER_ID MATCHES NAG)
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
     set_property(TARGET OpenMP::OpenMP_Fortran PROPERTY
       INTERFACE_LINK_LIBRARIES "")
     set_property(TARGET OpenMP::OpenMP_Fortran PROPERTY INTERFACE_LINK_OPTIONS "-openmp")

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -3,6 +3,6 @@ add_subdirectory(tests)
 
 install(PROGRAMS funitproc DESTINATION ${dest}/bin)
 
-add_test(unit_test_processor
-         ${Python_EXECUTABLE} -m unittest discover
+add_test(NAME unit_test_processor
+         COMMAND ${Python_EXECUTABLE} -m unittest discover
          --start-directory=${CMAKE_CURRENT_SOURCE_DIR})

--- a/bin/tests/CMakeLists.txt
+++ b/bin/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/outputs)
 file(GLOB test_cases
      RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/inputs
      ${CMAKE_CURRENT_SOURCE_DIR}/inputs/*.pf)
-foreach( case ${test_cases})
+foreach(case IN LISTS test_cases)
   get_filename_component(name ${case} NAME_WE)
 
   set(input_file "${CMAKE_CURRENT_SOURCE_DIR}/inputs/${name}.pf")
@@ -12,11 +12,12 @@ foreach( case ${test_cases})
 
   get_filename_component(executable_file
                          "${CMAKE_CURRENT_SOURCE_DIR}/../funitproc" REALPATH)
-  add_test(processor_test_${name} ${CMAKE_COMMAND}
-           -D Python_EXECUTABLE=${Python_EXECUTABLE}
-           -D executable_file=${executable_file}
-           -D input_file=${input_file}
-           -D output_file=${output_file}
-           -D expected_file=${expected_file}
+  add_test(NAME processor_test_${name}
+           COMMAND ${CMAKE_COMMAND}
+           -DPython_EXECUTABLE=${Python_EXECUTABLE}
+           -Dexecutable_file=${executable_file}
+           -Dinput_file=${input_file}
+           -Doutput_file=${output_file}
+           -Dexpected_file=${expected_file}
            -P ${CMAKE_CURRENT_SOURCE_DIR}/run-test.cmake)
 endforeach()

--- a/cmake/CheckFortranSource.cmake
+++ b/cmake/CheckFortranSource.cmake
@@ -23,7 +23,7 @@ function (CHECK_FORTRAN_SOURCE_RUN file var)
     set(${var} ${${var}} CACHE STRING "" FORCE)
 
   endif()
-  add_definitions(-D${var}=${${var}})
+  add_compile_definitions(${var}=${${var}})
 endfunction (CHECK_FORTRAN_SOURCE_RUN)
 
 
@@ -50,5 +50,5 @@ function (CHECK_FORTRAN_SOURCE_COMPILE file var)
 
     set(${var} ${${var}} CACHE STRING "" FORCE)
   endif()
-  add_definitions(-D${var})
+  add_compile_definitions(${var})
 endfunction (CHECK_FORTRAN_SOURCE_COMPILE)

--- a/cmake/GNU.cmake
+++ b/cmake/GNU.cmake
@@ -14,4 +14,4 @@ endif ()
 set(CMAKE_Fortran_FLAGS_DEBUG "-g ${common_flags} ${traceback}")
 set(CMAKE_Fortran_FLAGS_RELEASE "${common_flags}")
 
-add_definitions(-D_GNU)
+add_compile_definitions(_GNU)

--- a/cmake/Intel.cmake
+++ b/cmake/Intel.cmake
@@ -7,7 +7,7 @@ else()
   set(no_optimize "-O0")
   set(check_all "-check all")
 endif()
-  
+
 
 set(disable_warning_for_long_names "-diag-disable 5462")
 set(traceback "-traceback")
@@ -18,5 +18,5 @@ set(common_flags "${cpp} ${disable_warning_for_long_names}")
 set(CMAKE_Fortran_FLAGS_DEBUG  "-O0 -g ${common_flags} ${traceback} ${no_optimize} ${check_all}")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3 ${common_flags}")
 
-add_definitions(-D_INTEL)
-add_definitions(-D__ifort_18)
+add_compile_definitions(_INTEL)
+add_compile_definitions(__ifort_18)

--- a/cmake/NAG.cmake
+++ b/cmake/NAG.cmake
@@ -12,4 +12,4 @@ set(common_flags "${cpp} -w=x95")
 set(CMAKE_Fortran_FLAGS_DEBUG "${common_flags} -O0 ${check_all} ${traceback}")
 set(CMAKE_Fortran_FLAGS_RELEASE ${common_flags})
 
-add_definitions(-D_NAG)
+add_compile_definitions(_NAG)

--- a/cmake/XL.cmake
+++ b/cmake/XL.cmake
@@ -8,5 +8,4 @@ set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 set(CMAKE_Fortran_FLAGS "-g ${cpp} ${check_all}")
 
-add_definitions(-DIBM)
-
+add_compile_definitions(IBM)

--- a/include/add_pfunit_sources.cmake
+++ b/include/add_pfunit_sources.cmake
@@ -27,13 +27,13 @@
 function( ADD_PFUNIT_SOURCES out_var )
 
   set( out_files )
-  foreach( file ${ARGN} )
+  foreach( file IN LISTS ARGN )
 
     get_filename_component (basename "${file}" NAME_WE)
     get_filename_component( abs_file "${file}" ABSOLUTE )
-    
+
     # replace the extension with .F90 to determine the output file name
-  
+
     if (IS_ABSOLUTE ${file}) # it is in build tree, and out_file is sibling
 
       get_filename_component (file_dir "${file}" DIRECTORY BASE_DIR ${CMAKE_CURRENT_BINARY_DIR})
@@ -56,19 +56,17 @@ function( ADD_PFUNIT_SOURCES out_var )
 
     # append the output file to the list of outputs
     list( APPEND out_files "${out_file}" )
-    
+
     # now add the custom command to generate the output file
     add_custom_command( OUTPUT "${out_file}"
       COMMAND ${PFUNIT_PARSER} "${abs_file}" "${out_file}"
       DEPENDS "${abs_file}"
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       )
-    
+
   endforeach ( )
-  
+
   # set the output list in the calling scope
   set( ${out_var} ${${out_var}} ${out_files} PARENT_SCOPE )
 
 endfunction( ADD_PFUNIT_SOURCES )
-
-

--- a/src/funit/CMakeLists.txt
+++ b/src/funit/CMakeLists.txt
@@ -79,7 +79,7 @@ if (BUILD_SHARED_LIBS)
   list(APPEND funit_targets funit_shared)
 endif()
 
-foreach(funit_target ${funit_targets})
+foreach(funit_target IN LISTS funit_targets)
   set_funit_target_properties(${funit_target})
   funit_target_link_pfunit(${funit_target})
 

--- a/src/funit/asserts/CMakeLists.txt
+++ b/src/funit/asserts/CMakeLists.txt
@@ -18,7 +18,7 @@ function (expand in out)
     )
 endfunction()
 
-foreach(type Logical Integer Real Complex)
+foreach(type IN ITEMS Logical Integer Real Complex)
   foreach(rank RANGE ${MAX_ASSERT_RANK})
     expand (${CMAKE_CURRENT_SOURCE_DIR}/Assert_${type}.tmpl Assert${type}_${rank}d.F90)
   endforeach()

--- a/src/pfunit/CMakeLists.txt
+++ b/src/pfunit/CMakeLists.txt
@@ -23,8 +23,8 @@ endif()
 
 add_subdirectory (core)
 
-foreach(pfunit_target ${pfunit_targets})
-  set_target_properties (${pfunit_target} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)
+foreach(pfunit_target IN LISTS pfunit_targets)
+  set_property (TARGET ${pfunit_target} PROPERTY Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)
 
   target_include_directories (${pfunit_target} PUBLIC ${MPI_Fortran_INCLUDE_PATH})
 

--- a/tests/pfunit/CMakeLists.txt
+++ b/tests/pfunit/CMakeLists.txt
@@ -60,13 +60,13 @@ if (NOT MPI_USE_MPIEXEC)
 endif()
 
 add_test(NAME mpi-tests
-  COMMAND ${MPIEXEC} ${MPIEXEC_PREFLAGS} ${MPIEXEC_NUMPROC_FLAG} 4 ./parallel_tests.x
+  COMMAND ${MPIEXEC} ${MPIEXEC_PREFLAGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:parallel_tests.x>
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 add_dependencies(build-tests parallel_tests.x)
 
 add_test(NAME new_ptests
-  COMMAND ${MPIEXEC} ${MPIEXEC_PREFLAGS} ${MPIEXEC_NUMPROC_FLAG} 4 ./new_ptests.x
+  COMMAND ${MPIEXEC} ${MPIEXEC_PREFLAGS} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:new_ptests.x>
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 set_property (TEST new_ptests


### PR DESCRIPTION
These updates fit with CMake >= 3.12 and avoid hard-coded flags or ambiguous syntax from CMake 2.x era. No change in behavior.