### PR TITLE
Hotfix/namespace protect loader module

### DIFF
--- a/include/driver.F90
+++ b/include/driver.F90
@@ -46,7 +46,7 @@ contains
 
    end function load_tests
 
-end pf_module loader
+end module pf_loader
 
 program main
    use FUnit, only : stub

--- a/include/driver.F90
+++ b/include/driver.F90
@@ -14,7 +14,7 @@
 ! runs the user links with FUnit _and_ pFUnit.
 !---------------------------------------------------------------------------
 
-module loader
+module pf_loader
    use FUnit, only: TestSuite
    implicit none
 
@@ -46,11 +46,11 @@ contains
 
    end function load_tests
 
-end module loader
+end pf_module loader
 
 program main
    use FUnit, only : stub
-   use loader
+   use pf_loader
 #ifdef PFUNIT_EXTRA_USE
       ! Use external code for whatever suite-wide fixture is in use.
       use PFUNIT_EXTRA_USE

--- a/include/driver.F90.in
+++ b/include/driver.F90.in
@@ -15,7 +15,7 @@
 !---------------------------------------------------------------------------
 
 #cmakedefine PFUNIT_EXTRA_USE @PFUNIT_EXTRA_USE@
-module loader
+module pf_loader
    use FUnit, only: TestSuite
    implicit none
 
@@ -47,11 +47,11 @@ contains
 
    end function load_tests
 
-end module loader
+end pf_module loader
 
 program main
    use FUnit, only : stub
-   use loader
+   use pf_loader
 #ifdef PFUNIT_EXTRA_USE
       ! Use external code for whatever suite-wide fixture is in use.
       use @PFUNIT_EXTRA_USE@

--- a/include/driver.F90.in
+++ b/include/driver.F90.in
@@ -47,7 +47,7 @@ contains
 
    end function load_tests
 
-end pf_module loader
+end module pf_loader
 
 program main
    use FUnit, only : stub


### PR DESCRIPTION
Workaround for weird CI issue.    Complains about not finding "loader.mod" in downstream project, and am guessing that "loader" is too generic of a name and conflicting with some other use.