### PR TITLE
CMake Bugfix: Set runtime output dir of posix_predefined.x

### DIFF
--- a/src/funit/core/CMakeLists.txt
+++ b/src/funit/core/CMakeLists.txt
@@ -58,6 +58,9 @@ set(srcs
 if (NOT SKIP_ROBUST)
 
   add_executable(posix_predefined.x posix_predefined.c)
+  set_target_properties(posix_predefined.x PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+    )
   set_source_files_properties(posix_predefined.inc PROPERTIES GENERATED TRUE)
   add_custom_command(
     OUTPUT posix_predefined.inc


### PR DESCRIPTION
This fixes a small CMake bug which can lead to `posix_predefined.x` being built in the wrong build subdirectory. If `CMAKE_RUNTIME_OUTPUT_DIRECTORY` is set*, the following lines will fail:

https://github.com/Goddard-Fortran-Ecosystem/pFUnit/blob/49a83b1ff56a953a00468bb783aac31dad1895d1/src/funit/core/CMakeLists.txt#L60-L68

When  `CMAKE_RUNTIME_OUTPUT_DIRECTORY` is set, `posix_predefined.x` will be built somewhere other than `CMAKE_CURRENT_BINARY_DIR`, so the command that produces `posix_predefined.inc` will fail. These changes ensure `posix_predefined.x` will always be built in the correct subdirectory.

I made a little [test repo](https://github.com/LiamPattinson/bugfix_pFUnit_posix_predefined_not_found) while I was trying to figure out what was going wrong, and this demonstrates the bug. It uses either `FetchContent` or Git submodules to load pFUnit.

---

\* In my case, this was being set at a global level by a separate dependency of my project. I normally always prefer to set things like output directories as properties on individual targets, but in this case I'm stuck with it.