### PR TITLE
Restore consistent behaviour between `*_sources.cmake` and `*_ctest.cmake` 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Restored consistent behaviour for file paths between `add_pfunit_ctest` amd `add_pfunit_sources`.
+  Now the `add_pfunit_ctest` handles relative filepaths (e.g. `./path/to/source.pf`) as described
+  in the script documentation.
+
 ## [4.7.0] - 2023-04-17
 
 ### Changed

--- a/include/add_pfunit_ctest.cmake
+++ b/include/add_pfunit_ctest.cmake
@@ -51,17 +51,18 @@ function (add_pfunit_ctest test_package_name)
 
   set (test_sources_f90)
   set (test_suites_inc "")
-  foreach (pf_file ${PF_TEST_TEST_SOURCES})
 
+  # Create contents of the test_suites files
+  foreach (pf_file ${PF_TEST_TEST_SOURCES})
     get_filename_component (basename ${pf_file} NAME_WE)
-    set (f90_file "${basename}.F90")
-    list (APPEND test_sources_f90 ${f90_file})
     set (test_suites_inc "${test_suites_inc}ADD_TEST_SUITE(${basename}_suite)\n")
-    add_pfunit_sources(test_sources_f90 ${PF_TEST_TEST_SOURCES})
 
   endforeach()
 
-  
+  # Preprocess test files
+  # F90 files are set in test_sources_f90
+  add_pfunit_sources(test_sources_f90 ${PF_TEST_TEST_SOURCES})
+
   if (PF_TEST_EXTRA_USE)
     set(PFUNIT_EXTRA_USE ${PF_TEST_EXTRA_USE})
   endif()


### PR DESCRIPTION
Should resolve issue #426. 
It seems that the it was sufficient to avoid adding basenames to the `test_sources_f90` list before all F90 files are set in `add_pfunit_sources` function  