### PR TITLE
Prepare for 4.17.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project (PFUNIT
-  VERSION 4.16.0
+  VERSION 4.17.0
   LANGUAGES Fortran C)
 
 cmake_policy(SET CMP0077 NEW)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.17.0] - 2026-04-08
+
 ### Changed
 
 - Updated license to Apache-2.0


### PR DESCRIPTION
This PR updates Changelog and CMakeLists for a 4.17.0 release.

NOTE: We can always change the date when we do it. I just chose tomorrow (2026-04-07) for now.