### PR TITLE
Add ifx support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added IntelLLVM.cmake to support ifx
+
 ### Fixed
 
 - Fix GitHub CI workflow by pinning to CMake 3.24.3

--- a/cmake/IntelLLVM.cmake
+++ b/cmake/IntelLLVM.cmake
@@ -1,0 +1,22 @@
+# Compiler specific flags for Intel Fortran compiler
+
+if(WIN32)
+  set(no_optimize "-Od")
+  set(check_all "-check:all")
+else()
+  set(no_optimize "-O0")
+  set(check_all "-check all")
+endif()
+  
+
+set(disable_warning_for_long_names "-diag-disable 5462")
+set(traceback "-traceback")
+set(cpp "-cpp")
+
+
+set(common_flags "${cpp} ${disable_warning_for_long_names}")
+set(CMAKE_Fortran_FLAGS_DEBUG  "-O0 -g ${common_flags} ${traceback} ${no_optimize} ${check_all}")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3 ${common_flags}")
+
+add_definitions(-D_INTEL)
+add_definitions(-D__ifort_18)


### PR DESCRIPTION
This is a draft pull request, I simply copied Intel.cmake to IntelLLVM.cmake. With `ifx (IFORT) 2021.4.0 Beta 20210924` pFUnit does however not compile due to an compilation error in gFTL-shared:

```
/home/reuter/GitProjects/pFUnit_github/extern/fArgParse/extern/gFTL-shared/src/v1/demo.F90(299): error #6197: An assignment of different structure types is invalid.   [INTEGER32INTEGER32_MAP]
   Integer32Integer_map = Integer32Integer32_map
--------------------------^
compilation aborted for /home/reuter/GitProjects/pFUnit_github/extern/fArgParse/extern/gFTL-shared/src/v1/demo.F90 (code 1)
make[2]: *** [extern/fArgParse/extern/gFTL-shared/src/v1/CMakeFiles/demo.x.dir/build.make:75: extern/fArgParse/extern/gFTL-shared/src/v1/CMakeFiles/demo.x.dir/demo.F90.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:980: extern/fArgParse/extern/gFTL-shared/src/v1/CMakeFiles/demo.x.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```