### PR TITLE
Release v4.16.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,9 +197,12 @@ jobs:
   #      we have to do some tricks to get it to run in GitHub Actions.
   Nvidia-Build-Only:
     runs-on: ubuntu-24.04
+    # Turned off for now because NVHPC image is too large for free
+    # GitHub Actions runners, but leaving here for when we can run it again
+    if: false
     env:
       FC: nvfortran
-      NVHPC_IMAGE: nvcr.io/nvidia/nvhpc:25.11-devel-cuda13.0-ubuntu24.04
+      NVHPC_IMAGE: nvcr.io/nvidia/nvhpc:26.1-devel-cuda13.1-ubuntu24.04
 
     steps:
       # Reclaim lots of space
@@ -234,8 +237,21 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Pull NVHPC image
-        run: docker pull "$NVHPC_IMAGE"
+      - name: Pull NVHPC image (retry)
+        env:
+          DOCKER_CLIENT_TIMEOUT: 600
+          COMPOSE_HTTP_TIMEOUT: 600
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5; do
+            echo "Attempt $i: docker pull $NVHPC_IMAGE"
+            if docker pull "$NVHPC_IMAGE"; then
+              exit 0
+            fi
+            sleep $((i*20))
+          done
+          echo "Docker pull failed after retries"
+          exit 1
 
       # Run everything inside the NVHPC container
       - name: Build (inside NVHPC)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,9 @@ jobs:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         compiler: [gfortran-12, gfortran-13, gfortran-14, gfortran-15]
         # gfortran-10 and -11 are only on ubuntu-22.04
-        # gfortran-13, -14, and -15 are not on ubuntu-22.04
-        # gfortran-15 is only on macos
+        # gfortran-13 and -14 and -15 are not on ubuntu-22.04
         # gfortran-12 is not on macos
+        # gfortran-15 is only on macos
         include:
           - os: ubuntu-22.04
             compiler: gfortran-10
@@ -70,7 +70,7 @@ jobs:
           cmake --version
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Cache MPI
         id: cache-mpi
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/local/openmpi
           key: mpi-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}
@@ -117,7 +117,7 @@ jobs:
         run: ctest --test-dir build --parallel 1 --output-on-failure --repeat until-pass:4
 
       - name: Archive log files on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: logfiles-${{ matrix.compiler }}-${{ matrix.os }}
@@ -134,7 +134,7 @@ jobs:
     name: Intel Fortran
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -186,7 +186,7 @@ jobs:
         run: ctest --test-dir build --parallel 1 --output-on-failure --repeat until-pass:4
 
       - name: Archive log files on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: logfiles-Intel
@@ -230,7 +230,7 @@ jobs:
           docker system prune -af || true
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -274,7 +274,7 @@ jobs:
 
       - name: Archive log files on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: logfiles-Nvidia
           path: |
@@ -301,7 +301,7 @@ jobs:
           cmake --version
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -329,7 +329,7 @@ jobs:
         run: ctest --test-dir build --parallel 1 --output-on-failure --repeat until-pass:4
 
       - name: Archive log files on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: logfiles-Flang

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       FC: nvfortran
-      NVHPC_IMAGE: nvcr.io/nvidia/nvhpc:25.7-devel-cuda12.9-ubuntu24.04
+      NVHPC_IMAGE: nvcr.io/nvidia/nvhpc:25.11-devel-cuda13.0-ubuntu24.04
 
     steps:
       # Reclaim lots of space

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@
 /mpi_pFUnit.x
 /nag
 *.zip
