### PR TITLE
Update CI - 2024-Aug-22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Cache MPI
         id: cache-mpi
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/local/openmpi
           key: mpi-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,6 +235,13 @@ jobs:
     container: gmao/llvm-flang-openmpi:latest
     env:
       FC: flang-new
+      LANGUAGE: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+      LC_TYPE: en_US.UTF-8
+      OMPI_ALLOW_RUN_AS_ROOT: 1
+      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+      OMPI_MCA_btl_vader_single_copy_mechanism: none
 
     name: Flang
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,3 +230,52 @@ jobs:
           path: |
             build/**/*.log
 
+  Flang:
+    runs-on: ubuntu-latest
+    container: gmao/llvm-flang-openmpi:latest
+    env:
+      FC: flang-new
+
+    name: Flang
+    steps:
+      - name: Versions
+        run: |
+          ${FC} --version
+          cmake --version
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set all directories as git safe
+        run: |
+          git config --global --add safe.directory '*'
+
+      - name: Add python-is-python3 package
+        run: |
+          apt-get update
+          apt-get install -y python-is-python3
+
+      - name: Configure pFUnit
+        run: cmake -B build
+
+      - name: Build pfUnit
+        run: cmake --build build --parallel
+
+      - name: Build Tests
+        run: |
+          cmake --build build --parallel 4 --target build-tests
+          cmake --build build --parallel 4 --target tests
+
+      - name: Run Ctest
+        run: ctest --test-dir build --parallel 1 --output-on-failure --repeat until-pass:4
+
+      - name: Archive log files on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: logfiles
+          path: |
+            build/**/*.log
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,19 +19,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
-        compiler: [gfortran-11, gfortran-12, gfortran-13]
-        # gfortran-10 is only on ubuntu-22.04
-        # gfortran-14 is available on ubuntu-24.04
+        compiler: [gfortran-12, gfortran-13, gfortran-14]
+        # gfortran-10 and -11 are only on ubuntu-22.04
+        # gfortran-13 and -14 are not on ubuntu-22.04
         include:
           - os: ubuntu-22.04
             compiler: gfortran-10
-          - os: ubuntu-24.04
-            compiler: gfortran-14
-        exclude:
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             compiler: gfortran-11
+        exclude:
           - os: ubuntu-22.04
             compiler: gfortran-13
+          - os: ubuntu-22.04
+            compiler: gfortran-14
 
       # fail-fast if set to 'true' here is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails
@@ -113,7 +113,7 @@ jobs:
             build/**/*.log
 
   Intel:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
       FC: ifx
@@ -182,8 +182,8 @@ jobs:
             build/**/*.log
 
   Nvidia:
-    runs-on: ubuntu-20.04
-    container: nvcr.io/nvidia/nvhpc:24.1-devel-cuda12.3-ubuntu22.04
+    runs-on: ubuntu-22.04
+    container: nvcr.io/nvidia/nvhpc:24.7-devel-cuda12.5-ubuntu22.04
     env:
       FC: nvfortran
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -209,7 +209,7 @@ jobs:
           apt-get install -y python-is-python3
 
       - name: Configure pFUnit
-        run: cmake -B build
+        run: cmake -B build -DSKIP_ROBUST=ON
 
       - name: Build pfUnit
         run: cmake --build build --parallel

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update CI to have `gfortran-10` and `gfortran-11` only on `ubuntu-22.04`
+- Update CI NVIDIA to NVHPC 24.7
+
 ## [4.10.0] - 2024-07-10
 
 ### Changed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update CI to have `gfortran-10` and `gfortran-11` only on `ubuntu-22.04`
 - Update CI NVIDIA to NVHPC 24.7
+- Add Flang to CI
 
 ## [4.10.0] - 2024-07-10
 


### PR DESCRIPTION

This PR updates the CI to remove `gfortran-11` from the general matrix. Now only `ubuntu-22.04` supports `gfortran-10` and `gfortran-11`. The other images only support `gfortran-12` and higher. Moreover, `ubuntu-22.04` does not support `gfortran-13` and `gfortran-14`.

We also update the NVIDIA CI image to 24.7