### PR TITLE
Fix automatic rebuild when adding new test files (issue #380)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       FC: nvfortran
-      NVHPC_IMAGE: nvcr.io/nvidia/nvhpc:25.11-devel-cuda13.0-ubuntu24.04
+      NVHPC_IMAGE: nvcr.io/nvidia/nvhpc:26.1-devel-cuda13.1-ubuntu24.04
 
     steps:
       # Reclaim lots of space
@@ -234,8 +234,21 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Pull NVHPC image
-        run: docker pull "$NVHPC_IMAGE"
+      - name: Pull NVHPC image (retry)
+        env:
+          DOCKER_CLIENT_TIMEOUT: 600
+          COMPOSE_HTTP_TIMEOUT: 600
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5; do
+            echo "Attempt $i: docker pull $NVHPC_IMAGE"
+            if docker pull "$NVHPC_IMAGE"; then
+              exit 0
+            fi
+            sleep $((i*20))
+          done
+          echo "Docker pull failed after retries"
+          exit 1
 
       # Run everything inside the NVHPC container
       - name: Build (inside NVHPC)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,6 +197,9 @@ jobs:
   #      we have to do some tricks to get it to run in GitHub Actions.
   Nvidia-Build-Only:
     runs-on: ubuntu-24.04
+    # Turned off for now because NVHPC image is too large for free
+    # GitHub Actions runners, but leaving here for when we can run it again
+    if: false
     env:
       FC: nvfortran
       NVHPC_IMAGE: nvcr.io/nvidia/nvhpc:26.1-devel-cuda13.1-ubuntu24.04

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@
 /mpi_pFUnit.x
 /nag
 *.zip
-build/
+/build*/
+/install*/
 Testing/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,3 +247,16 @@ if (NOT MAIN_PROJECT)
   include(add_pfunit_test)
   include(add_pfunit_ctest)
 endif()
+
+# https://www.scivision.dev/cmake-auto-gitignore-build-dir/
+# --- auto-ignore build directory
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()
+
+# Piggyback that file into install
+install(
+   FILES ${PROJECT_BINARY_DIR}/.gitignore
+   DESTINATION ${CMAKE_INSTALL_PREFIX}
+   )
+

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Minor cleanup to CI
+- Update NVHPC CI to 26.1
 
 ### Fixed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix CMake build system to properly track test file dependencies (issue #380)
+- Fix `add_pfunit_ctest` to properly track test file dependencies (issue #380)
   - Adding new `.pf` files to `TEST_SOURCES` now triggers automatic rebuild without `make clean`
   - Test suite registry (`.inc` file) generation moved from configure-time to build-time
   - Added build-time dependency tracking between `.pf` files and generated registry

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minor cleanup to CI
 
+### Fixed
+
+- Fix CMake build system to properly track test file dependencies (issue #380)
+  - Adding new `.pf` files to `TEST_SOURCES` now triggers automatic rebuild without `make clean`
+  - Test suite registry (`.inc` file) generation moved from configure-time to build-time
+  - Added build-time dependency tracking between `.pf` files and generated registry
+  - Driver recompilation now triggered automatically when registry changes
+  - New helper script: `include/generate_test_suite_inc.cmake`
+
 ## [4.15.0] - 2025-11-24
 
 ### Changed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Minor cleanup to CI
-- Update NVHPC CI to 26.1
+- Turned off NVHPC CI test as it seems the image is too large for Github Actions.  Will investigate further and re-enable when possible.
 
 ### Fixed
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -38,7 +38,7 @@ file_compile_configuration()
 # Perform the install.
 #
 install(
-  FILES driver.F90 driver.F90.in add_pfunit_sources.cmake add_pfunit_ctest.cmake add_pfunit_test.cmake
+  FILES driver.F90 driver.F90.in add_pfunit_sources.cmake add_pfunit_ctest.cmake add_pfunit_test.cmake generate_test_suite_inc.cmake
   DESTINATION ${dest}/include
   )
 

--- a/include/generate_test_suite_inc.cmake
+++ b/include/generate_test_suite_inc.cmake
@@ -1,0 +1,20 @@
+# This script is executed at build time to generate the test suite .inc file
+# 
+# Required variables (passed via -D):
+#   PF_FILES_LIST - Path to a file containing list of .pf file paths (one per line)
+#   OUTPUT_FILE   - Path to the .inc file to generate
+
+# Read the list of .pf files from the file
+file(STRINGS "${PF_FILES_LIST}" pf_files_list)
+
+# Initialize output content
+set(test_suites_inc "")
+
+# Process each .pf file
+foreach(pf_file ${pf_files_list})
+  get_filename_component(basename "${pf_file}" NAME_WE)
+  set(test_suites_inc "${test_suites_inc}ADD_TEST_SUITE(${basename}_suite)\n")
+endforeach()
+
+# Write the output file
+file(WRITE "${OUTPUT_FILE}" "${test_suites_inc}")


### PR DESCRIPTION
When adding new .pf test files to TEST_SOURCES in add_pfunit_ctest(), the build system now properly detects and rebuilds without requiring 'make clean' or CMake reconfiguration.

Changes:
- Move test suite registry (.inc) generation from configure-time to build-time
- Add custom command with proper dependency tracking for .pf source files
- Ensure driver recompiles when registry file changes via OBJECT_DEPENDS
- Create new helper script: include/generate_test_suite_inc.cmake

The fix maintains full backward compatibility with user-provided REGISTRY option and all existing test configurations.

Fixes #380