-build/
+/build*/
+/install*/
 Testing/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project (PFUNIT
-  VERSION 4.15.0
+  VERSION 4.16.0
   LANGUAGES Fortran C)
 
 cmake_policy(SET CMP0077 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,3 +247,16 @@ if (NOT MAIN_PROJECT)
   include(add_pfunit_test)
   include(add_pfunit_ctest)
 endif()
+
+# https://www.scivision.dev/cmake-auto-gitignore-build-dir/
+# --- auto-ignore build directory
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()
+
+# Piggyback that file into install
+install(
+   FILES ${PROJECT_BINARY_DIR}/.gitignore
+   DESTINATION ${CMAKE_INSTALL_PREFIX}
+   )
+

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.16.0] - 2026-02-23
+
 ### Added
 
 - Advanced test filtering with regex and glob patterns (issue #523)
@@ -16,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update submodule (fArgParse v1.11.0)
 - Minor cleanup to CI
 - Turned off NVHPC CI test as it seems the image is too large for Github Actions.  Will investigate further and re-enable when possible.
 - Removed some unneeded debugging prints in `pFUnitParser.py`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Minor cleanup to CI
+- Turned off NVHPC CI test as it seems the image is too large for Github Actions.  Will investigate further and re-enable when possible.
+
+### Fixed
+
+- Fix `add_pfunit_ctest` to properly track test file dependencies (issue #380)
+  - Adding new `.pf` files to `TEST_SOURCES` now triggers automatic rebuild without `make clean`
+  - Test suite registry (`.inc` file) generation moved from configure-time to build-time
+  - Added build-time dependency tracking between `.pf` files and generated registry
+  - Driver recompilation now triggered automatically when registry changes
+  - New helper script: `include/generate_test_suite_inc.cmake`
 
 ## [4.15.0] - 2025-11-24
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minor cleanup to CI
 - Turned off NVHPC CI test as it seems the image is too large for Github Actions.  Will investigate further and re-enable when possible.
+- Removed some unneeded debugging prints in `pFUnitParser.py`
 
 ### Fixed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Minor cleanup to CI
+
 ## [4.15.0] - 2025-11-24
 
 ### Changed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Advanced test filtering with regex and glob patterns (issue #523)
+  - `-f`/`--filter` flag supports POSIX regex on Unix/Linux/macOS, glob patterns on Windows
+  - `-e`/`--exclude` flag for anti-filtering using glob patterns on all platforms
+  - Multiple space-separated patterns supported (OR logic)
+  - New modules: `RegexFilter`, `GlobFilter`, and C wrapper for POSIX regex
+  - Backward compatible with existing simple substring filtering
+
 ### Changed
 
 - Minor cleanup to CI

--- a/README.md
+++ b/README.md
@@ -270,11 +270,63 @@ the pFUnit preprocessor.
 
     -h or --help                    Prints this help message
     -d or -debug or --verbose       Provide debugging information.  Useful when a test crashes.
-    -f or --filter <pattern>        Only run tests that match the specified substring
+    -f or --filter <pattern>...     Only run tests matching pattern(s) (regex on Unix, glob on Windows)
+    -e or --exclude <pattern>...    Skip tests matching glob pattern(s)
     -h or --help                    Print help message.
     -o or --output <outputfile>     Direct pFUnit messages to a file.
     -r or --runner <runner>         Specify a non default test runner. (Advanced)
     -s or -skip  <n>                Used internally.
+
+#### Filtering Tests
+
+**Include Filters (`-f`/`--filter`):**
+- **Unix/Linux/macOS**: Uses POSIX regular expressions for powerful pattern matching
+- **Windows**: Uses glob patterns (supports `*` and `?` wildcards)
+- **Multiple patterns**: Space-separated within a single `-f` flag (OR logic - includes tests matching ANY pattern)
+- **Backward compatible**: Simple test names work as before
+
+**Exclude Filters (`-e`/`--exclude`):**
+- Uses glob patterns on all platforms
+- **Multiple patterns**: Space-separated within a single `-e` flag (OR logic - excludes tests matching ANY pattern)
+- Can be combined with `-f` for include/exclude logic
+
+**Examples:**
+
+Simple substring (backward compatible):
+```bash
+$ ./tests.x -f test_ABC
+```
+
+Glob patterns (all platforms):
+```bash
+$ ./tests.x -f "test_*"              # All tests starting with "test_"
+$ ./tests.x -f "*_fast" "*_quick"    # Tests ending with "_fast" OR "_quick" (space-separated)
+```
+
+Exclude patterns:
+```bash
+$ ./tests.x -e "test_slow_*"         # Skip slow tests
+$ ./tests.x -f "test_*" -e "test_slow_*"  # All tests except slow ones
+```
+
+Regex patterns (Unix/Linux/macOS only):
+```bash
+$ ./tests.x -f "^test_.*_fast$"      # Anchored pattern
+$ ./tests.x -f "test_[0-9]+"         # Tests with numbers
+$ ./tests.x -f "test_(foo|bar)_.*"   # Alternation
+```
+
+**Filter Logic:**
+- Multiple patterns with `-f`: Include if matches ANY pattern (OR logic)
+- Space-separated patterns within a single flag, not multiple flags
+- Multiple patterns with `-e`: Exclude if matches ANY pattern (OR logic)
+- Combined: `(matches any -f) AND NOT (matches any -e)`
+- No `-f` specified: Include all tests (then apply `-e` exclusions)
+
+**Platform Notes:**
+- **Regex support** (Unix/Linux/macOS only): Full POSIX extended regex
+- **Glob support** (all platforms): `*` (any chars), `?` (single char)
+- **Case sensitivity**: Filters are case-sensitive by default
 
 For example to run all tests whose names start with "test_ABC":
 

--- a/bin/funit/pFUnitParser.py
+++ b/bin/funit/pFUnitParser.py
@@ -163,7 +163,6 @@ class AtTest(Action):
 
             matchType = re.match(r'.*type\s*=\s*(\w+)', options.groups()[0], re.IGNORECASE)
             if matchType:
-                print ('Type', matchType.groups()[0])
                 self.parser.current_method['type'] = matchType.groups()[0]
 
             paramOption = re.search(r'testParameters\s*=\s*[{](.*)[}]', options.groups()[0], re.IGNORECASE)
@@ -349,9 +348,6 @@ class AtAssertAssociated(Action):
         # args = parseArgsFirstRest('@assertassociated',line)
         args = parseArgsFirstSecondRest('@assertassociated',line)
 
-        # print(9000,line)
-        # print(9001,args)
-        
         p.outputFile.write(cppSetLineAndFile(p.currentLineNumber, p.fileName))
         if len(args) > 1:
             if re.match('.*message=.*',args[1],re.IGNORECASE):
@@ -411,9 +407,6 @@ class AtAssertNotAssociated(Action):
         #ok args = parseArgsFirstSecondRest('@assertassociated',line)
         args = parseArgsFirstSecondRest(self.name,line)
 
-        # print(9000,line)
-        # print(9001,args)
-        
         p.outputFile.write(cppSetLineAndFile(p.currentLineNumber, p.fileName))
         if len(args) > 1:
             if re.match('.*message=.*',args[1],re.IGNORECASE):
@@ -626,7 +619,6 @@ class AtDisable(Action):
         return m
 
     def action(self, m, line):
-        print("Processing disable:")
         self.parser.current_method['disable'] = True
         self.parser.commentLine(line)
                 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -38,7 +38,7 @@ file_compile_configuration()
 # Perform the install.
 #
 install(
-  FILES driver.F90 driver.F90.in add_pfunit_sources.cmake add_pfunit_ctest.cmake add_pfunit_test.cmake
+  FILES driver.F90 driver.F90.in add_pfunit_sources.cmake add_pfunit_ctest.cmake add_pfunit_test.cmake generate_test_suite_inc.cmake
   DESTINATION ${dest}/include
   )
 

--- a/include/generate_test_suite_inc.cmake
+++ b/include/generate_test_suite_inc.cmake
@@ -1,0 +1,20 @@
+# This script is executed at build time to generate the test suite .inc file
+# 
+# Required variables (passed via -D):
+#   PF_FILES_LIST - Path to a file containing list of .pf file paths (one per line)
+#   OUTPUT_FILE   - Path to the .inc file to generate
+
+# Read the list of .pf files from the file
+file(STRINGS "${PF_FILES_LIST}" pf_files_list)
+
+# Initialize output content
+set(test_suites_inc "")
+
+# Process each .pf file
+foreach(pf_file ${pf_files_list})
+  get_filename_component(basename "${pf_file}" NAME_WE)
+  set(test_suites_inc "${test_suites_inc}ADD_TEST_SUITE(${basename}_suite)\n")
+endforeach()
+
+# Write the output file
+file(WRITE "${OUTPUT_FILE}" "${test_suites_inc}")

--- a/src/funit/FUnit.F90
+++ b/src/funit/FUnit.F90
@@ -38,6 +38,13 @@ contains
       use fArgParse
       use pf_StringUtilities
       use pf_AbstractPrinter
+      use gFTL2_StringVector, only: gFTL2_SV => StringVector
+      use pf_Test
+      use pf_TestVector
+      use pf_GlobFilter
+#ifndef _WIN32
+      use pf_RegexFilter
+#endif
       procedure(LoadTests_interface) :: load_tests
       class(ParallelContext), intent(in) :: context
 
@@ -49,7 +56,6 @@ contains
       logical :: xml
       type (StringUnlimitedMap) :: options
       class(*), pointer :: option
-      character(:), allocatable :: pattern
       integer :: unit
       integer :: n_skip
       character(:), allocatable :: ofile
@@ -109,15 +115,22 @@ contains
 
 
 
+      ! Load all tests first
+      unfiltered = TestSuite()
+      call load_tests(unfiltered)
+
+      ! Apply include filters (-f)
       option => options%at('filter')
-      suite = TestSuite()
       if (associated(option)) then
-         call cast(option, pattern)
-         unfiltered = TestSuite()
-         call load_tests(unfiltered)
-         call unfiltered%filter_sub(NameFilter(pattern), suite)
+         call apply_include_filters(option, unfiltered, suite, unit)
       else
-         call load_tests(suite)
+         suite = unfiltered
+      end if
+
+      ! Apply exclude filters (-e)
+      option => options%at('exclude')
+      if (associated(option)) then
+         call apply_exclude_filters(option, suite, unit)
       end if
 
       r = runner%run(suite, context)
@@ -126,13 +139,228 @@ contains
    contains
 
 
+      logical function is_regex_pattern(pattern)
+         character(*), intent(in) :: pattern
+         ! Check for regex metacharacters that don't exist in glob
+         is_regex_pattern = index(pattern, '^') > 0 .or. &
+                            index(pattern, '$') > 0 .or. &
+                            index(pattern, '[') > 0 .or. &
+                            index(pattern, ']') > 0 .or. &
+                            index(pattern, '(') > 0 .or. &
+                            index(pattern, ')') > 0 .or. &
+                            index(pattern, '|') > 0 .or. &
+                            index(pattern, '+') > 0 .or. &
+                            index(pattern, '{') > 0 .or. &
+                            index(pattern, '}') > 0
+      end function is_regex_pattern
+
+
+       subroutine apply_include_filters(option, unfiltered, suite, unit)
+          class(*), pointer :: option
+          type(TestSuite), intent(in) :: unfiltered
+          type(TestSuite), intent(inout) :: suite
+          integer, intent(in) :: unit
+
+          type(gFTL2_SV) :: patterns
+          type(TestSuite) :: temp_suite
+          character(:), allocatable :: pattern
+          integer :: i
+
+          ! Check if patterns are provided
+          select type (option)
+          type is (character(*))
+             ! Single pattern as string - convert to vector with one element
+             patterns = gFTL2_SV()
+             call patterns%push_back(option)
+          class is (gFTL2_SV)
+             patterns = option
+          class default
+             ! Try to cast
+             call cast(option, patterns)
+          end select
+
+          if (patterns%size() == 0) then
+            ! No patterns specified, include all tests
+            suite = unfiltered
+            return
+         end if
+
+         ! Initialize empty suite
+         suite = TestSuite()
+
+          ! OR logic: include if matches ANY pattern
+          do i = 1, patterns%size()
+             pattern = trim(adjustl(patterns%at(i)))
+             temp_suite = TestSuite()
+
+#ifndef _WIN32
+             ! Unix: use regex
+             call unfiltered%filter_sub(RegexFilter(pattern), temp_suite)
+#else
+            ! Windows: use glob, warn if regex syntax detected
+            if (is_regex_pattern(pattern)) then
+               write(unit, '(a)') 'WARNING: Regex syntax detected but not supported on Windows.'
+               write(unit, '(a)') '         Using glob pattern matching instead.'
+            end if
+            call unfiltered%filter_sub(GlobFilter(pattern), temp_suite)
+#endif
+
+            ! Merge temp_suite into suite (union)
+            call merge_suites(suite, temp_suite)
+         end do
+      end subroutine apply_include_filters
+
+
+      subroutine apply_exclude_filters(option, suite, unit)
+         class(*), pointer :: option
+         type(TestSuite), intent(inout) :: suite
+         integer, intent(in) :: unit
+
+         type(gFTL2_SV) :: patterns
+         type(TestSuite) :: excluded
+         character(:), allocatable :: pattern
+         integer :: i
+
+          ! Check if patterns are provided
+          select type (option)
+          type is (character(*))
+             ! Single pattern as string
+             patterns = gFTL2_SV()
+             call patterns%push_back(option)
+             write(unit,'(a,i0,a)') 'DEBUG EXCLUDE: Got single pattern, size=', patterns%size()
+          class is (gFTL2_SV)
+             patterns = option
+          class default
+             call cast(option, patterns)
+          end select
+
+          if (patterns%size() == 0) then
+             ! No exclusions
+             return
+          end if
+
+          ! OR logic: exclude if matches ANY pattern
+          do i = 1, patterns%size()
+             pattern = trim(adjustl(patterns%at(i)))
+             excluded = TestSuite()
+
+             ! Always use glob for exclude (simpler, works everywhere)
+             call suite%filter_sub(GlobFilter(pattern), excluded)
+
+             ! Remove matches from suite
+             call subtract_suite(suite, excluded)
+          end do
+      end subroutine apply_exclude_filters
+
+
+      subroutine merge_suites(target_suite, source_suite)
+         use PF_Test, only: Test
+         use PF_TestVector, only: TestVector
+         type(TestSuite), intent(inout) :: target_suite
+         type(TestSuite), intent(in) :: source_suite
+
+         type(TestVector) :: test_list
+         class(Test), pointer :: t
+         integer :: i
+
+         ! Get all test cases from source suite
+         call source_suite%getTestCases(test_list)
+
+         ! Add each test to target suite if not already present
+         do i = 1, test_list%size()
+            t => test_list%at(i)
+            if (.not. suite_contains_test(target_suite, t)) then
+               call target_suite%tests%push_back(t)
+            end if
+         end do
+      end subroutine merge_suites
+
+
+      logical function suite_contains_test(suite, aTest) result(contains)
+         use PF_Test, only: Test
+         use PF_TestVector, only: TestVector
+         type(TestSuite), intent(in) :: suite
+         class(Test), pointer, intent(in) :: aTest
+
+         type(TestVector) :: test_list
+         class(Test), pointer :: t
+         integer :: i
+
+         contains = .false.
+
+         call suite%getTestCases(test_list)
+         do i = 1, test_list%size()
+            t => test_list%at(i)
+            if (t%getName() == aTest%getName()) then
+               contains = .true.
+               return
+            end if
+         end do
+      end function suite_contains_test
+
+
+       subroutine subtract_suite(target_suite, exclude_suite)
+          use PF_Test, only: Test
+          use PF_TestVector, only: TestVector
+          type(TestSuite), intent(inout) :: target_suite
+          type(TestSuite), intent(in) :: exclude_suite
+
+          type(TestVector) :: exclude_list, new_list, target_list
+          class(Test), pointer :: t
+          integer :: i
+
+          ! Get list of tests to exclude
+          call exclude_suite%getTestCases(exclude_list)
+          
+          ! Get current tests from target
+          call target_suite%getTestCases(target_list)
+
+          ! Build new test vector without excluded tests
+          new_list = TestVector()
+          do i = 1, target_list%size()
+             t => target_list%at(i)
+             if (.not. is_in_exclude_list(t, exclude_list)) then
+                call new_list%push_back(t)
+             end if
+          end do
+
+          ! Replace target's test vector
+          target_suite%tests = new_list
+       end subroutine subtract_suite
+
+
+       logical function is_in_exclude_list(aTest, exclude_list) result(excluded)
+          use PF_Test, only: Test
+          use PF_TestVector, only: TestVector
+          class(Test), pointer, intent(in) :: aTest
+          type(TestVector), intent(in) :: exclude_list
+
+          class(Test), pointer :: t
+          integer :: i
+
+          excluded = .false.
+          do i = 1, exclude_list%size()
+             t => exclude_list%at(i)
+             if (t%getName() == aTest%getName()) then
+                excluded = .true.
+                return
+             end if
+          end do
+       end function is_in_exclude_list
+
+
       subroutine set_command_line_options()
          parser = ArgParser()
          call parser%add_argument('-d', '-v', '--debug', '--verbose', action='store_true', &
               & help='make output more verbose')
 
          call parser%add_argument('-f', '--filter', action='store', &
-              & help='only run tests that match pattern')
+              & n_arguments='*', &
+              & help='run tests matching pattern(s) (regex on Unix, glob on Windows)')
+
+         call parser%add_argument('-e', '--exclude', action='store', &
+              & n_arguments='*', &
+              & help='skip tests matching glob pattern(s)')
 
          call parser%add_argument('-o', '--output', action='store', &
               & help='only run tests that match pattern')

--- a/src/funit/core/CMakeLists.txt
+++ b/src/funit/core/CMakeLists.txt
@@ -50,9 +50,19 @@ set(srcs
 
   TestFilter.F90
   NameFilter.F90
+  GlobFilter.F90
   FUnit_Core.F90
   get_errno.c
   )
+
+# Add regex support for Unix/Linux/macOS only
+if(NOT WIN32)
+  list(APPEND srcs
+    regex_F.c
+    regex_module.F90
+    RegexFilter.F90
+  )
+endif()
 
 # Support for RobustRunner
 if (NOT SKIP_ROBUST)

--- a/src/funit/core/GlobFilter.F90
+++ b/src/funit/core/GlobFilter.F90
@@ -1,0 +1,40 @@
+module pf_GlobFilter
+   use pf_TestFilter
+   use pf_Test
+   use PF_GlobPattern
+   implicit none
+   private
+
+   public :: GlobFilter
+
+   type, extends(TestFilter) :: GlobFilter
+      private
+      type(GlobPattern) :: pattern
+    contains
+      procedure :: filter
+   end type GlobFilter
+
+
+   interface GlobFilter
+      module procedure new_GlobFilter
+   end interface GlobFilter
+
+contains
+
+   function new_GlobFilter(pattern_str) result(filter)
+     type(GlobFilter) :: filter
+     character(*), intent(in) :: pattern_str
+
+     filter%pattern = GlobPattern(pattern_str)
+   end function new_GlobFilter
+
+
+   logical function filter(this, a_test)
+     class(GlobFilter), intent(in) :: this
+     class(Test), intent(in) :: a_test
+
+     filter = this%pattern%match(a_test%getName())
+   end function filter
+
+
+end module pf_GlobFilter

--- a/src/funit/core/RegexFilter.F90
+++ b/src/funit/core/RegexFilter.F90
@@ -1,0 +1,71 @@
+#ifndef _WIN32
+module pf_RegexFilter
+   use pf_TestFilter
+   use pf_Test
+   use pf_regex_module
+   implicit none
+   private
+
+   public :: RegexFilter
+
+   type, extends(TestFilter) :: RegexFilter
+      private
+      type(regex_type) :: regex
+      logical :: compiled = .false.
+      character(:), allocatable :: pattern
+    contains
+      procedure :: filter
+      final :: cleanup
+   end type RegexFilter
+
+
+   interface RegexFilter
+      module procedure new_RegexFilter
+   end interface RegexFilter
+
+contains
+
+   function new_RegexFilter(pattern) result(filter)
+     type(RegexFilter) :: filter
+     character(*), intent(in) :: pattern
+     integer :: status
+
+     filter%pattern = pattern
+     
+     ! Compile regex with 'x' (extended) flag for full regex syntax
+     call regcomp(filter%regex, pattern, flags='x', status=status)
+     
+     if (status == 0) then
+        filter%compiled = .true.
+     else
+        ! Compilation failed - filter will never match
+        filter%compiled = .false.
+        ! Could optionally print warning here
+     end if
+   end function new_RegexFilter
+
+
+   logical function filter(this, a_test)
+     class(RegexFilter), intent(in) :: this
+     class(Test), intent(in) :: a_test
+
+     if (.not. this%compiled) then
+        filter = .false.
+        return
+     end if
+     
+     filter = regexec(this%regex, a_test%getName())
+   end function filter
+
+
+   subroutine cleanup(this)
+     type(RegexFilter), intent(inout) :: this
+     
+     if (this%compiled) then
+        call regfree(this%regex)
+     end if
+   end subroutine cleanup
+
+
+end module pf_RegexFilter
+#endif

--- a/src/funit/core/regex_F.c
+++ b/src/funit/core/regex_F.c
@@ -1,0 +1,60 @@
+#ifndef _WIN32
+/*
+ * C wrapper for POSIX regex functions
+ * Adapted from MAPL3 utilities/regex/regex_F.c
+ * Provides interface between Fortran and system regex library
+ */
+
+#include <sys/types.h>
+#include <regex.h>
+#include <string.h>
+#include <stdlib.h>
+
+void C_regalloc(regex_t **preg_return) {
+  *preg_return = malloc(sizeof(**preg_return));
+}
+
+/* pattern must be NUL terminated. */
+void C_regcomp(regex_t *preg, const char *pattern,
+               const char *flags, int *status_return) {
+  int i, cflags=0;
+  for (i=0;flags[i];i++) {
+    switch (flags[i]) {
+      case 'i': cflags |= REG_ICASE; break;
+      case 'm': cflags |= REG_NEWLINE; break;
+      case 'x': cflags |= REG_EXTENDED; break;
+      case 'n': cflags |= REG_NOSUB; break;
+      case ' ': break;
+      default: *status_return=-2; return;
+    }
+  }
+  *status_return = regcomp(preg,pattern,cflags);
+}
+
+void C_regexec(const regex_t *preg, const char *string, int nmatch,
+               int matches[nmatch][2], const char *flags,
+               int *status_return) {
+  int i, eflags=0;
+  regmatch_t *pmatch;
+  for (i=0;flags[i];i++) {
+    switch (flags[i]) {
+      case 'b': eflags |= REG_NOTBOL; break;
+      case 'e': eflags |= REG_NOTEOL; break;
+      case ' ': break;
+      default: *status_return=-2; return;
+    }
+  }
+  if (nmatch>0 && sizeof(pmatch->rm_so)!=sizeof(matches[0][0])) {
+    pmatch = malloc(sizeof(regmatch_t)*nmatch);
+    *status_return = regexec(preg,string,nmatch,pmatch,eflags);
+    for (i=0;i<nmatch;i++) {
+      matches[i][0]=pmatch[i].rm_so;
+      matches[i][1]=pmatch[i].rm_eo;
+    }
+    free(pmatch);
+  } else {
+    *status_return = regexec(preg,string,nmatch,(regmatch_t*)&(matches[0][0]),eflags);
+  }
+}
+
+#endif /* _WIN32 */

--- a/src/funit/core/regex_module.F90
+++ b/src/funit/core/regex_module.F90
@@ -1,0 +1,169 @@
+#ifndef _WIN32
+module pf_regex_module
+! Fortran interface to POSIX regex, using ISO_C_BINDING.
+! Adapted from MAPL3 utilities/regex/regex_module.F90
+!
+! API:
+!
+! Compile a regex into a regex object
+!  subroutine regcomp(this,pattern,flags,status)
+!    type(regex_type), intent(out) :: this           ! new regex object
+!    character(len=*), intent(in) :: pattern         ! regex pattern string
+!    character(len=*), intent(in), optional :: flags ! flag characters:
+!                                           ! x = extended regex (REG_EXTENDED)
+!                                           ! m = multi-line     (REG_NEWLINE)
+!                                           ! i = case-insensitive (REG_ICASE)
+!                                           ! n = no MATCH required (REG_NOSUB)
+!    integer, intent(out), optional :: status ! If absent, errors are fatal
+!  end subroutine regcomp
+!
+! Execute a compiled regex against a string
+!  function regexec(this,string,matches,flags,status) result(match)
+!    logical :: match ! .TRUE. if the pattern matched
+!    type(regex_type), intent(in) :: this ! regex object
+!    character(len=*), intent(in) :: string ! target string
+!    character(len=*), intent(in), optional :: flags ! flag characters (for partial lines):
+!                                       ! b = no beginning-of-line (REG_NOTBOL)
+!                                       ! e = no end-of-line (REG_NOTEOL)
+!    integer, intent(out), optional :: matches(:,:) ! match locations
+!    integer, intent(out), optional :: status ! If absent, errors are fatal
+!  end function
+!
+! Release 
+!  subroutine regfree(this)
+!    type(regex_type), intent(inout) :: this
+!  end subroutine regfree
+!-------------------------------------------------------------------
+  use ISO_C_Binding, only: C_ptr, C_int, C_size_t, C_char, &
+                           C_NULL_char, C_NULL_ptr, C_associated
+  use ISO_Fortran_Env, only: ERROR_UNIT
+
+  implicit none
+  private
+
+  public :: regex_type
+  public :: regcomp
+  public :: regexec
+  public :: regfree
+  public :: regerror
+
+  integer, parameter  :: NO_MATCH = -1
+! Fortran regex structure holds a pointer to an opaque C structure
+  type regex_type
+    type(C_ptr) :: preg = C_NULL_ptr
+  end type regex_type
+  
+  interface
+    subroutine C_regalloc(preg_return) &
+        bind(C,name="C_regalloc")
+      import
+      type(C_ptr), intent(out) :: preg_return
+    end subroutine C_regalloc
+    
+    subroutine C_regcomp(preg,pattern,flags,status) &
+        bind(C,name="C_regcomp")
+      import
+      type(C_ptr), intent(in), value :: preg
+      character(len=1,kind=C_char), intent(in) :: pattern(*)
+      character(len=1,kind=C_char), intent(in) :: flags(*)
+      integer(C_int), intent(inout) :: status
+    end subroutine C_regcomp
+    
+    subroutine C_regexec(preg,string,nmatch,matches,flags,status) &
+        bind(C,name="C_regexec")
+      import
+      type(C_ptr), intent(in), value :: preg
+      character(len=1,kind=C_char), intent(in) :: string(*)
+      integer(C_int), intent(in), value :: nmatch
+      integer(C_int), intent(out) :: matches(2,nmatch)
+      character(len=1,kind=C_char), intent(in) :: flags(*)
+      integer(C_int), intent(out) :: status
+    end subroutine C_regexec
+    
+    function C_regerror(errcode, preg, errbuf, errbuf_size) &
+        result(regerror) bind(C,name="regerror")
+      import
+      integer(C_size_t) :: regerror
+      integer(C_int), value :: errcode
+      type(C_ptr), intent(in), value :: preg
+      character(len=1,kind=C_char), intent(out) :: errbuf
+      integer(C_size_t), value :: errbuf_size
+    end function C_regerror
+    
+    subroutine C_regfree(preg) bind(C,name="regfree")
+      import
+      type(C_ptr), intent(in), value :: preg
+    end subroutine C_regfree
+  end interface
+  
+contains
+
+  subroutine regcomp(this,pattern,flags,status)
+    type(regex_type), intent(out) :: this
+    character(len=*), intent(in) :: pattern
+    character(len=*), intent(in), optional :: flags
+    integer, intent(out), optional :: status
+! local
+    integer(C_int) :: status_
+    character(len=10,kind=C_char) :: flags_
+! begin
+    flags_=' '
+    if (present(flags)) flags_=flags
+    this%preg = C_NULL_ptr
+    call C_regalloc(this%preg)
+    call C_regcomp(this%preg, trim(pattern)//C_NULL_char, &
+                   trim(flags_)//C_NULL_char, status_)
+    if (present(status)) then
+      status=status_
+    end if
+  end subroutine regcomp
+  
+  logical function regexec(this,string,matches,flags,status) &
+        result(match)
+    type(regex_type), intent(in) :: this
+    character(len=*), intent(in) :: string
+    character(len=*), intent(in), optional :: flags
+    integer, intent(out), optional :: matches(:,:)
+    integer, intent(out), optional :: status
+! local
+    integer(C_int) :: status_, matches_(2,1)
+    character(len=10,kind=C_char) :: flags_
+! begin
+    flags_=' '
+    if (present(flags)) flags_=flags
+    if (present(matches)) then
+      matches = NO_MATCH
+      call C_regexec(this%preg, trim(string)//C_NULL_char, &
+                   size(matches,2),matches, &
+                   trim(flags_)//C_NULL_char, status_)
+    else
+      call C_regexec(this%preg, trim(string)//C_NULL_char, &
+                   int(0,C_int),matches_, &
+                   trim(flags_)//C_NULL_char, status_)
+    end if
+    match = status_==0
+    if (status_ == 1 ) status_ = 0 ! value "1" is not an error
+   if (present(status)) then
+      status=status_
+    end if
+  end function regexec
+  
+  subroutine regerror(this,errcode,errmsg,errmsg_len)
+    type(regex_type), intent(in) :: this
+    integer, intent(in) :: errcode
+    character, intent(out) :: errmsg
+    integer, intent(out) :: errmsg_len
+    errmsg_len = C_regerror(int(errcode,C_int), this%preg, &
+                 errmsg, int(len(errmsg),C_size_t))
+  end subroutine regerror
+  
+  subroutine regfree(this)
+    type(regex_type), intent(inout) :: this
+    if (c_associated(this%preg)) then
+      call C_regfree(this%preg)
+      this%preg = C_NULL_ptr
+    end if
+  end subroutine regfree
+  
+end module pf_regex_module
+#endif

--- a/tests/funit-core/CMakeLists.txt
+++ b/tests/funit-core/CMakeLists.txt
@@ -37,6 +37,7 @@ set(pf_tests
 #  Test_AssertRelativelyEqual_Real.pf
   Test_Norms.pf
   Test_GlobPattern.pf
+  Test_GlobFilter.pf
   Test_LiteralPattern.pf
   Test_DotPattern.pf
   Test_RepeatPattern.pf
@@ -45,6 +46,11 @@ set(pf_tests
   Test_RegularExpression.pf
   Test_TestMethod_before.pf
   Test_Long_Subroutine_Name.pf)
+
+# Add regex filter tests for non-Windows platforms
+if(NOT WIN32)
+  list(APPEND pf_tests Test_RegexFilter.pf)
+endif()
 
 set (new_test_srcs)
 set (test_srcs
@@ -121,6 +127,22 @@ add_dependencies(build-tests new_tests.x)
 set_property (TEST old_tests
     PROPERTY FAIL_REGULAR_EXPRESSION "Encountered 1 or more failures/errors during testing"
     )
+
+# Command-line filtering tests
+add_pfunit_ctest (filter_cmdline_tests.x
+  TEST_SOURCES FilterCommandLineTests.pf
+  LINK_LIBRARIES other_shared
+)
+add_dependencies(build-tests filter_cmdline_tests.x)
+
+add_test(NAME command_line_filtering
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_command_line_filtering.sh 
+          ${CMAKE_CURRENT_BINARY_DIR}/filter_cmdline_tests.x
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+set_tests_properties(command_line_filtering PROPERTIES
+  DEPENDS filter_cmdline_tests.x
+)
 
 
 

--- a/tests/funit-core/FilterCommandLineTests.pf
+++ b/tests/funit-core/FilterCommandLineTests.pf
@@ -1,0 +1,37 @@
+module FilterCommandLineTests
+   use FUnit
+   implicit none
+
+contains
+
+   @test
+   subroutine test_alpha_one()
+      @assertTrue(.true.)
+   end subroutine test_alpha_one
+
+   @test
+   subroutine test_alpha_two()
+      @assertTrue(.true.)
+   end subroutine test_alpha_two
+
+   @test
+   subroutine test_beta_one()
+      @assertTrue(.true.)
+   end subroutine test_beta_one
+
+   @test
+   subroutine test_beta_two()
+      @assertTrue(.true.)
+   end subroutine test_beta_two
+
+   @test
+   subroutine other_test()
+      @assertTrue(.true.)
+   end subroutine other_test
+
+   @test
+   subroutine slow_test()
+      @assertTrue(.true.)
+   end subroutine slow_test
+
+end module FilterCommandLineTests

--- a/tests/funit-core/Test_GlobFilter.pf
+++ b/tests/funit-core/Test_GlobFilter.pf
@@ -1,0 +1,143 @@
+module Test_GlobFilter
+   use FUnit
+   use pf_GlobFilter
+   use pf_TestMethod
+   implicit none
+
+   @suite(name='GlobFilter_suite')
+
+contains
+
+   @test
+   subroutine test_exact_match()
+      type(GlobFilter) :: filter
+      type(TestMethod) :: test
+
+      filter = GlobFilter('test_foo')
+      test = TestMethod('test_foo', dummy_method)
+      
+      @assertTrue(filter%filter(test))
+   end subroutine test_exact_match
+
+   @test
+   subroutine test_no_match()
+      type(GlobFilter) :: filter
+      type(TestMethod) :: test
+
+      filter = GlobFilter('test_foo')
+      test = TestMethod('test_bar', dummy_method)
+      
+      @assertFalse(filter%filter(test))
+   end subroutine test_no_match
+
+   @test
+   subroutine test_star_wildcard()
+      type(GlobFilter) :: filter
+      type(TestMethod) :: test1, test2, test3
+
+      filter = GlobFilter('test_*')
+      test1 = TestMethod('test_foo', dummy_method)
+      test2 = TestMethod('test_bar_baz', dummy_method)
+      test3 = TestMethod('other_test', dummy_method)
+      
+      @assertTrue(filter%filter(test1), 'Should match test_foo')
+      @assertTrue(filter%filter(test2), 'Should match test_bar_baz')
+      @assertFalse(filter%filter(test3), 'Should not match other_test')
+   end subroutine test_star_wildcard
+
+   @test
+   subroutine test_star_middle()
+      type(GlobFilter) :: filter
+      type(TestMethod) :: test1, test2
+
+      filter = GlobFilter('test_*_end')
+      test1 = TestMethod('test_middle_end', dummy_method)
+      test2 = TestMethod('test_middle_other', dummy_method)
+      
+      @assertTrue(filter%filter(test1), 'Should match with star in middle')
+      @assertFalse(filter%filter(test2), 'Should not match different ending')
+   end subroutine test_star_middle
+
+   @test
+   subroutine test_question_wildcard()
+      type(GlobFilter) :: filter
+      type(TestMethod) :: test1, test2, test3
+
+      filter = GlobFilter('test_?_foo')
+      test1 = TestMethod('test_a_foo', dummy_method)
+      test2 = TestMethod('test_X_foo', dummy_method)
+      test3 = TestMethod('test_ab_foo', dummy_method)
+      
+      @assertTrue(filter%filter(test1), 'Should match single char a')
+      @assertTrue(filter%filter(test2), 'Should match single char X')
+      @assertFalse(filter%filter(test3), 'Should not match two chars')
+   end subroutine test_question_wildcard
+
+   @test
+   subroutine test_multiple_wildcards()
+      type(GlobFilter) :: filter
+      type(TestMethod) :: test
+
+      filter = GlobFilter('test_*_??_*')
+      test = TestMethod('test_foo_ab_bar', dummy_method)
+      
+      @assertTrue(filter%filter(test))
+   end subroutine test_multiple_wildcards
+
+   @test
+   subroutine test_case_sensitive()
+      type(GlobFilter) :: filter
+      type(TestMethod) :: test1, test2
+
+      filter = GlobFilter('Test_Foo')
+      test1 = TestMethod('Test_Foo', dummy_method)
+      test2 = TestMethod('test_foo', dummy_method)
+      
+      @assertTrue(filter%filter(test1), 'Should match exact case')
+      @assertFalse(filter%filter(test2), 'Should not match different case')
+   end subroutine test_case_sensitive
+
+   @test
+   subroutine test_with_nested_suite_name()
+      type(GlobFilter) :: filter
+      type(TestMethod) :: test
+
+      filter = GlobFilter('Suite1.Suite2.test_*')
+      test = TestMethod('test_foo', dummy_method)
+      call test%setName('Suite1.Suite2.test_foo')
+      
+      @assertTrue(filter%filter(test))
+   end subroutine test_with_nested_suite_name
+
+   @test
+   subroutine test_wildcard_matches_empty()
+      type(GlobFilter) :: filter
+      type(TestMethod) :: test
+
+      filter = GlobFilter('test*')
+      test = TestMethod('test', dummy_method)
+      
+      @assertTrue(filter%filter(test), 'Star should match zero characters')
+   end subroutine test_wildcard_matches_empty
+
+   @test
+   subroutine test_complex_pattern()
+      type(GlobFilter) :: filter
+      type(TestMethod) :: test1, test2, test3
+
+      ! Match test suites from Test_GlobPattern.pf
+      filter = GlobFilter('*issip*ss*')
+      test1 = TestMethod('mississipissippi', dummy_method)
+      test2 = TestMethod('missiSIPpi', dummy_method)
+      test3 = TestMethod('other', dummy_method)
+      
+      @assertTrue(filter%filter(test1))
+      @assertFalse(filter%filter(test2), 'Case sensitive should not match')
+      @assertFalse(filter%filter(test3))
+   end subroutine test_complex_pattern
+
+   subroutine dummy_method()
+      ! Empty dummy method for TestMethod constructor
+   end subroutine dummy_method
+
+end module Test_GlobFilter

--- a/tests/funit-core/Test_RegexFilter.pf
+++ b/tests/funit-core/Test_RegexFilter.pf
@@ -1,0 +1,153 @@
+#ifndef _WIN32
+module Test_RegexFilter
+   use FUnit
+   use pf_RegexFilter
+   use pf_TestMethod
+   implicit none
+
+   @suite(name='RegexFilter_suite')
+
+contains
+
+   @test
+   subroutine test_exact_match()
+      type(RegexFilter) :: filter
+      type(TestMethod) :: test
+
+      filter = RegexFilter('^test_foo$')
+      test = TestMethod('test_foo', dummy_method)
+      
+      @assertTrue(filter%filter(test))
+   end subroutine test_exact_match
+
+   @test
+   subroutine test_no_match()
+      type(RegexFilter) :: filter
+      type(TestMethod) :: test
+
+      filter = RegexFilter('^test_foo$')
+      test = TestMethod('test_bar', dummy_method)
+      
+      @assertFalse(filter%filter(test))
+   end subroutine test_no_match
+
+   @test
+   subroutine test_character_class()
+      type(RegexFilter) :: filter
+      type(TestMethod) :: test1, test2, test3
+
+      filter = RegexFilter('test_[0-9]+')
+      test1 = TestMethod('test_123', dummy_method)
+      test2 = TestMethod('test_456', dummy_method)
+      test3 = TestMethod('test_abc', dummy_method)
+      
+      @assertTrue(filter%filter(test1), 'Should match test_123')
+      @assertTrue(filter%filter(test2), 'Should match test_456')
+      @assertFalse(filter%filter(test3), 'Should not match test_abc')
+   end subroutine test_character_class
+
+   @test
+   subroutine test_anchors()
+      type(RegexFilter) :: filter
+      type(TestMethod) :: test1, test2, test3
+
+      filter = RegexFilter('^test_')
+      test1 = TestMethod('test_foo', dummy_method)
+      test2 = TestMethod('my_test_foo', dummy_method)
+      test3 = TestMethod('test_bar', dummy_method)
+      
+      @assertTrue(filter%filter(test1), 'Should match starting with test_')
+      @assertFalse(filter%filter(test2), 'Should not match with prefix')
+      @assertTrue(filter%filter(test3), 'Should match another test_')
+   end subroutine test_anchors
+
+   @test
+   subroutine test_alternation()
+      type(RegexFilter) :: filter
+      type(TestMethod) :: test1, test2, test3
+
+      filter = RegexFilter('test_(foo|bar)')
+      test1 = TestMethod('test_foo', dummy_method)
+      test2 = TestMethod('test_bar', dummy_method)
+      test3 = TestMethod('test_baz', dummy_method)
+      
+      @assertTrue(filter%filter(test1), 'Should match test_foo')
+      @assertTrue(filter%filter(test2), 'Should match test_bar')
+      @assertFalse(filter%filter(test3), 'Should not match test_baz')
+   end subroutine test_alternation
+
+   @test
+   subroutine test_dot_wildcard()
+      type(RegexFilter) :: filter
+      type(TestMethod) :: test1, test2
+
+      filter = RegexFilter('test.foo')
+      test1 = TestMethod('test_foo', dummy_method)
+      test2 = TestMethod('testXfoo', dummy_method)
+      
+      @assertTrue(filter%filter(test1), 'Dot should match underscore')
+      @assertTrue(filter%filter(test2), 'Dot should match X')
+   end subroutine test_dot_wildcard
+
+   @test
+   subroutine test_quantifiers()
+      type(RegexFilter) :: filter
+      type(TestMethod) :: test1, test2, test3
+
+      filter = RegexFilter('test_a+b')
+      test1 = TestMethod('test_ab', dummy_method)
+      test2 = TestMethod('test_aaab', dummy_method)
+      test3 = TestMethod('test_b', dummy_method)
+      
+      @assertTrue(filter%filter(test1), 'Should match one a')
+      @assertTrue(filter%filter(test2), 'Should match multiple a')
+      @assertFalse(filter%filter(test3), 'Should not match zero a')
+   end subroutine test_quantifiers
+
+   @test
+   subroutine test_case_sensitive()
+      type(RegexFilter) :: filter
+      type(TestMethod) :: test1, test2
+
+      filter = RegexFilter('Test_Foo')
+      test1 = TestMethod('Test_Foo', dummy_method)
+      test2 = TestMethod('test_foo', dummy_method)
+      
+      @assertTrue(filter%filter(test1), 'Should match exact case')
+      @assertFalse(filter%filter(test2), 'Should not match different case')
+   end subroutine test_case_sensitive
+
+   @test
+   subroutine test_escaped_dot()
+      type(RegexFilter) :: filter
+      type(TestMethod) :: test1, test2
+
+      filter = RegexFilter('Suite\.test_foo')
+      test1 = TestMethod('Suite.test_foo', dummy_method)
+      test2 = TestMethod('SuiteXtest_foo', dummy_method)
+      
+      @assertTrue(filter%filter(test1), 'Escaped dot should match literal dot')
+      @assertFalse(filter%filter(test2), 'Escaped dot should not match other chars')
+   end subroutine test_escaped_dot
+
+   @test
+   subroutine test_complex_pattern()
+      type(RegexFilter) :: filter
+      type(TestMethod) :: test1, test2, test3
+
+      filter = RegexFilter('^[A-Z][a-z]+\.[a-z_]+[0-9]*$')
+      test1 = TestMethod('Suite.test_123', dummy_method)
+      test2 = TestMethod('Suite.test_abc', dummy_method)
+      test3 = TestMethod('suite.Test', dummy_method)
+      
+      @assertTrue(filter%filter(test1))
+      @assertTrue(filter%filter(test2))
+      @assertFalse(filter%filter(test3))
+   end subroutine test_complex_pattern
+
+   subroutine dummy_method()
+      ! Empty dummy method for TestMethod constructor
+   end subroutine dummy_method
+
+end module Test_RegexFilter
+#endif

--- a/tests/funit-core/test_command_line_filtering.sh
+++ b/tests/funit-core/test_command_line_filtering.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Test command-line filtering options for pFUnit
+# Tests -f/--filter and -e/--exclude flags
+
+set -e  # Exit on error
+
+TEST_EXE="$1"
+if [ -z "$TEST_EXE" ] || [ ! -x "$TEST_EXE" ]; then
+    echo "ERROR: Test executable not provided or not executable: $TEST_EXE"
+    exit 1
+fi
+
+# Color output helpers
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+FAILED=0
+PASSED=0
+
+# Test function
+test_filter() {
+    local description="$1"
+    shift
+    local expected_count="$1"
+    shift
+    
+    echo -n "Testing: $description ... "
+    
+    # Run test and capture output
+    output=$("$TEST_EXE" "$@" 2>&1 || true)
+    
+    # Extract actual test count from "(N tests)" or "(N test)"
+    actual_count=$(echo "$output" | grep -o "([0-9]* test" | grep -o "[0-9]*" || echo "0")
+    
+    if [ "$actual_count" = "$expected_count" ]; then
+        echo -e "${GREEN}PASS${NC} (ran $actual_count tests)"
+        PASSED=$((PASSED + 1))
+    else
+        echo -e "${RED}FAIL${NC} (expected $expected_count, got $actual_count)"
+        echo "Output: $output"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+echo "=========================================="
+echo "Testing pFUnit Command-Line Filtering"
+echo "=========================================="
+echo ""
+
+# Test 1: No filter - all tests run
+test_filter "No filter (all tests)" 6
+
+# Test 2: Filter with glob pattern - specific prefix
+test_filter "Filter test_alpha_* (glob)" 2 -f "FilterCommandLineTests_suite.test_alpha_*"
+
+# Test 3: Filter with glob pattern - different prefix  
+test_filter "Filter test_beta_* (glob)" 2 -f "FilterCommandLineTests_suite.test_beta_*"
+
+# Test 4: Filter with wildcard matching multiple
+test_filter "Filter test_* (glob)" 4 -f "FilterCommandLineTests_suite.test_*"
+
+# Test 5: Exclude pattern
+test_filter "Exclude *slow* (glob)" 5 -e "FilterCommandLineTests_suite.*slow*"
+
+# Test 6: Multiple include patterns (OR logic)
+test_filter "Filter test_alpha_* OR test_beta_* (glob)" 4 -f "FilterCommandLineTests_suite.test_alpha_*" "FilterCommandLineTests_suite.test_beta_*"
+
+# Test 7: Include + Exclude
+test_filter "Filter test_* exclude test_alpha_* (glob)" 2 -f "FilterCommandLineTests_suite.test_*" -e "FilterCommandLineTests_suite.test_alpha_*"
+
+# Test 8: Exclude multiple patterns
+test_filter "Exclude slow* and other* (glob)" 4 -e "FilterCommandLineTests_suite.*slow*" "FilterCommandLineTests_suite.*other*"
+
+# Unix-specific regex tests
+if [ "$(uname)" != "MINGW"* ] && [ "$(uname)" != "MSYS"* ]; then
+    echo ""
+    echo "Running Unix/Linux/macOS-specific regex tests..."
+    
+    # Test 9: Regex pattern with character class
+    test_filter "Filter test_alpha_[a-z]+ (regex)" 2 -f "FilterCommandLineTests_suite\.test_alpha_.*"
+    
+    # Test 10: Regex with anchors
+    test_filter "Filter ^.*test_beta_one$ (regex)" 1 -f "^FilterCommandLineTests_suite\.test_beta_one$"
+    
+    # Test 11: Regex alternation
+    test_filter "Filter test_(alpha|beta)_one (regex)" 2 -f "FilterCommandLineTests_suite\.test_(alpha|beta)_one"
+fi
+
+echo ""
+echo "=========================================="
+echo "Results: $PASSED passed, $FAILED failed"
+echo "=========================================="
+
+if [ $FAILED -gt 0 ]; then
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Preparing release v4.16.0

### Added

- Advanced test filtering with regex and glob patterns (issue #523)
  - `-f`/`--filter` flag supports POSIX regex on Unix/Linux/macOS, glob patterns on Windows
  - `-e`/`--exclude` flag for anti-filtering using glob patterns on all platforms
  - Multiple space-separated patterns supported (OR logic)
  - New modules: RegexFilter, GlobFilter, and C wrapper for POSIX regex
  - Backward compatible with existing simple substring filtering

### Changed

- Update submodule (fArgParse v1.11.0)
- Minor cleanup to CI
- Turned off NVHPC CI test as it seems the image is too large for Github Actions
- Removed some unneeded debugging prints in pFUnitParser.py

### Fixed

- Fix `add_pfunit_ctest` to properly track test file dependencies (issue #380)
  - Adding new `.pf` files to `TEST_SOURCES` now triggers automatic rebuild without make clean
  - Test suite registry (.inc file) generation moved from configure-time to build-time
  - Added build-time dependency tracking between .pf files and generated registry
  - Driver recompilation now triggered automatically when registry changes
  - New helper script: include/generate_test_suite_inc.cmake