### PR TITLE
Hotfix/real128 format  fixes #428

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project (PFUNIT
-  VERSION 4.7.0
+  VERSION 4.7.1
   LANGUAGES Fortran C)
 
 cmake_policy(SET CMP0077 NEW)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.7.1] - 2023-06-26
+
+### Fixed
+
+- Increased size of buffer for reporting real values in asserts.   Previous length was not quite enough for some 128 bit values, which resulted in EOR failures during execution.
+
 ## [4.7.0] - 2023-04-17
 
 ### Changed

--- a/src/funit/asserts/Assert_Real.tmpl
+++ b/src/funit/asserts/Assert_Real.tmpl
@@ -187,7 +187,7 @@ module pf_AssertReal_{rank}d
    @overload(assert_relatively_equal, minimal)
 
 
-   integer, parameter :: MAX_LEN_REAL_AS_STRING = 40
+   integer, parameter :: MAX_LEN_REAL_AS_STRING = 45
 
 contains
 


### PR DESCRIPTION
### Fixed

Increased size of buffer for reporting real values in asserts. Previous length was not quite enough for some 128 bit values, which resulted in EOR failures during execution.