### PR TITLE
Draft: Update pFUnit to use v2 template interfaces

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated pFUnit to use v2 template interfaces
 - Added `-quiet` flag for NAG Fortran
 
 ### Added

--- a/src/funit/CMakeLists.txt
+++ b/src/funit/CMakeLists.txt
@@ -22,15 +22,15 @@ function(funit_target_link_pfunit funit_target)
     target_link_libraries (${funit_target} PUBLIC OpenMP::OpenMP_Fortran)
   endif ()
 
-  if (NOT TARGET GFTL::gftl)
+  if (NOT TARGET GFTL::gftl-v2)
     message(FATAL_ERROR "Could not find gFTL. This should not happen.")
   endif ()
 
-  if (NOT TARGET GFTL_SHARED::gftl-shared)
+  if (NOT TARGET GFTL_SHARED::gftl-shared-v2)
     message(FATAL_ERROR "Could not find gFTL-shared. This should not happen.")
   endif ()
 
-  target_link_libraries (${funit_target} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared FARGPARSE::fargparse)
+  target_link_libraries (${funit_target} PUBLIC GFTL::gftl-v2 GFTL_SHARED::gftl-shared-v2 GFTL_SHARED::gftl-shared-v2-as-default FARGPARSE::fargparse)
   target_include_directories(${funit_target} PUBLIC
     $<BUILD_INTERFACE:${PFUNIT_SOURCE_DIR}/include>
     )

--- a/src/funit/core/AbstractPattern.F90
+++ b/src/funit/core/AbstractPattern.F90
@@ -25,11 +25,11 @@ end module PF_AbstractPattern
 
 module PF_AbstractPatternVector
    use PF_AbstractPattern
-#define _type class (AbstractPattern)
-#define _allocatable
-#define _vector AbstractPatternVector
-#define _iterator AbstractPatternVectorIterator
+#define T AbstractPattern
+#define T_polymorphic
+#define Vector AbstractPatternVector
+#define VectorIterator AbstractPatternVectorIterator
 
-#include "templates/vector.inc"
+#include "vector/template.inc"
 
 end module PF_AbstractPatternVector

--- a/src/funit/core/ExceptionList.F90
+++ b/src/funit/core/ExceptionList.F90
@@ -102,10 +102,10 @@ contains
 
       iter = this%begin()
       do while (iter /= this%end())
-         e => iter%get()
+         e => iter%of()
          if (e%getMessage() == message) then
             found = .true.
-            if (.not. preserveMessage(preserve)) call this%erase(iter)
+            if (.not. preserveMessage(preserve)) iter = this%erase(iter)
             return
          end if
          call iter%next()
@@ -119,6 +119,7 @@ contains
       class (ExceptionList), intent(inOut) :: this
       logical, optional, intent(in) :: preserve
       type (Exception) :: anException
+      type (ExceptionVectorIterator) :: iter
 
       
       if (.not. this%empty()) then
@@ -134,7 +135,7 @@ contains
 #endif
          if (preserveMessage(preserve)) return
          
-         call this%erase(this%begin())
+         iter = this%erase(this%begin())
       end if
 
    end function catch_next

--- a/src/funit/core/ExceptionVector.F90
+++ b/src/funit/core/ExceptionVector.F90
@@ -1,10 +1,10 @@
 module PF_ExceptionVector
    use PF_Exception
    
-#define _type class(Exception)
-#define _allocatable
-#define _vector ExceptionVector
-#define _iterator ExceptionVectorIterator
-#include "templates/vector.inc"
+#define T Exception
+#define T_polymorphic
+#define Vector ExceptionVector
+#define VectorIterator ExceptionVectorIterator
+#include "vector/template.inc"
 
 end module PF_ExceptionVector

--- a/src/funit/core/TestAnnotation.F90
+++ b/src/funit/core/TestAnnotation.F90
@@ -24,13 +24,12 @@ end module pf_TestAnnotation
 module pf_StringTestAnnotationMap
    use pf_TestAnnotation
 
-#define _map StringTestAnnotationMap
-#define _iterator StringTestAnnotationMapIterator
-#define _pair StringTestAnnotationPair
-#include "types/key_deferredLengthString.inc"
-#define _value_allocatable
-#define _value class(TestAnnotation)
-#define _alt
-#include "templates/map.inc"
+#define Map StringTestAnnotationMap
+#define MapIterator StringTestAnnotationMapIterator
+#define Pair StringTestAnnotationPair
+#define Key __CHARACTER_DEFERRED
+#define T TestAnnotation
+#define T_polymorphic
+#include "map/template.inc"
 
 end module pf_StringTestAnnotationMap

--- a/src/funit/core/TestFailureVector.F90
+++ b/src/funit/core/TestFailureVector.F90
@@ -1,8 +1,13 @@
 module PF_TestFailureVector
    use PF_TestFailure
-#define _type type (TestFailure)
-#define _vector TestFailureVector
-#define _iterator TestFailureVectorIterator
-#include "templates/vector.inc"
+!#define _type type (TestFailure)
+!#define _vector TestFailureVector
+!#define _iterator TestFailureVectorIterator
+!#include "templates/vector.inc"
+
+#define T TestFailure
+#define Vector TestFailureVector
+#define VectorIterator TestFailureVectorIterator
+#include "vector/template.inc"
 
 end module PF_TestFailureVector

