### PR TITLE
Fixes for ifx 2025.2 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
-        compiler: [gfortran-12, gfortran-13, gfortran-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
+        compiler: [gfortran-12, gfortran-13, gfortran-14, gfortran-15]
         # gfortran-10 and -11 are only on ubuntu-22.04
-        # gfortran-13 and -14 are not on ubuntu-22.04
+        # gfortran-13, -14, and -15 are not on ubuntu-22.04
+        # gfortran-15 is only on macos
         include:
           - os: ubuntu-22.04
             compiler: gfortran-10
@@ -34,6 +35,10 @@ jobs:
             compiler: gfortran-13
           - os: ubuntu-22.04
             compiler: gfortran-14
+          - os: ubuntu-22.04
+            compiler: gfortran-15
+          - os: ubuntu-24.04
+            compiler: gfortran-15
 
       # fail-fast if set to 'true' here is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Alter CMake in `add_pfunit_test.cmake` and `add_pfunit_ctest.cmake` to workaround ifx 2025.2 preprocessor bug
 
+### Changed
+
+- Remove `macos-13` from CI, add `macos-15`
+- Add `gfortran-15` for macOS CI
+
 ## [4.12.0] - 2025-04-07
 
 ### Changed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Alter CMake in `add_pfunit_test.cmake` and `add_pfunit_ctest.cmake` to workaround ifx 2025.2 preprocessor bug
+
 ## [4.12.0] - 2025-04-07
 
 ### Changed

--- a/include/add_pfunit_ctest.cmake
+++ b/include/add_pfunit_ctest.cmake
@@ -97,7 +97,7 @@ function (add_pfunit_ctest test_package_name)
     endif (${should_write_inc_file})
   endif ()
 
-  target_compile_definitions (${test_package_name} PRIVATE -D_TEST_SUITES="${test_suite_inc_file}")
+  target_compile_definitions (${test_package_name} PRIVATE _TEST_SUITES=\<${test_suite_inc_file}\>)
   target_include_directories (${test_package_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
   if (PF_TEST_EXTRA_USE)

--- a/include/add_pfunit_test.cmake
+++ b/include/add_pfunit_test.cmake
@@ -102,7 +102,7 @@ function (add_pfunit_test test_package_name test_sources extra_sources extra_sou
     target_include_directories (${test_package_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/include/${test_package_name})
 
     # Define TestSuites
-    target_compile_definitions (${test_package_name} PRIVATE -D_TEST_SUITES="${TEST_SUITE_INC_FILE}")
+    target_compile_definitions (${test_package_name} PRIVATE _TEST_SUITES=\<${TEST_SUITE_INC_FILE}\>)
 
     # Test utility preprocessing
     set_property ( SOURCE ${PFUNIT_TESTUTILS}


### PR DESCRIPTION
This PR has a CMake workaround for an ifx 2025.2 bug in their preprocessor, see https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/td-p/1703735

This bug will be fixed in ifx 2025.3, but there is a need to get ifx 2025.2 working (as it fixes bugs in other repos, e.g., fms).

Note: This should be taken in concert with:

- https://github.com/Goddard-Fortran-Ecosystem/yaFyaml/pull/88
- https://github.com/Goddard-Fortran-Ecosystem/pFlogger/pull/145

cc: @climbfuji

---

As GitHub will soon drop support for macOS 13, we are updating our CI workflows to use macOS 15. Additionally, we are adding support for gfortran-15 to ensure compatibility with the latest Fortran compiler.