### PR TITLE
Make stops explicit about their return code

### DIFF
--- a/src/funit/FUnit.F90
+++ b/src/funit/FUnit.F90
@@ -168,7 +168,11 @@ contains
 #if defined(PGI)
          call exit(-1)
 #else
-         stop '*** Encountered 1 or more failures/errors during testing. ***'
+         write( &
+            output_unit, &
+            '("*** Encountered 1 or more failures/errors during testing ***")' &
+         )
+         stop 2
 #endif
       end if
 
@@ -180,7 +184,7 @@ contains
 
       if (use_mpi) then
          print*,'Cannot use MPI - need to link with pFUnit not FUnit.'
-         stop
+         stop 1
       end if
       context = SerialContext()
    end function get_context

--- a/src/funit/core/RemoteRunner.F90
+++ b/src/funit/core/RemoteRunner.F90
@@ -38,6 +38,9 @@
 ! -----------------------------------------------------------------------
 
 module PF_RemoteRunner
+
+   use, intrinsic :: iso_fortran_env, only : error_unit
+
    use PF_Test
    use PF_BaseTestRunner
    use, intrinsic :: iso_c_binding, only: C_NULL_CHAR
@@ -111,7 +114,9 @@ contains
       class is (TestCase)
          call testCaseList%push_back(aTest)
       class default
-         stop
+         write( error_unit, &
+                '("Unexpected child passsed to RemotetRunner%run")' )
+         stop 1
       end select
 
       result = TestResult()

--- a/src/funit/core/RobustRunner.F90
+++ b/src/funit/core/RobustRunner.F90
@@ -23,6 +23,9 @@
 !
 !-------------------------------------------------------------------------------
 module PF_RobustRunner
+
+   use, intrinsic :: iso_fortran_env, only : error_unit
+
    use PF_Test
    use PF_TestCase
    use PF_BaseTestRunner
@@ -164,7 +167,9 @@ contains
       class is (TestCase)
          call testCases%push_back(aTest)
       class default
-         stop
+         write( error_unit, &
+                '("Unexpected child passed to RobustRunner%runWithResult")' )
+         stop 1
       end select
 
       needs_launch = .true.

--- a/src/pfunit/core/pFUnit.F90
+++ b/src/pfunit/core/pFUnit.F90
@@ -63,6 +63,9 @@ end module pFUnit_private
 !
 !-------------------------------------------------------------------------------
 module pFUnit
+
+   ise intrinsic :: iso_fortran_env, only : error_unit
+
    use FUnit_private
    use pFUnit_private
    use PF_MPI_MODULE
@@ -82,7 +85,10 @@ contains
       integer :: error
 
       call mpi_init(error)
-      if (error /= MPI_SUCCESS) stop
+      if (error /= MPI_SUCCESS) then
+         write( error_unit, '("MPI failed to initialise.")' )
+         stop 1
+      end if
 
       call funit_initialize(extra_initialize)
 
@@ -135,7 +141,7 @@ contains
          print*,'THIS NEEDS FIXING - must call extra_finalize() on all ranks.'
          call funit_finalize(extra_finalize, allSuccessful)
       else
-         stop
+         stop 0
       end if
 
    end subroutine finalize

--- a/src/pfunit/pFUnit.F90
+++ b/src/pfunit/pFUnit.F90
@@ -63,6 +63,9 @@ end module pFUnit_private
 !
 !-------------------------------------------------------------------------------
 module pFUnit
+
+   use, intrinsic :: iso_fortran_env, only : error_unit
+
    ! Rename overlapping entities to avoid name conflicts
    ! Cannot use ONLY, because the list will change over time.
    use FUnit, funit_initialize => initialize
@@ -88,7 +91,10 @@ contains
       integer :: error
 
       call mpi_init(error)
-      if (error /= MPI_SUCCESS) stop
+      if (error /= MPI_SUCCESS) then
+         write( error_unit, '("MPI failed to initialise")' )
+         stop 1
+      end if
 
       call funit_initialize(extra_initialize)
 

--- a/tests/funit-core/robustTestSuite.F90
+++ b/tests/funit-core/robustTestSuite.F90
@@ -78,7 +78,7 @@ contains
    ! This will stop the framework cold.  The robust runner
    ! should detect this - reporting it as an Error.
    subroutine runStops()
-      stop
+      stop 0
    end subroutine runStops
 
    ! This test will hang.  The robust runner


### PR DESCRIPTION
In order to integrate pFUnit into C.I. systems it needs to return a non-zero code when tests fail. Otherwise the C.I. system believes everything was fine.

This change makes return codes explicit where `stop` is called and when tests fail or error it flags a fault condition with a non-zero value.

I have chosen values of 1 to indicate internal errors such as MPI not initialising and 2 for test problems. Just in case anyone cares to know the difference.