### PR TITLE
Add macos-12/gcc-12 test and changelog enforcer

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -11,12 +11,12 @@ jobs:
     - uses: dangoslen/changelog-enforcer@v3
       with:
         changeLogPath: 'ChangeLog.md'
-        skipLabels: 'skip changelog'
+        skipLabels: 'Skip Changelog,0 diff trivial,automatic,dependencies,github_actions'
         missingUpdateErrorMessage: >
             No update to ChangeLog.md found! Please add a changelog
             entry to it describing your change.  Please note that the
             keepachangelog (https://keepachangelog.com) format is
             used. If your change is very trivial not applicable for a
-            changelog entry, add a 'skip changelog' label to the pull
+            changelog entry, add a 'Skip Changelog' label to the pull
             request to skip the changelog enforcer.
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,6 @@ jobs:
             compiler: gfortran-9
           - os: macos-12
             compiler: gfortran-10
-          - os: macos-12
-            compiler: gfortran-12
 
       # fail-fast if set to 'true' here is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails


### PR DESCRIPTION
This PR adds the new macos-12/gcc-12 test (now that that image has it), and adds the changelog enforcer