### PR TITLE
Update CMake minimum version to 3.24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         compiler: [gfortran-12, gfortran-13, gfortran-14]
         # gfortran-10 and -11 are only on ubuntu-22.04
         # gfortran-13 and -14 are not on ubuntu-22.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 #   cmake <path-to-source> [<options>]
 #
 # ------------------------------------------------------------------------ #
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.24)
 
 project (PFUNIT
   VERSION 4.12.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update CMake minimum version to 3.24 to match other GFE repos
+- Update CI to use `macos-15`, remove `macos-13`
 
 ## [4.12.0] - 2025-04-07
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update CMake minimum version to 3.24 to match other GFE repos
+
 ## [4.12.0] - 2025-04-07
 
 ### Changed

--- a/tests/fhamcrest/CMakeLists.txt
+++ b/tests/fhamcrest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.24)
 
 set(pf_tests
   Test_Core.pf

--- a/tests/funit-core/CMakeLists.txt
+++ b/tests/funit-core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.24)
 
 #include_directories (${PFUNIT_SOURCE_DIR}/include)
 #include_directories (${PFUNIT_BINARY_DIR}/src)


### PR DESCRIPTION
This PR updates the CMake minimum version to 3.24. We choose this as internal use of GFE with MAPL uses 3.24 so we update here for consistency.

NOTE: This is sort of "above and beyond" #488 from @jatkinson1000 . However, internally with MAPL we set our CMake minimum to 3.24, so we are updating all of GFE for consistency.