### PR TITLE
Fix windows line markers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix handling of forward/backward slashes in the parser on Windows when using the usual Python Windows release (worked only with Python through MinGW before)
+
 ## [4.12.0] - 2025-04-07
 
 ### Changed

--- a/bin/funit/pFUnitParser.py
+++ b/bin/funit/pFUnitParser.py
@@ -24,7 +24,7 @@ assert_operands = {'fail': 0, 'equal': 2, 'notequal': 2, 'true': 1, 'false': 1,
                    'exceptionraised': 0, 'sameshape': 2, 'that': 2, '_that': 2}
 
 def cppSetLineAndFile(line, file):
-    if sysconfig.get_platform() == 'mingw':
+    if sysconfig.get_platform() == 'mingw' or sysconfig.get_platform().startswith('win-'):
         return "#line " + str(line) + ' "' + file.replace(sep,posixpath.sep) + '"\n'
     else:
         return "#line " + str(line) + ' "' + file + '"\n'


### PR DESCRIPTION
In our Windows setup, python `sysconfig.get_platform()` results in `win-amd64`.
So we get the wrong path separator in generated source files (`\` instead of `/`) which leads to compiler errors.