### PR TITLE
Add uninit flag for ifx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project (PFUNIT
-  VERSION 4.7.3
+  VERSION 4.7.4
   LANGUAGES Fortran C)
 
 cmake_policy(SET CMP0077 NEW)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.7.4] - 2023-11-01
+
+### Fixed
+
+- Several workarounds added to enable building with gfortran 13.2.   Polymorphic assignment is broken, and must be replaced by `ALLOCATE(obj,source=...)`.  But apparently not everywhere?
+- Add `-check nouninit` for Intel LLVM to work around [`ifx` bug](https://github.com/HPC-Bugs/reproducers/tree/main/compiler/Fortran/ifx/allocatable).
+
 ### Changed
+
 - Updated CI to remove gcc-9 from macOS11 and add gcc-12
 
 ## [4.7.3] - 2023-07-21

--- a/cmake/IntelLLVM.cmake
+++ b/cmake/IntelLLVM.cmake
@@ -5,7 +5,7 @@ if(WIN32)
   set(check_all "-check:all")
 else()
   set(no_optimize "-O0")
-  set(check_all "-check all")
+  set(check_all "-check all,nouninit")
 endif()
   
 


### PR DESCRIPTION
This PR adds the `-check uninit` flag for `ifx` as there is currently a bug with this (see https://github.com/HPC-Bugs/reproducers/tree/main/compiler/Fortran/ifx/allocatable)