--- a/src/funit/core/TestListenerVector.F90
+++ b/src/funit/core/TestListenerVector.F90
@@ -1,9 +1,9 @@
 module PF_TestListenerVector
    use PF_TestListener
-#define _type class (TestListener)
-#define _allocatable
-#define _vector TestListenerVector
-#define _iterator TestListenerVectorIterator
-#include "templates/vector.inc"
+#define T TestListener
+#define T_polymorphic
+#define Vector TestListenerVector
+#define VectorIterator TestListenerVectorIterator
+#include "vector/template.inc"
 
 end module PF_TestListenerVector

--- a/src/funit/core/TestSuite.F90
+++ b/src/funit/core/TestSuite.F90
@@ -189,7 +189,7 @@ contains
       
       iter = this%tests%begin()
       do while (iter /= this%tests%end())
-         t => iter%get()
+         t => iter%of()
 
          select type (t)
          class is (TestSuite)

--- a/src/funit/core/TestVector.F90
+++ b/src/funit/core/TestVector.F90
@@ -1,9 +1,9 @@
 module PF_TestVector
    use PF_Test
-#define _type class (Test)
-#define _allocatable
-#define _vector TestVector
-#define _iterator TestVectorIterator
-#include "templates/vector.inc"
+#define T Test
+#define T_polymorphic
+#define Vector TestVector
+#define VectorIterator TestVectorIterator
+#include "vector/template.inc"
 
 end module PF_TestVector

--- a/src/funit/fhamcrest/AllOf.F90
+++ b/src/funit/fhamcrest/AllOf.F90
@@ -89,7 +89,7 @@ contains
 
     iter = this%matchers%begin()
     do while (iter /= this%matchers%end())
-       matcher => iter%get()
+       matcher => iter%of()
        if (.not. matcher%matches(actual_value)) then
           matches = .false.
           return
@@ -120,7 +120,7 @@ contains
     allocate(matchers_as_SelfDescribing) ! ensure empty at each iteration
     iter = this%matchers%begin()
     do while (iter /= this%matchers%end())
-       call matchers_as_SelfDescribing%push_back(iter%get())
+       call matchers_as_SelfDescribing%push_back(iter%of())
        call iter%next()
     end do
 

--- a/src/funit/fhamcrest/AnyOf.F90
+++ b/src/funit/fhamcrest/AnyOf.F90
@@ -93,7 +93,7 @@ contains
 
     iter = this%matchers%begin()
     do while (iter /= this%matchers%end())
-       matcher => iter%get()
+       matcher => iter%of()
        if (matcher%matches(actual_value)) then
           matches = .true.
           return
@@ -125,7 +125,7 @@ contains
     allocate(matchers_as_SelfDescribing) ! ensure empty at each iteration
     iter = this%matchers%begin()
     do while (iter /= this%matchers%end())
-       call matchers_as_SelfDescribing%push_back(iter%get())
+       call matchers_as_SelfDescribing%push_back(iter%of())
        call iter%next()
     end do
 

--- a/src/funit/fhamcrest/BaseDescription.F90
+++ b/src/funit/fhamcrest/BaseDescription.F90
@@ -246,7 +246,7 @@ contains
       iter = values%begin()
       do while (iter /= values%end())
          if (separate) call this%append(separator)
-         call this%append_description_of(iter%get())
+         call this%append_description_of(iter%of())
          separate = .true.
          call iter%next()
       end do

--- a/src/funit/fhamcrest/MatcherVector.F90
+++ b/src/funit/fhamcrest/MatcherVector.F90
@@ -1,16 +1,17 @@
 module pf_MatcherVector
   use pf_AbstractMatcher
 
-#define _type class(AbstractMatcher)
-#define _vector MatcherVector
-#define _vectorIterator MatcherVectorIterator
-#define _allocatable
+#define T AbstractMatcher
+#define T_polymorphic
+#define Vector MatcherVector
+#define VectorIterator MatcherVectorIterator
 
-#include "templates/vector.inc"
+#include "vector/template.inc"
 
-#undef _allocatable
-#undef _vectorIterator
-#undef _vector
-#undef _type
-  
+#undef VectorIterator
+#undef Vector
+#undef T_polymorphic
+#undef T
+
+
 end module pf_MatcherVector

--- a/src/funit/fhamcrest/SelfDescribingVector.F90
+++ b/src/funit/fhamcrest/SelfDescribingVector.F90
@@ -1,16 +1,16 @@
 module pf_SelfDescribingVector
   use pf_SelfDescribing
 
-#define _type class(SelfDescribing)
-#define _vector SelfDescribingVector
-#define _vectorIterator SelfDescribingVectorIterator
-#define _allocatable
+#define T SelfDescribing
+#define T_polymorphic
+#define Vector SelfDescribingVector
+#define VectorIterator SelfDescribingVectorIterator
 
-#include "templates/vector.inc"
+#include "vector/template.inc"
 
-#undef _allocatable
-#undef _vectorIterator
-#undef _vector
-#undef _type
-  
+#undef VectorIterator
+#undef Vector
+#undef T_polymorphic
+#undef T
+
 end module pf_SelfDescribingVector


### PR DESCRIPTION
This adds the changes needed for pFUnit to build using the v2 versions of the template interfaces.

Note that this PR depends on Goddard-Fortran-Ecosystem/fArgParse#142 and will not build without it.

Resolves #463.