### PR TITLE
Build and run tests only if ENABLE_TESTS=ON

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
         # gfortran-10 and -11 are only on ubuntu-22.04
         # gfortran-13, -14, and -15 are not on ubuntu-22.04
         # gfortran-15 is only on macos
+        # gfortran-12 is not on macos
         include:
           - os: ubuntu-22.04
             compiler: gfortran-10
@@ -39,6 +40,10 @@ jobs:
             compiler: gfortran-15
           - os: ubuntu-24.04
             compiler: gfortran-15
+          - os: macos-14
+            compiler: gfortran-12
+          - os: macos-15
+            compiler: gfortran-12
 
       # fail-fast if set to 'true' here is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,24 +156,26 @@ if (ENABLE_BUILD_DOXYGEN)
   add_subdirectory(documentation)
 endif()
 
-if (NOT TARGET build-tests)
-  add_custom_target(build-tests)
+if (ENABLE_TESTS)
+  if (NOT TARGET build-tests)
+    add_custom_target(build-tests)
+  endif()
+
+  if (NOT TARGET tests)
+    add_custom_target(tests
+      COMMAND ${CMAKE_CTEST_COMMAND}
+      EXCLUDE_FROM_ALL)
+  endif ()
+  add_dependencies(tests build-tests)
+  add_subdirectory (tests EXCLUDE_FROM_ALL)
+
+  # The following forces tests to be built when using "make ctest" even if some targets
+  # are EXCLUDE_FROM_ALL
+  # From https://stackoverflow.com/questions/733475/cmake-ctest-make-test-doesnt-build-tests/56448477#56448477
+  build_command(CTEST_CUSTOM_PRE_TEST TARGET build-tests)
+  string(CONFIGURE \"@CTEST_CUSTOM_PRE_TEST@\" CTEST_CUSTOM_PRE_TEST_QUOTED ESCAPE_QUOTES)
+  file(WRITE "${CMAKE_BINARY_DIR}/CTestCustom.cmake" "set(CTEST_CUSTOM_PRE_TEST ${CTEST_CUSTOM_PRE_TEST_QUOTED})" "\n")
 endif()
-
-if (NOT TARGET tests)
-  add_custom_target(tests
-    COMMAND ${CMAKE_CTEST_COMMAND}
-    EXCLUDE_FROM_ALL)
-endif ()
-add_dependencies(tests build-tests)
-add_subdirectory (tests EXCLUDE_FROM_ALL)
-
-# The following forces tests to be built when using "make ctest" even if some targets
-# are EXCLUDE_FROM_ALL
-# From https://stackoverflow.com/questions/733475/cmake-ctest-make-test-doesnt-build-tests/56448477#56448477
-build_command(CTEST_CUSTOM_PRE_TEST TARGET build-tests)
-string(CONFIGURE \"@CTEST_CUSTOM_PRE_TEST@\" CTEST_CUSTOM_PRE_TEST_QUOTED ESCAPE_QUOTES)
-file(WRITE "${CMAKE_BINARY_DIR}/CTestCustom.cmake" "set(CTEST_CUSTOM_PRE_TEST ${CTEST_CUSTOM_PRE_TEST_QUOTED})" "\n")
 
 # The following is needed for external projects using *nix make when
 # parent project builds pFUnit as a subproject.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Enable `build-tests` and `tests` targets only if `ENABLE_TESTS` is `ON`.
+
 ## [4.14.0] - 2025-10-14
 
 ### Changed


### PR DESCRIPTION
I am building pFUnit via FetchContent from a parent project. When I then run the ctest command on the parent project, also tests for pFUnit are built and run, which is not the intention to my understanding. Usually, ENABLE_TESTS is set to OFF if pFUnit is not the main project, so it should also not build or run any tests via the ctest command.
This PR just encloses all test related lines into the `if(ENABLE_TESTS)` which seems to avoid the mentioned problems.