### PR TITLE
Fixes for LLVM Flang

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix parser on Windows for paths with different drive letters
 - Updates for CMake versions newer than 3.30.
 - Update NVHPC CI (build only)
+- Fix CMake for LLVM Flang
 
 ## [4.13.0] - 2025-09-30
 

--- a/include/add_pfunit_ctest.cmake
+++ b/include/add_pfunit_ctest.cmake
@@ -97,7 +97,13 @@ function (add_pfunit_ctest test_package_name)
     endif (${should_write_inc_file})
   endif ()
 
-  target_compile_definitions (${test_package_name} PRIVATE _TEST_SUITES=\<${test_suite_inc_file}\>)
+  # LLVM Flang apparently does not like the <...> syntax for includes?
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+    target_compile_definitions (${test_package_name} PRIVATE _TEST_SUITES="${test_suite_inc_file}")
+  else()
+    target_compile_definitions (${test_package_name} PRIVATE _TEST_SUITES=\<${test_suite_inc_file}\>)
+  endif()
+
   target_include_directories (${test_package_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
   if (PF_TEST_EXTRA_USE)

--- a/include/add_pfunit_test.cmake
+++ b/include/add_pfunit_test.cmake
@@ -102,7 +102,11 @@ function (add_pfunit_test test_package_name test_sources extra_sources extra_sou
     target_include_directories (${test_package_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/include/${test_package_name})
 
     # Define TestSuites
-    target_compile_definitions (${test_package_name} PRIVATE _TEST_SUITES=\<${TEST_SUITE_INC_FILE}\>)
+    if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+      target_compile_definitions (${test_package_name} PRIVATE _TEST_SUITES="${test_suite_inc_file}")
+    else()
+      target_compile_definitions (${test_package_name} PRIVATE _TEST_SUITES=\<${test_suite_inc_file}\>)
+    endif()
 
     # Test utility preprocessing
     set_property ( SOURCE ${PFUNIT_TESTUTILS}


### PR DESCRIPTION
Closes #508 

I think a fix added for ifx has now broken flang. Weirdly, all other compilers were happy with the `<>` way of include, but not flang? 