### PR TITLE
Increase default allocated string length for integers to match real string allocation.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow for larger integer value comparisons greater than 20 digits (issue #540)
+  - Previously, a large but valid `_int64` based integer would fail to be written
+    to a string because of being hard coded to only be allocated 20 characters
+  - Now supports up to 45 digits including potential `-` sign matching
+    supported real value digit count
+
 ## [4.17.1] - 2026-04-09
 
 ### Fixed

--- a/src/funit/asserts/Assert_Integer.tmpl
+++ b/src/funit/asserts/Assert_Integer.tmpl
@@ -69,7 +69,7 @@ module pf_AssertInteger_{rank}d
 
 
 
-   integer, parameter :: MAX_LEN_INT_AS_STRING = 20
+   integer, parameter :: MAX_LEN_INT_AS_STRING = 45
 
 contains
 


### PR DESCRIPTION
Increases the default string allocation for rendering integer based comparisons from 20 characters to 45 characters to match real number string conversions.  Allows assertions for larger but valid integer values.