### PR TITLE
Update minimum CMake version in subdirectories to 3.12.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated minimum required CMake version to 3.12 in tests/ to match main CMakeLists.txt and documentation. Previously set to 3.0 which is now deprecated and was causing build issues.
+
 ## [4.11.1] - 2025-02-04
 
 ### Fixed

--- a/tests/fhamcrest/CMakeLists.txt
+++ b/tests/fhamcrest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 
 set(pf_tests
   Test_Core.pf

--- a/tests/funit-core/CMakeLists.txt
+++ b/tests/funit-core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 
 #include_directories (${PFUNIT_SOURCE_DIR}/include)
 #include_directories (${PFUNIT_BINARY_DIR}/src)


### PR DESCRIPTION
I recently experienced failure on a long-standing workflow (Ubuntu on GitHub) due to the CMake version being set too low (3.0) now deprecated in some files (`tests/fhamcrest/CMakeLists.txt` and `tests/funit-core/CMakeLists.txt`).

This PR updates the minimum version to `3.12` to match that in the main CMakeLists.txt and the minimum version specified by pFUnit's documentation.

I have tested my fork in the failing workflow (instead of cloning from Goddard) and can confirm it resolves the issues seen.
For reference the PR to our repository in which I do this is [here](https://github.com/Cambridge-ICCS/FTorch/pull/351)