### PR TITLE
Update to fArgParse v1.11.0 and release v4.16.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project (PFUNIT
-  VERSION 4.15.0
+  VERSION 4.16.0
   LANGUAGES Fortran C)
 
 cmake_policy(SET CMP0077 NEW)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update submodule (fArgParse v1.11.0)
 - Minor cleanup to CI
+- Turned off NVHPC CI test as it seems the image is too large for Github Actions.  Will investigate further and re-enable when possible.
+- Removed some unneeded debugging prints in `pFUnitParser.py`
+
+### Fixed
+
+- Fix `add_pfunit_ctest` to properly track test file dependencies (issue #380)
+  - Adding new `.pf` files to `TEST_SOURCES` now triggers automatic rebuild without `make clean`
+  - Test suite registry (`.inc` file) generation moved from configure-time to build-time
+  - Added build-time dependency tracking between `.pf` files and generated registry
+  - Driver recompilation now triggered automatically when registry changes
+  - New helper script: `include/generate_test_suite_inc.cmake`
 
 ## [4.15.0] - 2025-11-24
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.16.0] - 2026-02-23
+
 ### Added
 
 - Advanced test filtering with regex and glob patterns (issue #523)
@@ -16,18 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update submodule (fArgParse v1.11.0)
 - Minor cleanup to CI
-- Turned off NVHPC CI test as it seems the image is too large for Github Actions.  Will investigate further and re-enable when possible.
-- Removed some unneeded debugging prints in `pFUnitParser.py`
-
-### Fixed
-
-- Fix `add_pfunit_ctest` to properly track test file dependencies (issue #380)
-  - Adding new `.pf` files to `TEST_SOURCES` now triggers automatic rebuild without `make clean`
-  - Test suite registry (`.inc` file) generation moved from configure-time to build-time
-  - Added build-time dependency tracking between `.pf` files and generated registry
-  - Driver recompilation now triggered automatically when registry changes
-  - New helper script: `include/generate_test_suite_inc.cmake`
 
 ## [4.15.0] - 2025-11-24
 


### PR DESCRIPTION
## Summary

- Updated fArgParse submodule from v1.10.0 to v1.11.0
- Bumped pFUnit version to 4.16.0
- Updated ChangeLog.md with release notes for v4.16.0

This update brings in the latest improvements from the fArgParse library (which includes gFTL-shared v1.12.0 and gFTL v1.17.0).