### PR TITLE
Add quiet flag for NAG Fortran

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added `-quiet` flag for NAG Fortran
+
 ## [4.9.0] - 2024-02-06
 
 ### Added

--- a/cmake/NAG.cmake
+++ b/cmake/NAG.cmake
@@ -7,7 +7,7 @@ set(check_all "-C=pointer")
 set(cpp "-fpp")
 set(mismatch "-mismatch")
 
-set(common_flags "${cpp} -w=x95")
+set(common_flags "${cpp} -w=x95 -quiet")
 
 set(CMAKE_Fortran_FLAGS_DEBUG "${common_flags} -O0 ${check_all} ${traceback}")
 set(CMAKE_Fortran_FLAGS_RELEASE ${common_flags})


### PR DESCRIPTION
This PR adds `-quiet` to the NAG Fortran compiler flags. This flag will "[s]uppress the compiler banner and the summary line, so that only diagnostic messages will appear."