### PR TITLE
CI: Remove macos-11 and -12, add macos-13, -14; Add ubuntu 24, add gfortran-14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,14 +19,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
-        compiler: [gfortran-10, gfortran-11, gfortran-12, gfortran-13]
-        exclude:
-          - os: macos-13
-            compiler: gfortran-10
-          - os: macos-14
+        compiler: [gfortran-11, gfortran-12, gfortran-13]
+        # gfortran-10 is only on ubuntu-22.04
+        # gfortran-14 is available on ubuntu-24.04
+        include:
+          - os: ubuntu-22.04
             compiler: gfortran-10
           - os: ubuntu-24.04
-            compiler: gfortran-10
+            compiler: gfortran-14
+        exclude:
           - os: ubuntu-24.04
             compiler: gfortran-11
           - os: ubuntu-22.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,10 +93,10 @@ jobs:
         run: cmake -B build
 
       - name: Build pfUnit
-        run: cmake --build build --parallel
+        run: cmake --build build --parallel 4
 
       - name: Build Tests
-        run: cmake --build build --parallel -t build-tests
+        run: cmake --build build --parallel 4 -t build-tests
 
       - name: Run Tests
         run: ctest --test-dir build --parallel 1 --output-on-failure --repeat until-pass:4 --schedule-random

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, macos-13]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
         compiler: [gfortran-10, gfortran-11, gfortran-12, gfortran-13]
         exclude:
-          - os: macos-12
-            compiler: gfortran-10
           - os: macos-13
             compiler: gfortran-10
+          - os: macos-14
+            compiler: gfortran-10
+          - os: ubuntu-24.04
+            compiler: gfortran-10
+          - os: ubuntu-24.04
+            compiler: gfortran-11
+          - os: ubuntu-22.04
+            compiler: gfortran-13
 
       # fail-fast if set to 'true' here is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-11, macos-12]
+        os: [ubuntu-22.04, macos-12, macos-13]
         compiler: [gfortran-10, gfortran-11, gfortran-12, gfortran-13]
         exclude:
-          - os: macos-11
-            compiler: gfortran-13
           - os: macos-12
+            compiler: gfortran-10
+          - os: macos-13
             compiler: gfortran-10
 
       # fail-fast if set to 'true' here is good for production, but when

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Build MPI
         if: steps.cache-mpi.outputs.cache-hit != 'true'
         run: |
-          sh ${GITHUB_WORKSPACE}/tools/ci-install-mpi.sh openmpi 4.1.4
+          sh ${GITHUB_WORKSPACE}/tools/ci-install-mpi.sh openmpi 5.0.2
 
       - name: Set MPI Environment
         run: |

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added `-quiet` flag for NAG Fortran
+- Remove `macos-11` from GitHub Actions, add `macos-12`
 
 ## [4.9.0] - 2024-02-06
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added `-quiet` flag for NAG Fortran
-- Remove `macos-11` from GitHub Actions, add `macos-12`
+- Remove `macos-11` from GitHub Actions, add `macos-12` and `gfortran-14` to Ubuntu 24.04
 
 ### Added
 

--- a/tools/ci-install-mpi.sh
+++ b/tools/ci-install-mpi.sh
@@ -15,7 +15,7 @@ then
    tar xjf ${MPI_IMPL}-${MPI_VER}.tar.bz2 && rm ${MPI_IMPL}-${MPI_VER}.tar.bz2
    cd ${MPI_IMPL}-${MPI_VER}
    ./configure --prefix=${HOME}/local/${MPI_IMPL} --disable-wrapper-rpath --disable-wrapper-runpath --with-hwloc=internal --with-libevent=internal
-   make -j $(nproc)
+   make -j 4
    make install-strip
    cd .. && rm -r ${MPI_IMPL}-${MPI_VER}
    exit 0


### PR DESCRIPTION
As `macos-11` is deprecated at GitHub Actions (and is ancient) and `macos-12` is also old, we remove them and add `macos-13` and `macos-14`.

We also fix up the Ubuntu tests as gcc 13 is no longer in Ubuntu 22

Finally, we add `gfortran-14` to the CI for Ubuntu 24