### PR TITLE
Remove explicit CMake in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,10 +59,6 @@ jobs:
         if: matrix.os == 'ubuntu-22.04' && matrix.compiler == 'gfortran-12'
         run: |
           sudo apt-get install gfortran-12 -y
-      # There is a bug between pFUnit and CMake 3.25.0 which is in ubuntu-latest.
-      # For now, we grab CMake 3.24.3
-      - name: Get specific version CMake, v3.24.3
-        uses: lukka/get-cmake@v3.24.3
       - name: Compiler Versions
         run: |
           ${FC} --version
@@ -119,10 +115,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # There is a bug between pFUnit and CMake 3.25.0 which is in ubuntu-latest.
-      # For now, we grab CMake 3.24.3
-      - name: Get specific version CMake, v3.24.3
-        uses: lukka/get-cmake@v3.24.3
       - name: Install Intel compilers
         run: |
           cd /tmp

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix GitHub CI workflow by pinning to CMake 3.24.3
+- Converted GitHub CI to use cmake abstract build commands
 
 ## [4.6.1] - 2022-11-15
 


### PR DESCRIPTION
From what I can tell, GitHub Actions images now have CMake 3.25.1. From my reading of the git log of CMake, this should have the fix for pFUnit's cmake issue seen earlier (see #399). 

This will be a good test!

NOTE: The changelog entry for this is weird as it talks about the changes from @scivision in #403, but until #401 gets in, the changelog isn't enforced.