### PR TITLE
Cmake error when compiled with BUILD_SHARED_LIB=ON

### DIFF
--- a/src/pfunit/CMakeLists.txt
+++ b/src/pfunit/CMakeLists.txt
@@ -40,5 +40,7 @@ foreach(pfunit_target IN LISTS pfunit_targets)
   target_link_libraries (${pfunit_target} PRIVATE pfunit-mpi-defines)
 
   install (DIRECTORY  ${CMAKE_CURRENT_BINARY_DIR}/mod/ DESTINATION ${dest}/include)
-  install (TARGETS ${pfunit_target} pfunit-mpi-defines EXPORT PFUNIT DESTINATION ${dest}/lib)
+  install (TARGETS ${pfunit_target} EXPORT PFUNIT DESTINATION ${dest}/lib)
 endforeach()
+
+install (TARGETS pfunit-mpi-defines EXPORT PFUNIT DESTINATION ${dest}/lib)


### PR DESCRIPTION
Dear authors,

I ran into this CMake error while compiling with MPI and with `BUILD_SHARED_LIB=ON`.
```
-- MPI enabled
-- OpenMP enabled
-- Using submodule /path/to/pFUnit/extern/fArgParse
-- Using submodule /path/to/pFUnit/extern/fArgParse/extern/gFTL-shared
-- Performing Test _LOGICAL_DEFAULT_KIND: SUCCESS (value=4)
-- Performing Test _INT_DEFAULT_KIND: SUCCESS (value=4)
-- Performing Test _ISO_INT8: SUCCESS (value=1)
-- Performing Test _ISO_INT16: SUCCESS (value=2)
-- Performing Test _ISO_INT32: SUCCESS (value=4)
-- Performing Test _ISO_INT64: SUCCESS (value=8)
-- Performing Test _REAL_DEFAULT_KIND: SUCCESS (value=4)
-- Performing Test _DOUBLE_DEFAULT_KIND: SUCCESS (value=8)
-- Performing Test _ISO_REAL32: SUCCESS (value=4)
-- Performing Test _ISO_REAL64: SUCCESS (value=8)
-- Performing Test _ISO_REAL128: SUCCESS (value=16)
-- Using submodule /path/to/pFUnit/extern/fArgParse/extern/gFTL-shared/extern/gFTL
-- cpp is /usr/bin/cpp
-- Configuring done
CMake Error: install(EXPORT "PFUNIT" ...) includes target "pfunit-mpi-defines" more than once in the export set.
CMake Error: install(EXPORT "PFUNIT" ...) includes target "pfunit-mpi-defines" more than once in the export set.
CMake Error in CMakeLists.txt:
  given target "pfunit-mpi-defines" more than once.


CMake Generate step failed.  Build files cannot be regenerated correctly.
```

This error was caused by installing pfunit-mpi-defines in the foreach loop repeatedly.
This branch fixes the error.
Please consider merging this fix.