### PR TITLE
Extend near(), relatively_near(), and equal_to() matchers for REAL64 and rank-4 arrays (issue #542)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Extended `near()` and `relatively_near()` Hamcrest matchers to support `REAL64` and array ranks 1–4 (issue #542)
+  - New typed matcher types: `IsNear_32`, `IsNear_64`, `IsRelativelyNear_32`, `IsRelativelyNear_64`
+  - Tolerance precision matches the expected value's precision
+  - The actual value may be of a different precision (upcast internally)
+- Extended `equal_to()` Hamcrest matcher and `assert_that()` to support rank-4 arrays
+
 ## [4.17.1] - 2026-04-09
 
 ### Fixed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended `near()` and `relatively_near()` Hamcrest matchers to support `REAL64` and array ranks 1–4 (issue #542)
   - New typed matcher types: `IsNear_32`, `IsNear_64`, `IsRelativelyNear_32`, `IsRelativelyNear_64`
   - Tolerance precision matches the expected value's precision
-  - The actual value may be of a different precision (upcast internally)
+  - For arrays, the actual value may be of higher precision than expected (e.g. `real(REAL64)` actual with default-real expected and tolerance), as a convenience to the test writer
+  - For scalars, both precision directions are accepted to preserve backward compatibility
 - Extended `equal_to()` Hamcrest matcher and `assert_that()` to support rank-4 arrays
 
 ## [4.17.1] - 2026-04-09

--- a/src/funit/fhamcrest/IsEqual.F90
+++ b/src/funit/fhamcrest/IsEqual.F90
@@ -21,18 +21,20 @@ module pf_IsEqual
      procedure :: describe_to
      procedure :: describe_mismatch
 
-     procedure :: matches_array_1d
-     procedure :: matches_array_2d
-     procedure :: matches_array_3d
-     procedure :: matches_intrinsic
-  end type IsEqual
+      procedure :: matches_array_1d
+      procedure :: matches_array_2d
+      procedure :: matches_array_3d
+      procedure :: matches_array_4d
+      procedure :: matches_intrinsic
+   end type IsEqual
 
-  interface equal_to
-     module procedure :: equal_to_scalar
-     module procedure :: equal_to_array_1d
-     module procedure :: equal_to_array_2d
-     module procedure :: equal_to_array_3d
-  end interface equal_to
+   interface equal_to
+      module procedure :: equal_to_scalar
+      module procedure :: equal_to_array_1d
+      module procedure :: equal_to_array_2d
+      module procedure :: equal_to_array_3d
+      module procedure :: equal_to_array_4d
+   end interface equal_to
 
 contains
 
@@ -72,6 +74,15 @@ contains
   end function equal_to_array_3d
 
 
+  function equal_to_array_4d(operand) result(matcher)
+    type (IsEqual) :: matcher
+    class(*), intent(in) :: operand(:,:,:,:)
+
+    matcher%expected_value = ArrayWrapper(operand)
+
+  end function equal_to_array_4d
+
+
   subroutine describe_to(this, description)
     class(IsEqual), intent(in):: this
     class(MatcherDescription), intent(inout) :: description
@@ -106,6 +117,8 @@ contains
        matches = this%matches_array_2d(e%items, actual_value)
     type is (ArrayWrapper_3d)
        matches = this%matches_array_3d(e%items, actual_value)
+    type is (ArrayWrapper_4d)
+       matches = this%matches_array_4d(e%items, actual_value)
     class is (Matchable)
        matches = (e == actual_value)
     class default ! intrinsics
@@ -213,6 +226,44 @@ contains
     end select
 
   end function matches_array_3d
+
+
+
+  logical function matches_array_4d(this, expected_items, actual_value)
+    class(IsEqual), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:,:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j, k, l
+    type (IsEqual) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_4d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do l = 1, size(a%items,4)
+             do k = 1, size(a%items,3)
+                do j = 1, size(a%items,2)
+                   do i = 1, size(a%items,1)
+                      m = equal_to(expected_items(i,j,k,l))
+                      if (.not. m%matches(a%items(i,j,k,l))) then
+                         matches_array_4d = .false.
+                         return
+                      end if
+                   end do
+                end do
+             end do
+          end do
+          matches_array_4d = .true.
+       else
+          matches_array_4d = .false. ! differing shape/size
+       end if
+    class default
+       matches_array_4d = .false. ! differing types
+    end select
+
+  end function matches_array_4d
 
 
 

--- a/src/funit/fhamcrest/IsNear.F90
+++ b/src/funit/fhamcrest/IsNear.F90
@@ -575,6 +575,8 @@ contains
     end if
 
     select type (actual_value)
+    type is (real(kind=REAL32))
+       matches_safely_64 = abs(real(actual_value, kind=REAL64) - this%value) <= this%tolerance
     type is (real(kind=REAL64))
        matches_safely_64 = abs(actual_value - this%value) <= this%tolerance
     end select
@@ -778,6 +780,13 @@ contains
     real(kind=REAL64) :: d
 
     select type (actual)
+    type is (real(kind=REAL32))
+       d = this%delta(real(actual, kind=REAL64))
+       call description%append_value(actual)
+       call description%append_text(" differed by ")
+       call description%append_value(d)
+       call description%append_text(" which exceeds the tolerance by ")
+       call description%append_value(d - this%tolerance)
     type is (real(kind=REAL64))
        d = this%delta(actual)
        call description%append_value(actual)
@@ -797,6 +806,8 @@ contains
     _UNUSED_DUMMY(this)
 
     select type (actual)
+    type is (real(kind=REAL32))
+       supported = .true.
     type is (real(kind=REAL64))
        supported = .true.
     class is (ArrayWrapper_1d)

--- a/src/funit/fhamcrest/IsNear.F90
+++ b/src/funit/fhamcrest/IsNear.F90
@@ -289,23 +289,28 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, n_items
-    type(IsNear_32) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL32) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_1d)
        n_items = size(expected_items)
        if (size(a%items) == n_items) then
-           do i = 1, n_items
+          do i = 1, n_items
              select type (e => expected_items(i))
              type is (real(kind=REAL32))
-                m = near(e, this%tolerance)
+                e_val = e
              class default
                 matches_array_1d_32 = .false.
                 return
              end select
-             if (.not. m%matches_safely(a%items(i))) then
+             select type (av => a%items(i))
+             type is (real(kind=REAL32))
+                a_val = av
+             class default
+                matches_array_1d_32 = .false.
+                return
+             end select
+             if (abs(a_val - e_val) > this%tolerance) then
                 matches_array_1d_32 = .false.
                 return
              end if
@@ -327,23 +332,28 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, j
-    type(IsNear_32) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL32) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_2d)
        if (all(shape(a%items) == shape(expected_items))) then
           do j = 1, size(a%items,2)
-              do i = 1, size(a%items,1)
+             do i = 1, size(a%items,1)
                 select type (e => expected_items(i,j))
                 type is (real(kind=REAL32))
-                   m = near(e, this%tolerance)
+                   e_val = e
                 class default
                    matches_array_2d_32 = .false.
                    return
                 end select
-                if (.not. m%matches_safely(a%items(i,j))) then
+                select type (av => a%items(i,j))
+                type is (real(kind=REAL32))
+                   a_val = av
+                class default
+                   matches_array_2d_32 = .false.
+                   return
+                end select
+                if (abs(a_val - e_val) > this%tolerance) then
                    matches_array_2d_32 = .false.
                    return
                 end if
@@ -366,24 +376,29 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, j, k
-    type(IsNear_32) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL32) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_3d)
        if (all(shape(a%items) == shape(expected_items))) then
           do k = 1, size(a%items,3)
              do j = 1, size(a%items,2)
-                 do i = 1, size(a%items,1)
+                do i = 1, size(a%items,1)
                    select type (e => expected_items(i,j,k))
                    type is (real(kind=REAL32))
-                      m = near(e, this%tolerance)
+                      e_val = e
                    class default
                       matches_array_3d_32 = .false.
                       return
                    end select
-                   if (.not. m%matches_safely(a%items(i,j,k))) then
+                   select type (av => a%items(i,j,k))
+                   type is (real(kind=REAL32))
+                      a_val = av
+                   class default
+                      matches_array_3d_32 = .false.
+                      return
+                   end select
+                   if (abs(a_val - e_val) > this%tolerance) then
                       matches_array_3d_32 = .false.
                       return
                    end if
@@ -407,9 +422,7 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, j, k, l
-    type(IsNear_32) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL32) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_4d)
@@ -417,15 +430,22 @@ contains
           do l = 1, size(a%items,4)
              do k = 1, size(a%items,3)
                 do j = 1, size(a%items,2)
-                    do i = 1, size(a%items,1)
+                   do i = 1, size(a%items,1)
                       select type (e => expected_items(i,j,k,l))
                       type is (real(kind=REAL32))
-                         m = near(e, this%tolerance)
+                         e_val = e
                       class default
                          matches_array_4d_32 = .false.
                          return
                       end select
-                      if (.not. m%matches_safely(a%items(i,j,k,l))) then
+                      select type (av => a%items(i,j,k,l))
+                      type is (real(kind=REAL32))
+                         a_val = av
+                      class default
+                         matches_array_4d_32 = .false.
+                         return
+                      end select
+                      if (abs(a_val - e_val) > this%tolerance) then
                          matches_array_4d_32 = .false.
                          return
                       end if
@@ -508,10 +528,16 @@ contains
     class(IsNear_32), intent(in) :: this
     class(MatcherDescription), intent(inout) :: description
 
-    call description%append_text("a numeric value within ")
-    call description%append_value(this%tolerance)
-    call description%append_text(" of ")
-    call description%append_value(this%value)
+    if (allocated(this%array_value)) then
+       call description%append_text("an array where each element is within ")
+       call description%append_value(this%tolerance)
+       call description%append_text(" of the expected element")
+    else
+       call description%append_text("a numeric value within ")
+       call description%append_value(this%tolerance)
+       call description%append_text(" of ")
+       call description%append_value(this%value)
+    end if
 
   end subroutine describe_to_32
 
@@ -556,23 +582,30 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, n_items
-    type(IsNear_64) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL64) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_1d)
        n_items = size(expected_items)
        if (size(a%items) == n_items) then
-           do i = 1, n_items
+          do i = 1, n_items
              select type (e => expected_items(i))
              type is (real(kind=REAL64))
-                m = near(e, this%tolerance)
+                e_val = e
              class default
                 matches_array_1d_64 = .false.
                 return
              end select
-             if (.not. m%matches_safely(a%items(i))) then
+             select type (av => a%items(i))
+             type is (real(kind=REAL32))
+                a_val = real(av, kind=REAL64)
+             type is (real(kind=REAL64))
+                a_val = av
+             class default
+                matches_array_1d_64 = .false.
+                return
+             end select
+             if (abs(a_val - e_val) > this%tolerance) then
                 matches_array_1d_64 = .false.
                 return
              end if
@@ -594,23 +627,30 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, j
-    type(IsNear_64) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL64) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_2d)
        if (all(shape(a%items) == shape(expected_items))) then
           do j = 1, size(a%items,2)
-              do i = 1, size(a%items,1)
+             do i = 1, size(a%items,1)
                 select type (e => expected_items(i,j))
                 type is (real(kind=REAL64))
-                   m = near(e, this%tolerance)
+                   e_val = e
                 class default
                    matches_array_2d_64 = .false.
                    return
                 end select
-                if (.not. m%matches_safely(a%items(i,j))) then
+                select type (av => a%items(i,j))
+                type is (real(kind=REAL32))
+                   a_val = real(av, kind=REAL64)
+                type is (real(kind=REAL64))
+                   a_val = av
+                class default
+                   matches_array_2d_64 = .false.
+                   return
+                end select
+                if (abs(a_val - e_val) > this%tolerance) then
                    matches_array_2d_64 = .false.
                    return
                 end if
@@ -633,24 +673,31 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, j, k
-    type(IsNear_64) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL64) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_3d)
        if (all(shape(a%items) == shape(expected_items))) then
           do k = 1, size(a%items,3)
              do j = 1, size(a%items,2)
-                 do i = 1, size(a%items,1)
+                do i = 1, size(a%items,1)
                    select type (e => expected_items(i,j,k))
                    type is (real(kind=REAL64))
-                      m = near(e, this%tolerance)
+                      e_val = e
                    class default
                       matches_array_3d_64 = .false.
                       return
                    end select
-                   if (.not. m%matches_safely(a%items(i,j,k))) then
+                   select type (av => a%items(i,j,k))
+                   type is (real(kind=REAL32))
+                      a_val = real(av, kind=REAL64)
+                   type is (real(kind=REAL64))
+                      a_val = av
+                   class default
+                      matches_array_3d_64 = .false.
+                      return
+                   end select
+                   if (abs(a_val - e_val) > this%tolerance) then
                       matches_array_3d_64 = .false.
                       return
                    end if
@@ -674,9 +721,7 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, j, k, l
-    type(IsNear_64) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL64) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_4d)
@@ -684,15 +729,24 @@ contains
           do l = 1, size(a%items,4)
              do k = 1, size(a%items,3)
                 do j = 1, size(a%items,2)
-                    do i = 1, size(a%items,1)
+                   do i = 1, size(a%items,1)
                       select type (e => expected_items(i,j,k,l))
                       type is (real(kind=REAL64))
-                         m = near(e, this%tolerance)
+                         e_val = e
                       class default
                          matches_array_4d_64 = .false.
                          return
                       end select
-                      if (.not. m%matches_safely(a%items(i,j,k,l))) then
+                      select type (av => a%items(i,j,k,l))
+                      type is (real(kind=REAL32))
+                         a_val = real(av, kind=REAL64)
+                      type is (real(kind=REAL64))
+                         a_val = av
+                      class default
+                         matches_array_4d_64 = .false.
+                         return
+                      end select
+                      if (abs(a_val - e_val) > this%tolerance) then
                          matches_array_4d_64 = .false.
                          return
                       end if
@@ -775,10 +829,16 @@ contains
     class(IsNear_64), intent(in) :: this
     class(MatcherDescription), intent(inout) :: description
 
-    call description%append_text("a numeric value within ")
-    call description%append_value(this%tolerance)
-    call description%append_text(" of ")
-    call description%append_value(this%value)
+    if (allocated(this%array_value)) then
+       call description%append_text("an array where each element is within ")
+       call description%append_value(this%tolerance)
+       call description%append_text(" of the expected element")
+    else
+       call description%append_text("a numeric value within ")
+       call description%append_value(this%tolerance)
+       call description%append_text(" of ")
+       call description%append_value(this%value)
+    end if
 
   end subroutine describe_to_64
 

--- a/src/funit/fhamcrest/IsNear.F90
+++ b/src/funit/fhamcrest/IsNear.F90
@@ -306,6 +306,8 @@ contains
              select type (av => a%items(i))
              type is (real(kind=REAL32))
                 a_val = av
+             type is (real(kind=REAL64))
+                a_val = real(av, kind=REAL32)
              class default
                 matches_array_1d_32 = .false.
                 return
@@ -349,6 +351,8 @@ contains
                 select type (av => a%items(i,j))
                 type is (real(kind=REAL32))
                    a_val = av
+                type is (real(kind=REAL64))
+                   a_val = real(av, kind=REAL32)
                 class default
                    matches_array_2d_32 = .false.
                    return
@@ -394,6 +398,8 @@ contains
                    select type (av => a%items(i,j,k))
                    type is (real(kind=REAL32))
                       a_val = av
+                   type is (real(kind=REAL64))
+                      a_val = real(av, kind=REAL32)
                    class default
                       matches_array_3d_32 = .false.
                       return
@@ -441,6 +447,8 @@ contains
                       select type (av => a%items(i,j,k,l))
                       type is (real(kind=REAL32))
                          a_val = av
+                      type is (real(kind=REAL64))
+                         a_val = real(av, kind=REAL32)
                       class default
                          matches_array_4d_32 = .false.
                          return
@@ -567,8 +575,6 @@ contains
     end if
 
     select type (actual_value)
-    type is (real(kind=REAL32))
-       matches_safely_64 = abs(real(actual_value, kind=REAL64) - this%value) <= this%tolerance
     type is (real(kind=REAL64))
        matches_safely_64 = abs(actual_value - this%value) <= this%tolerance
     end select
@@ -597,8 +603,6 @@ contains
                 return
              end select
              select type (av => a%items(i))
-             type is (real(kind=REAL32))
-                a_val = real(av, kind=REAL64)
              type is (real(kind=REAL64))
                 a_val = av
              class default
@@ -642,8 +646,6 @@ contains
                    return
                 end select
                 select type (av => a%items(i,j))
-                type is (real(kind=REAL32))
-                   a_val = real(av, kind=REAL64)
                 type is (real(kind=REAL64))
                    a_val = av
                 class default
@@ -689,8 +691,6 @@ contains
                       return
                    end select
                    select type (av => a%items(i,j,k))
-                   type is (real(kind=REAL32))
-                      a_val = real(av, kind=REAL64)
                    type is (real(kind=REAL64))
                       a_val = av
                    class default
@@ -738,8 +738,6 @@ contains
                          return
                       end select
                       select type (av => a%items(i,j,k,l))
-                      type is (real(kind=REAL32))
-                         a_val = real(av, kind=REAL64)
                       type is (real(kind=REAL64))
                          a_val = av
                       class default
@@ -780,13 +778,6 @@ contains
     real(kind=REAL64) :: d
 
     select type (actual)
-    type is (real(kind=REAL32))
-       d = this%delta(real(actual, kind=REAL64))
-       call description%append_value(actual)
-       call description%append_text(" differed by ")
-       call description%append_value(d)
-       call description%append_text(" which exceeds the tolerance by ")
-       call description%append_value(d - this%tolerance)
     type is (real(kind=REAL64))
        d = this%delta(actual)
        call description%append_value(actual)
@@ -806,8 +797,6 @@ contains
     _UNUSED_DUMMY(this)
 
     select type (actual)
-    type is (real(kind=REAL32))
-       supported = .true.
     type is (real(kind=REAL64))
        supported = .true.
     class is (ArrayWrapper_1d)

--- a/src/funit/fhamcrest/IsNear.F90
+++ b/src/funit/fhamcrest/IsNear.F90
@@ -1,84 +1,739 @@
 #include "unused_dummy.fh"
 
 module pf_IsNear
+  use iso_fortran_env, only: REAL32, REAL64
   use pf_TypeSafeMatcher
   use pf_MatcherDescription
+  use pf_AbstractArrayWrapper
+  use pf_ArrayWrapper
   implicit none
   private
 
-  public :: IsNear
+  public :: IsNear_32
+  public :: IsNear_64
   public :: near
 
-  type, extends(TypeSafeMatcher) :: IsNear
+
+
+  !------------------------------------------------------------
+  ! 32-bit variant
+  !------------------------------------------------------------
+  type, extends(TypeSafeMatcher) :: IsNear_32
      private
      real :: tolerance
      real :: value
+     class(*), allocatable :: array_value
    contains
-     procedure :: matches_safely
-     procedure :: describe_mismatch_safely
-     procedure :: expects_type_of
-     procedure :: delta
-     procedure :: describe_to
-  end type IsNear
+     procedure :: matches_safely      => matches_safely_32
+     procedure :: describe_mismatch_safely => describe_mismatch_safely_32
+     procedure :: expects_type_of     => expects_type_of_32
+     procedure :: delta               => delta_32
+     procedure :: describe_to         => describe_to_32
+     procedure :: matches_array_1d    => matches_array_1d_32
+     procedure :: matches_array_2d    => matches_array_2d_32
+     procedure :: matches_array_3d    => matches_array_3d_32
+     procedure :: matches_array_4d    => matches_array_4d_32
+  end type IsNear_32
+
+  !------------------------------------------------------------
+  ! 64-bit variant
+  !------------------------------------------------------------
+  type, extends(TypeSafeMatcher) :: IsNear_64
+     private
+     real(kind=REAL64) :: tolerance
+     real(kind=REAL64) :: value
+     class(*), allocatable :: array_value
+   contains
+     procedure :: matches_safely      => matches_safely_64
+     procedure :: describe_mismatch_safely => describe_mismatch_safely_64
+     procedure :: expects_type_of     => expects_type_of_64
+     procedure :: delta               => delta_64
+     procedure :: describe_to         => describe_to_64
+     procedure :: matches_array_1d    => matches_array_1d_64
+     procedure :: matches_array_2d    => matches_array_2d_64
+     procedure :: matches_array_3d    => matches_array_3d_64
+     procedure :: matches_array_4d    => matches_array_4d_64
+  end type IsNear_64
 
   interface near
+     ! scalar
      module procedure near_real
+     module procedure near_double
+#if (defined(_ISO_REAL32) && (_ISO_REAL32 != _REAL_DEFAULT_KIND) && (_ISO_REAL32 != _DOUBLE_DEFAULT_KIND))
+     module procedure near_real32
+#endif
+#if (defined(_ISO_REAL64) && (_ISO_REAL64 != _REAL_DEFAULT_KIND) && (_ISO_REAL64 != _DOUBLE_DEFAULT_KIND))
+     module procedure near_real64
+#endif
+     ! arrays — 32-bit
+     module procedure near_real_1d
+     module procedure near_real_2d
+     module procedure near_real_3d
+     module procedure near_real_4d
+     ! arrays — 64-bit
+     module procedure near_double_1d
+     module procedure near_double_2d
+     module procedure near_double_3d
+     module procedure near_double_4d
+#if (defined(_ISO_REAL32) && (_ISO_REAL32 != _REAL_DEFAULT_KIND) && (_ISO_REAL32 != _DOUBLE_DEFAULT_KIND))
+     module procedure near_real32_1d
+     module procedure near_real32_2d
+     module procedure near_real32_3d
+     module procedure near_real32_4d
+#endif
+#if (defined(_ISO_REAL64) && (_ISO_REAL64 != _REAL_DEFAULT_KIND) && (_ISO_REAL64 != _DOUBLE_DEFAULT_KIND))
+     module procedure near_real64_1d
+     module procedure near_real64_2d
+     module procedure near_real64_3d
+     module procedure near_real64_4d
+#endif
   end interface near
-  
+
 
 contains
 
+  !=============================================================
+  ! Constructors — return IsNear_32 or IsNear_64
+  !=============================================================
 
-  function near_real(value, tolerance) result(near)
-    type(IsNear) :: near
-    real, intent(in) :: value
-    real, intent(in) :: tolerance
-
-    near%value = value
-    near%tolerance = tolerance
-
+  function near_real(value, tolerance) result(matcher)
+    type(IsNear_32) :: matcher
+    real, intent(in) :: value, tolerance
+    matcher%value     = value
+    matcher%tolerance = tolerance
   end function near_real
 
+  function near_double(value, tolerance) result(matcher)
+    type(IsNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value, tolerance
+    matcher%value     = value
+    matcher%tolerance = tolerance
+  end function near_double
 
-  function relatively_near_real(value, tolerance) result(relatively_near)
-    type(IsNear) :: relatively_near
-    real, intent(in) :: value
-    real, intent(in) :: tolerance
+#if (defined(_ISO_REAL32) && (_ISO_REAL32 != _REAL_DEFAULT_KIND) && (_ISO_REAL32 != _DOUBLE_DEFAULT_KIND))
+  function near_real32(value, tolerance) result(matcher)
+    type(IsNear_32) :: matcher
+    real(kind=REAL32), intent(in) :: value, tolerance
+    matcher%value     = real(value)
+    matcher%tolerance = real(tolerance)
+  end function near_real32
+#endif
 
-    relatively_near%value = value
-    relatively_near%tolerance = tolerance
+#if (defined(_ISO_REAL64) && (_ISO_REAL64 != _REAL_DEFAULT_KIND) && (_ISO_REAL64 != _DOUBLE_DEFAULT_KIND))
+  function near_real64(value, tolerance) result(matcher)
+    type(IsNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value, tolerance
+    matcher%value     = real(value, kind=REAL64)
+    matcher%tolerance = real(tolerance, kind=REAL64)
+  end function near_real64
+#endif
 
-  end function relatively_near_real
+  ! --- array constructors returning IsNear_32 ---
+
+  function near_real_1d(value, tolerance) result(matcher)
+    type(IsNear_32) :: matcher
+    real, intent(in) :: value(:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function near_real_1d
+
+  function near_real_2d(value, tolerance) result(matcher)
+    type(IsNear_32) :: matcher
+    real, intent(in) :: value(:,:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function near_real_2d
+
+  function near_real_3d(value, tolerance) result(matcher)
+    type(IsNear_32) :: matcher
+    real, intent(in) :: value(:,:,:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function near_real_3d
+
+  function near_real_4d(value, tolerance) result(matcher)
+    type(IsNear_32) :: matcher
+    real, intent(in) :: value(:,:,:,:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function near_real_4d
+
+  ! --- array constructors returning IsNear_64 ---
+
+  function near_double_1d(value, tolerance) result(matcher)
+    type(IsNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function near_double_1d
+
+  function near_double_2d(value, tolerance) result(matcher)
+    type(IsNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:,:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function near_double_2d
+
+  function near_double_3d(value, tolerance) result(matcher)
+    type(IsNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:,:,:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function near_double_3d
+
+  function near_double_4d(value, tolerance) result(matcher)
+    type(IsNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:,:,:,:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function near_double_4d
+
+#if (defined(_ISO_REAL32) && (_ISO_REAL32 != _REAL_DEFAULT_KIND) && (_ISO_REAL32 != _DOUBLE_DEFAULT_KIND))
+  function near_real32_1d(value, tolerance) result(matcher)
+    type(IsNear_32) :: matcher
+    real(kind=REAL32), intent(in) :: value(:), tolerance
+    matcher%tolerance = real(tolerance)
+    matcher%array_value = ArrayWrapper(value)
+  end function near_real32_1d
+
+  function near_real32_2d(value, tolerance) result(matcher)
+    type(IsNear_32) :: matcher
+    real(kind=REAL32), intent(in) :: value(:,:), tolerance
+    matcher%tolerance = real(tolerance)
+    matcher%array_value = ArrayWrapper(value)
+  end function near_real32_2d
+
+  function near_real32_3d(value, tolerance) result(matcher)
+    type(IsNear_32) :: matcher
+    real(kind=REAL32), intent(in) :: value(:,:,:), tolerance
+    matcher%tolerance = real(tolerance)
+    matcher%array_value = ArrayWrapper(value)
+  end function near_real32_3d
+
+  function near_real32_4d(value, tolerance) result(matcher)
+    type(IsNear_32) :: matcher
+    real(kind=REAL32), intent(in) :: value(:,:,:,:), tolerance
+    matcher%tolerance = real(tolerance)
+    matcher%array_value = ArrayWrapper(value)
+  end function near_real32_4d
+#endif
+
+#if (defined(_ISO_REAL64) && (_ISO_REAL64 != _REAL_DEFAULT_KIND) && (_ISO_REAL64 != _DOUBLE_DEFAULT_KIND))
+  function near_real64_1d(value, tolerance) result(matcher)
+    type(IsNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:), tolerance
+    matcher%tolerance = real(tolerance, kind=REAL64)
+    matcher%array_value = ArrayWrapper(value)
+  end function near_real64_1d
+
+  function near_real64_2d(value, tolerance) result(matcher)
+    type(IsNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:,:), tolerance
+    matcher%tolerance = real(tolerance, kind=REAL64)
+    matcher%array_value = ArrayWrapper(value)
+  end function near_real64_2d
+
+  function near_real64_3d(value, tolerance) result(matcher)
+    type(IsNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:,:,:), tolerance
+    matcher%tolerance = real(tolerance, kind=REAL64)
+    matcher%array_value = ArrayWrapper(value)
+  end function near_real64_3d
+
+  function near_real64_4d(value, tolerance) result(matcher)
+    type(IsNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:,:,:,:), tolerance
+    matcher%tolerance = real(tolerance, kind=REAL64)
+    matcher%array_value = ArrayWrapper(value)
+  end function near_real64_4d
+#endif
 
 
-  logical function matches_safely(this, actual_value)
-    class(IsNear), intent(in) :: this
+  !=============================================================
+  ! IsNear_32 implementations
+  !=============================================================
+
+  logical function matches_safely_32(this, actual_value)
+    class(IsNear_32), intent(in) :: this
     class(*), intent(in) :: actual_value
 
+    if (allocated(this%array_value)) then
+       select type (a => this%array_value)
+       type is (ArrayWrapper_1d)
+          matches_safely_32 = this%matches_array_1d(a%items, actual_value)
+       type is (ArrayWrapper_2d)
+          matches_safely_32 = this%matches_array_2d(a%items, actual_value)
+       type is (ArrayWrapper_3d)
+          matches_safely_32 = this%matches_array_3d(a%items, actual_value)
+       type is (ArrayWrapper_4d)
+          matches_safely_32 = this%matches_array_4d(a%items, actual_value)
+       class default
+          matches_safely_32 = .false.
+       end select
+       return
+    end if
+
     select type (actual_value)
-    type is (real)
-       matches_safely = abs(actual_value - this%value) <= this%tolerance
+    type is (real(kind=REAL32))
+       matches_safely_32 = abs(actual_value - this%value) <= this%tolerance
+    type is (real(kind=REAL64))
+       matches_safely_32 = abs(real(actual_value, kind=REAL32) - this%value) <= this%tolerance
     end select
-    
-  end function matches_safely
 
-  real function delta(this, actual)
-    class(IsNear), intent(in) :: this
+  end function matches_safely_32
+
+
+  logical function matches_array_1d_32(this, expected_items, actual_value)
+    class(IsNear_32), intent(in) :: this
+    class(*), intent(in) :: expected_items(:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, n_items
+    type(IsNear_32) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_1d)
+       n_items = size(expected_items)
+       if (size(a%items) == n_items) then
+           do i = 1, n_items
+             select type (e => expected_items(i))
+             type is (real(kind=REAL32))
+                m = near(e, this%tolerance)
+             class default
+                matches_array_1d_32 = .false.
+                return
+             end select
+             if (.not. m%matches_safely(a%items(i))) then
+                matches_array_1d_32 = .false.
+                return
+             end if
+          end do
+          matches_array_1d_32 = .true.
+       else
+          matches_array_1d_32 = .false.
+       end if
+    class default
+       matches_array_1d_32 = .false.
+    end select
+
+  end function matches_array_1d_32
+
+
+  logical function matches_array_2d_32(this, expected_items, actual_value)
+    class(IsNear_32), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j
+    type(IsNear_32) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_2d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do j = 1, size(a%items,2)
+              do i = 1, size(a%items,1)
+                select type (e => expected_items(i,j))
+                type is (real(kind=REAL32))
+                   m = near(e, this%tolerance)
+                class default
+                   matches_array_2d_32 = .false.
+                   return
+                end select
+                if (.not. m%matches_safely(a%items(i,j))) then
+                   matches_array_2d_32 = .false.
+                   return
+                end if
+             end do
+          end do
+          matches_array_2d_32 = .true.
+       else
+          matches_array_2d_32 = .false.
+       end if
+    class default
+       matches_array_2d_32 = .false.
+    end select
+
+  end function matches_array_2d_32
+
+
+  logical function matches_array_3d_32(this, expected_items, actual_value)
+    class(IsNear_32), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j, k
+    type(IsNear_32) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_3d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do k = 1, size(a%items,3)
+             do j = 1, size(a%items,2)
+                 do i = 1, size(a%items,1)
+                   select type (e => expected_items(i,j,k))
+                   type is (real(kind=REAL32))
+                      m = near(e, this%tolerance)
+                   class default
+                      matches_array_3d_32 = .false.
+                      return
+                   end select
+                   if (.not. m%matches_safely(a%items(i,j,k))) then
+                      matches_array_3d_32 = .false.
+                      return
+                   end if
+                end do
+             end do
+          end do
+          matches_array_3d_32 = .true.
+       else
+          matches_array_3d_32 = .false.
+       end if
+    class default
+       matches_array_3d_32 = .false.
+    end select
+
+  end function matches_array_3d_32
+
+
+  logical function matches_array_4d_32(this, expected_items, actual_value)
+    class(IsNear_32), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:,:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j, k, l
+    type(IsNear_32) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_4d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do l = 1, size(a%items,4)
+             do k = 1, size(a%items,3)
+                do j = 1, size(a%items,2)
+                    do i = 1, size(a%items,1)
+                      select type (e => expected_items(i,j,k,l))
+                      type is (real(kind=REAL32))
+                         m = near(e, this%tolerance)
+                      class default
+                         matches_array_4d_32 = .false.
+                         return
+                      end select
+                      if (.not. m%matches_safely(a%items(i,j,k,l))) then
+                         matches_array_4d_32 = .false.
+                         return
+                      end if
+                   end do
+                end do
+             end do
+          end do
+          matches_array_4d_32 = .true.
+       else
+          matches_array_4d_32 = .false.
+       end if
+    class default
+       matches_array_4d_32 = .false.
+    end select
+
+  end function matches_array_4d_32
+
+
+  real function delta_32(this, actual)
+    class(IsNear_32), intent(in) :: this
     real, intent(in) :: actual
+    delta_32 = abs(actual - this%value)
+  end function delta_32
 
-    delta = abs(actual - this%value)
-  end function delta
 
-
-  subroutine describe_mismatch_safely(this, actual, description)
-    class(IsNear), intent(in) :: this
+  subroutine describe_mismatch_safely_32(this, actual, description)
+    class(IsNear_32), intent(in) :: this
     class(*), intent(in) :: actual
     class(MatcherDescription), intent(inout) :: description
 
     real :: d
 
     select type (actual)
-    type is (real)
+    type is (real(kind=REAL32))
+       d = this%delta(actual)
+       call description%append_value(actual)
+       call description%append_text(" differed by ")
+       call description%append_value(d)
+       call description%append_text(" which exceeds the tolerance by ")
+       call description%append_value(d - this%tolerance)
+    type is (real(kind=REAL64))
+       d = this%delta(real(actual, kind=REAL32))
+       call description%append_value(actual)
+       call description%append_text(" differed by ")
+       call description%append_value(d)
+       call description%append_text(" which exceeds the tolerance by ")
+       call description%append_value(d - this%tolerance)
+    end select
+
+  end subroutine describe_mismatch_safely_32
+
+
+  logical function expects_type_of_32(this, actual) result(supported)
+    class(IsNear_32), intent(in) :: this
+    class(*), intent(in) :: actual
+
+    _UNUSED_DUMMY(this)
+
+    select type (actual)
+    type is (real(kind=REAL32))
+       supported = .true.
+    type is (real(kind=REAL64))
+       supported = .true.
+    class is (ArrayWrapper_1d)
+       supported = allocated(this%array_value)
+    class is (ArrayWrapper_2d)
+       supported = allocated(this%array_value)
+    class is (ArrayWrapper_3d)
+       supported = allocated(this%array_value)
+    class is (ArrayWrapper_4d)
+       supported = allocated(this%array_value)
+    class default
+       supported = .false.
+    end select
+
+  end function expects_type_of_32
+
+
+  subroutine describe_to_32(this, description)
+    class(IsNear_32), intent(in) :: this
+    class(MatcherDescription), intent(inout) :: description
+
+    call description%append_text("a numeric value within ")
+    call description%append_value(this%tolerance)
+    call description%append_text(" of ")
+    call description%append_value(this%value)
+
+  end subroutine describe_to_32
+
+
+  !=============================================================
+  ! IsNear_64 implementations
+  !=============================================================
+
+  logical function matches_safely_64(this, actual_value)
+    class(IsNear_64), intent(in) :: this
+    class(*), intent(in) :: actual_value
+
+    if (allocated(this%array_value)) then
+       select type (a => this%array_value)
+       type is (ArrayWrapper_1d)
+          matches_safely_64 = this%matches_array_1d(a%items, actual_value)
+       type is (ArrayWrapper_2d)
+          matches_safely_64 = this%matches_array_2d(a%items, actual_value)
+       type is (ArrayWrapper_3d)
+          matches_safely_64 = this%matches_array_3d(a%items, actual_value)
+       type is (ArrayWrapper_4d)
+          matches_safely_64 = this%matches_array_4d(a%items, actual_value)
+       class default
+          matches_safely_64 = .false.
+       end select
+       return
+    end if
+
+    select type (actual_value)
+    type is (real(kind=REAL32))
+       matches_safely_64 = abs(real(actual_value, kind=REAL64) - this%value) <= this%tolerance
+    type is (real(kind=REAL64))
+       matches_safely_64 = abs(actual_value - this%value) <= this%tolerance
+    end select
+
+  end function matches_safely_64
+
+
+  logical function matches_array_1d_64(this, expected_items, actual_value)
+    class(IsNear_64), intent(in) :: this
+    class(*), intent(in) :: expected_items(:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, n_items
+    type(IsNear_64) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_1d)
+       n_items = size(expected_items)
+       if (size(a%items) == n_items) then
+           do i = 1, n_items
+             select type (e => expected_items(i))
+             type is (real(kind=REAL64))
+                m = near(e, this%tolerance)
+             class default
+                matches_array_1d_64 = .false.
+                return
+             end select
+             if (.not. m%matches_safely(a%items(i))) then
+                matches_array_1d_64 = .false.
+                return
+             end if
+          end do
+          matches_array_1d_64 = .true.
+       else
+          matches_array_1d_64 = .false.
+       end if
+    class default
+       matches_array_1d_64 = .false.
+    end select
+
+  end function matches_array_1d_64
+
+
+  logical function matches_array_2d_64(this, expected_items, actual_value)
+    class(IsNear_64), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j
+    type(IsNear_64) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_2d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do j = 1, size(a%items,2)
+              do i = 1, size(a%items,1)
+                select type (e => expected_items(i,j))
+                type is (real(kind=REAL64))
+                   m = near(e, this%tolerance)
+                class default
+                   matches_array_2d_64 = .false.
+                   return
+                end select
+                if (.not. m%matches_safely(a%items(i,j))) then
+                   matches_array_2d_64 = .false.
+                   return
+                end if
+             end do
+          end do
+          matches_array_2d_64 = .true.
+       else
+          matches_array_2d_64 = .false.
+       end if
+    class default
+       matches_array_2d_64 = .false.
+    end select
+
+  end function matches_array_2d_64
+
+
+  logical function matches_array_3d_64(this, expected_items, actual_value)
+    class(IsNear_64), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j, k
+    type(IsNear_64) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_3d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do k = 1, size(a%items,3)
+             do j = 1, size(a%items,2)
+                 do i = 1, size(a%items,1)
+                   select type (e => expected_items(i,j,k))
+                   type is (real(kind=REAL64))
+                      m = near(e, this%tolerance)
+                   class default
+                      matches_array_3d_64 = .false.
+                      return
+                   end select
+                   if (.not. m%matches_safely(a%items(i,j,k))) then
+                      matches_array_3d_64 = .false.
+                      return
+                   end if
+                end do
+             end do
+          end do
+          matches_array_3d_64 = .true.
+       else
+          matches_array_3d_64 = .false.
+       end if
+    class default
+       matches_array_3d_64 = .false.
+    end select
+
+  end function matches_array_3d_64
+
+
+  logical function matches_array_4d_64(this, expected_items, actual_value)
+    class(IsNear_64), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:,:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j, k, l
+    type(IsNear_64) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_4d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do l = 1, size(a%items,4)
+             do k = 1, size(a%items,3)
+                do j = 1, size(a%items,2)
+                    do i = 1, size(a%items,1)
+                      select type (e => expected_items(i,j,k,l))
+                      type is (real(kind=REAL64))
+                         m = near(e, this%tolerance)
+                      class default
+                         matches_array_4d_64 = .false.
+                         return
+                      end select
+                      if (.not. m%matches_safely(a%items(i,j,k,l))) then
+                         matches_array_4d_64 = .false.
+                         return
+                      end if
+                   end do
+                end do
+             end do
+          end do
+          matches_array_4d_64 = .true.
+       else
+          matches_array_4d_64 = .false.
+       end if
+    class default
+       matches_array_4d_64 = .false.
+    end select
+
+  end function matches_array_4d_64
+
+
+  real(kind=REAL64) function delta_64(this, actual)
+    class(IsNear_64), intent(in) :: this
+    real(kind=REAL64), intent(in) :: actual
+    delta_64 = abs(actual - this%value)
+  end function delta_64
+
+
+  subroutine describe_mismatch_safely_64(this, actual, description)
+    class(IsNear_64), intent(in) :: this
+    class(*), intent(in) :: actual
+    class(MatcherDescription), intent(inout) :: description
+
+    real(kind=REAL64) :: d
+
+    select type (actual)
+    type is (real(kind=REAL32))
+       d = this%delta(real(actual, kind=REAL64))
+       call description%append_value(actual)
+       call description%append_text(" differed by ")
+       call description%append_value(d)
+       call description%append_text(" which exceeds the tolerance by ")
+       call description%append_value(d - this%tolerance)
+    type is (real(kind=REAL64))
        d = this%delta(actual)
        call description%append_value(actual)
        call description%append_text(" differed by ")
@@ -87,26 +742,37 @@ contains
        call description%append_value(d - this%tolerance)
     end select
 
-  end subroutine describe_mismatch_safely
+  end subroutine describe_mismatch_safely_64
 
-  logical function expects_type_of(this, actual) result(supported)
-    class(IsNear), intent(in) :: this
+
+  logical function expects_type_of_64(this, actual) result(supported)
+    class(IsNear_64), intent(in) :: this
     class(*), intent(in) :: actual
 
     _UNUSED_DUMMY(this)
-    
+
     select type (actual)
-    type is (real)
+    type is (real(kind=REAL32))
        supported = .true.
+    type is (real(kind=REAL64))
+       supported = .true.
+    class is (ArrayWrapper_1d)
+       supported = allocated(this%array_value)
+    class is (ArrayWrapper_2d)
+       supported = allocated(this%array_value)
+    class is (ArrayWrapper_3d)
+       supported = allocated(this%array_value)
+    class is (ArrayWrapper_4d)
+       supported = allocated(this%array_value)
     class default
        supported = .false.
     end select
 
-  end function expects_type_of
+  end function expects_type_of_64
 
 
-  subroutine describe_to(this, description)
-    class(IsNear), intent(in) :: this
+  subroutine describe_to_64(this, description)
+    class(IsNear_64), intent(in) :: this
     class(MatcherDescription), intent(inout) :: description
 
     call description%append_text("a numeric value within ")
@@ -114,6 +780,6 @@ contains
     call description%append_text(" of ")
     call description%append_value(this%value)
 
-  end subroutine describe_to
+  end subroutine describe_to_64
 
 end module pf_IsNear

--- a/src/funit/fhamcrest/IsRelativelyNear.F90
+++ b/src/funit/fhamcrest/IsRelativelyNear.F90
@@ -1,79 +1,741 @@
 #include "unused_dummy.fh"
 
 module pf_IsRelativelyNear
+  use iso_fortran_env, only: REAL32, REAL64
   use pf_TypeSafeMatcher
   use pf_MatcherDescription
+  use pf_AbstractArrayWrapper
+  use pf_ArrayWrapper
   implicit none
   private
 
-  public :: IsRelativelyNear
+  public :: IsRelativelyNear_32
+  public :: IsRelativelyNear_64
   public :: relatively_near
 
 
-  type, extends(TypeSafeMatcher) :: IsRelativelyNear
+
+  !------------------------------------------------------------
+  ! 32-bit variant
+  !------------------------------------------------------------
+  type, extends(TypeSafeMatcher) :: IsRelativelyNear_32
      private
      real :: tolerance
      real :: value
      character(:), allocatable :: text_description
+     class(*), allocatable :: array_value
    contains
-     procedure :: matches_safely
-     procedure :: describe_mismatch_safely
-     procedure :: expects_type_of
-     procedure :: delta
-     procedure :: describe_to
-  end type IsRelativelyNear
+     procedure :: matches_safely           => matches_safely_32
+     procedure :: describe_mismatch_safely => describe_mismatch_safely_32
+     procedure :: expects_type_of          => expects_type_of_32
+     procedure :: delta                    => delta_32
+     procedure :: describe_to              => describe_to_32
+     procedure :: matches_array_1d         => matches_array_1d_32
+     procedure :: matches_array_2d         => matches_array_2d_32
+     procedure :: matches_array_3d         => matches_array_3d_32
+     procedure :: matches_array_4d         => matches_array_4d_32
+  end type IsRelativelyNear_32
 
+  !------------------------------------------------------------
+  ! 64-bit variant
+  !------------------------------------------------------------
+  type, extends(TypeSafeMatcher) :: IsRelativelyNear_64
+     private
+     real(kind=REAL64) :: tolerance
+     real(kind=REAL64) :: value
+     character(:), allocatable :: text_description
+     class(*), allocatable :: array_value
+   contains
+     procedure :: matches_safely           => matches_safely_64
+     procedure :: describe_mismatch_safely => describe_mismatch_safely_64
+     procedure :: expects_type_of          => expects_type_of_64
+     procedure :: delta                    => delta_64
+     procedure :: describe_to              => describe_to_64
+     procedure :: matches_array_1d         => matches_array_1d_64
+     procedure :: matches_array_2d         => matches_array_2d_64
+     procedure :: matches_array_3d         => matches_array_3d_64
+     procedure :: matches_array_4d         => matches_array_4d_64
+  end type IsRelativelyNear_64
 
   interface relatively_near
+     ! scalar
      module procedure relatively_near_real
+     module procedure relatively_near_double
+#if (defined(_ISO_REAL32) && (_ISO_REAL32 != _REAL_DEFAULT_KIND) && (_ISO_REAL32 != _DOUBLE_DEFAULT_KIND))
+     module procedure relatively_near_real32
+#endif
+#if (defined(_ISO_REAL64) && (_ISO_REAL64 != _REAL_DEFAULT_KIND) && (_ISO_REAL64 != _DOUBLE_DEFAULT_KIND))
+     module procedure relatively_near_real64
+#endif
+     ! arrays — 32-bit
+     module procedure relatively_near_real_1d
+     module procedure relatively_near_real_2d
+     module procedure relatively_near_real_3d
+     module procedure relatively_near_real_4d
+     ! arrays — 64-bit
+     module procedure relatively_near_double_1d
+     module procedure relatively_near_double_2d
+     module procedure relatively_near_double_3d
+     module procedure relatively_near_double_4d
+#if (defined(_ISO_REAL32) && (_ISO_REAL32 != _REAL_DEFAULT_KIND) && (_ISO_REAL32 != _DOUBLE_DEFAULT_KIND))
+     module procedure relatively_near_real32_1d
+     module procedure relatively_near_real32_2d
+     module procedure relatively_near_real32_3d
+     module procedure relatively_near_real32_4d
+#endif
+#if (defined(_ISO_REAL64) && (_ISO_REAL64 != _REAL_DEFAULT_KIND) && (_ISO_REAL64 != _DOUBLE_DEFAULT_KIND))
+     module procedure relatively_near_real64_1d
+     module procedure relatively_near_real64_2d
+     module procedure relatively_near_real64_3d
+     module procedure relatively_near_real64_4d
+#endif
   end interface relatively_near
-  
+
 
 contains
 
+  !=============================================================
+  ! Constructors
+  !=============================================================
 
-  function relatively_near_real(value, tolerance) result(relatively_near)
-    type(IsRelativelyNear) :: relatively_near
-    real, intent(in) :: value
-    real, intent(in) :: tolerance
-
-    relatively_near%value = value
-    relatively_near%tolerance = tolerance
-
+  function relatively_near_real(value, tolerance) result(matcher)
+    type(IsRelativelyNear_32) :: matcher
+    real, intent(in) :: value, tolerance
+    matcher%value     = value
+    matcher%tolerance = tolerance
   end function relatively_near_real
 
+  function relatively_near_double(value, tolerance) result(matcher)
+    type(IsRelativelyNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value, tolerance
+    matcher%value     = value
+    matcher%tolerance = tolerance
+  end function relatively_near_double
 
-  logical function matches_safely(this, actual_value)
-    class(IsRelativelyNear), intent(in) :: this
+#if (defined(_ISO_REAL32) && (_ISO_REAL32 != _REAL_DEFAULT_KIND) && (_ISO_REAL32 != _DOUBLE_DEFAULT_KIND))
+  function relatively_near_real32(value, tolerance) result(matcher)
+    type(IsRelativelyNear_32) :: matcher
+    real(kind=REAL32), intent(in) :: value, tolerance
+    matcher%value     = real(value)
+    matcher%tolerance = real(tolerance)
+  end function relatively_near_real32
+#endif
+
+#if (defined(_ISO_REAL64) && (_ISO_REAL64 != _REAL_DEFAULT_KIND) && (_ISO_REAL64 != _DOUBLE_DEFAULT_KIND))
+  function relatively_near_real64(value, tolerance) result(matcher)
+    type(IsRelativelyNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value, tolerance
+    matcher%value     = real(value, kind=REAL64)
+    matcher%tolerance = real(tolerance, kind=REAL64)
+  end function relatively_near_real64
+#endif
+
+  ! --- array constructors returning IsRelativelyNear_32 ---
+
+  function relatively_near_real_1d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_32) :: matcher
+    real, intent(in) :: value(:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_real_1d
+
+  function relatively_near_real_2d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_32) :: matcher
+    real, intent(in) :: value(:,:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_real_2d
+
+  function relatively_near_real_3d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_32) :: matcher
+    real, intent(in) :: value(:,:,:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_real_3d
+
+  function relatively_near_real_4d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_32) :: matcher
+    real, intent(in) :: value(:,:,:,:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_real_4d
+
+  ! --- array constructors returning IsRelativelyNear_64 ---
+
+  function relatively_near_double_1d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_double_1d
+
+  function relatively_near_double_2d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:,:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_double_2d
+
+  function relatively_near_double_3d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:,:,:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_double_3d
+
+  function relatively_near_double_4d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:,:,:,:), tolerance
+    matcher%tolerance = tolerance
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_double_4d
+
+#if (defined(_ISO_REAL32) && (_ISO_REAL32 != _REAL_DEFAULT_KIND) && (_ISO_REAL32 != _DOUBLE_DEFAULT_KIND))
+  function relatively_near_real32_1d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_32) :: matcher
+    real(kind=REAL32), intent(in) :: value(:), tolerance
+    matcher%tolerance = real(tolerance)
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_real32_1d
+
+  function relatively_near_real32_2d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_32) :: matcher
+    real(kind=REAL32), intent(in) :: value(:,:), tolerance
+    matcher%tolerance = real(tolerance)
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_real32_2d
+
+  function relatively_near_real32_3d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_32) :: matcher
+    real(kind=REAL32), intent(in) :: value(:,:,:), tolerance
+    matcher%tolerance = real(tolerance)
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_real32_3d
+
+  function relatively_near_real32_4d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_32) :: matcher
+    real(kind=REAL32), intent(in) :: value(:,:,:,:), tolerance
+    matcher%tolerance = real(tolerance)
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_real32_4d
+#endif
+
+#if (defined(_ISO_REAL64) && (_ISO_REAL64 != _REAL_DEFAULT_KIND) && (_ISO_REAL64 != _DOUBLE_DEFAULT_KIND))
+  function relatively_near_real64_1d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:), tolerance
+    matcher%tolerance = real(tolerance, kind=REAL64)
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_real64_1d
+
+  function relatively_near_real64_2d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:,:), tolerance
+    matcher%tolerance = real(tolerance, kind=REAL64)
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_real64_2d
+
+  function relatively_near_real64_3d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:,:,:), tolerance
+    matcher%tolerance = real(tolerance, kind=REAL64)
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_real64_3d
+
+  function relatively_near_real64_4d(value, tolerance) result(matcher)
+    type(IsRelativelyNear_64) :: matcher
+    real(kind=REAL64), intent(in) :: value(:,:,:,:), tolerance
+    matcher%tolerance = real(tolerance, kind=REAL64)
+    matcher%array_value = ArrayWrapper(value)
+  end function relatively_near_real64_4d
+#endif
+
+
+  !=============================================================
+  ! IsRelativelyNear_32 implementations
+  !=============================================================
+
+  logical function matches_safely_32(this, actual_value)
+    class(IsRelativelyNear_32), intent(in) :: this
     class(*), intent(in) :: actual_value
 
+    if (allocated(this%array_value)) then
+       select type (a => this%array_value)
+       type is (ArrayWrapper_1d)
+          matches_safely_32 = this%matches_array_1d(a%items, actual_value)
+       type is (ArrayWrapper_2d)
+          matches_safely_32 = this%matches_array_2d(a%items, actual_value)
+       type is (ArrayWrapper_3d)
+          matches_safely_32 = this%matches_array_3d(a%items, actual_value)
+       type is (ArrayWrapper_4d)
+          matches_safely_32 = this%matches_array_4d(a%items, actual_value)
+       class default
+          matches_safely_32 = .false.
+       end select
+       return
+    end if
+
     select type (actual_value)
-    type is (real)
-       ! Note: multiplication is used on RHS to avoid divide-by-zero issues
-       matches_safely = this%delta(actual_value) <= this%tolerance
+    type is (real(kind=REAL32))
+       matches_safely_32 = this%delta(actual_value) <= this%tolerance
+    type is (real(kind=REAL64))
+       matches_safely_32 = this%delta(real(actual_value, kind=REAL32)) <= this%tolerance
     end select
-    
-  end function matches_safely
+
+  end function matches_safely_32
 
 
-  real function delta(this, actual)
-    class(IsRelativelyNear), intent(in) :: this
+  logical function matches_array_1d_32(this, expected_items, actual_value)
+    class(IsRelativelyNear_32), intent(in) :: this
+    class(*), intent(in) :: expected_items(:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, n_items
+    type(IsRelativelyNear_32) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_1d)
+       n_items = size(expected_items)
+       if (size(a%items) == n_items) then
+           do i = 1, n_items
+             select type (e => expected_items(i))
+             type is (real(kind=REAL32))
+                m = relatively_near(e, this%tolerance)
+             class default
+                matches_array_1d_32 = .false.
+                return
+             end select
+             if (.not. m%matches_safely(a%items(i))) then
+                matches_array_1d_32 = .false.
+                return
+             end if
+          end do
+          matches_array_1d_32 = .true.
+       else
+          matches_array_1d_32 = .false.
+       end if
+    class default
+       matches_array_1d_32 = .false.
+    end select
+
+  end function matches_array_1d_32
+
+
+  logical function matches_array_2d_32(this, expected_items, actual_value)
+    class(IsRelativelyNear_32), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j
+    type(IsRelativelyNear_32) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_2d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do j = 1, size(a%items,2)
+              do i = 1, size(a%items,1)
+                select type (e => expected_items(i,j))
+                type is (real(kind=REAL32))
+                   m = relatively_near(e, this%tolerance)
+                class default
+                   matches_array_2d_32 = .false.
+                   return
+                end select
+                if (.not. m%matches_safely(a%items(i,j))) then
+                   matches_array_2d_32 = .false.
+                   return
+                end if
+             end do
+          end do
+          matches_array_2d_32 = .true.
+       else
+          matches_array_2d_32 = .false.
+       end if
+    class default
+       matches_array_2d_32 = .false.
+    end select
+
+  end function matches_array_2d_32
+
+
+  logical function matches_array_3d_32(this, expected_items, actual_value)
+    class(IsRelativelyNear_32), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j, k
+    type(IsRelativelyNear_32) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_3d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do k = 1, size(a%items,3)
+             do j = 1, size(a%items,2)
+                 do i = 1, size(a%items,1)
+                   select type (e => expected_items(i,j,k))
+                   type is (real(kind=REAL32))
+                      m = relatively_near(e, this%tolerance)
+                   class default
+                      matches_array_3d_32 = .false.
+                      return
+                   end select
+                   if (.not. m%matches_safely(a%items(i,j,k))) then
+                      matches_array_3d_32 = .false.
+                      return
+                   end if
+                end do
+             end do
+          end do
+          matches_array_3d_32 = .true.
+       else
+          matches_array_3d_32 = .false.
+       end if
+    class default
+       matches_array_3d_32 = .false.
+    end select
+
+  end function matches_array_3d_32
+
+
+  logical function matches_array_4d_32(this, expected_items, actual_value)
+    class(IsRelativelyNear_32), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:,:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j, k, l
+    type(IsRelativelyNear_32) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_4d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do l = 1, size(a%items,4)
+             do k = 1, size(a%items,3)
+                do j = 1, size(a%items,2)
+                    do i = 1, size(a%items,1)
+                      select type (e => expected_items(i,j,k,l))
+                      type is (real(kind=REAL32))
+                         m = relatively_near(e, this%tolerance)
+                      class default
+                         matches_array_4d_32 = .false.
+                         return
+                      end select
+                      if (.not. m%matches_safely(a%items(i,j,k,l))) then
+                         matches_array_4d_32 = .false.
+                         return
+                      end if
+                   end do
+                end do
+             end do
+          end do
+          matches_array_4d_32 = .true.
+       else
+          matches_array_4d_32 = .false.
+       end if
+    class default
+       matches_array_4d_32 = .false.
+    end select
+
+  end function matches_array_4d_32
+
+
+  real function delta_32(this, actual)
+    class(IsRelativelyNear_32), intent(in) :: this
     real, intent(in) :: actual
-
-    delta = abs(actual - this%value) / abs(this%value)
-
-  end function delta
+    delta_32 = abs(actual - this%value) / abs(this%value)
+  end function delta_32
 
 
-  subroutine describe_mismatch_safely(this, actual, description)
-    class(IsRelativelyNear), intent(in) :: this
+  subroutine describe_mismatch_safely_32(this, actual, description)
+    class(IsRelativelyNear_32), intent(in) :: this
     class(*), intent(in) :: actual
     class(MatcherDescription), intent(inout) :: description
 
     real :: d
 
     select type (actual)
-    type is (real)
+    type is (real(kind=REAL32))
+       d = this%delta(actual)
+       call description%append_value(actual)
+       call description%append_text(" has a relative error of ")
+       call description%append_value(d)
+       call description%append_text(" which exceeds the tolerance by ")
+       call description%append_value(d - this%tolerance)
+    type is (real(kind=REAL64))
+       d = this%delta(real(actual, kind=REAL32))
+       call description%append_value(actual)
+       call description%append_text(" has a relative error of ")
+       call description%append_value(d)
+       call description%append_text(" which exceeds the tolerance by ")
+       call description%append_value(d - this%tolerance)
+    end select
+
+  end subroutine describe_mismatch_safely_32
+
+
+  logical function expects_type_of_32(this, actual) result(supported)
+    class(IsRelativelyNear_32), intent(in) :: this
+    class(*), intent(in) :: actual
+
+    _UNUSED_DUMMY(this)
+
+    select type (actual)
+    type is (real(kind=REAL32))
+       supported = .true.
+    type is (real(kind=REAL64))
+       supported = .true.
+    class is (ArrayWrapper_1d)
+       supported = allocated(this%array_value)
+    class is (ArrayWrapper_2d)
+       supported = allocated(this%array_value)
+    class is (ArrayWrapper_3d)
+       supported = allocated(this%array_value)
+    class is (ArrayWrapper_4d)
+       supported = allocated(this%array_value)
+    class default
+       supported = .false.
+    end select
+
+  end function expects_type_of_32
+
+
+  subroutine describe_to_32(this, description)
+    class(IsRelativelyNear_32), intent(in) :: this
+    class(MatcherDescription), intent(inout) :: description
+
+    call description%append_text("a numeric value whose relative error from ")
+    call description%append_value(this%value)
+    call description%append_text(" is less than ")
+    call description%append_value(this%tolerance)
+
+  end subroutine describe_to_32
+
+
+  !=============================================================
+  ! IsRelativelyNear_64 implementations
+  !=============================================================
+
+  logical function matches_safely_64(this, actual_value)
+    class(IsRelativelyNear_64), intent(in) :: this
+    class(*), intent(in) :: actual_value
+
+    if (allocated(this%array_value)) then
+       select type (a => this%array_value)
+       type is (ArrayWrapper_1d)
+          matches_safely_64 = this%matches_array_1d(a%items, actual_value)
+       type is (ArrayWrapper_2d)
+          matches_safely_64 = this%matches_array_2d(a%items, actual_value)
+       type is (ArrayWrapper_3d)
+          matches_safely_64 = this%matches_array_3d(a%items, actual_value)
+       type is (ArrayWrapper_4d)
+          matches_safely_64 = this%matches_array_4d(a%items, actual_value)
+       class default
+          matches_safely_64 = .false.
+       end select
+       return
+    end if
+
+    select type (actual_value)
+    type is (real(kind=REAL32))
+       matches_safely_64 = this%delta(real(actual_value, kind=REAL64)) <= this%tolerance
+    type is (real(kind=REAL64))
+       matches_safely_64 = this%delta(actual_value) <= this%tolerance
+    end select
+
+  end function matches_safely_64
+
+
+  logical function matches_array_1d_64(this, expected_items, actual_value)
+    class(IsRelativelyNear_64), intent(in) :: this
+    class(*), intent(in) :: expected_items(:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, n_items
+    type(IsRelativelyNear_64) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_1d)
+       n_items = size(expected_items)
+       if (size(a%items) == n_items) then
+           do i = 1, n_items
+             select type (e => expected_items(i))
+             type is (real(kind=REAL64))
+                m = relatively_near(e, this%tolerance)
+             class default
+                matches_array_1d_64 = .false.
+                return
+             end select
+             if (.not. m%matches_safely(a%items(i))) then
+                matches_array_1d_64 = .false.
+                return
+             end if
+          end do
+          matches_array_1d_64 = .true.
+       else
+          matches_array_1d_64 = .false.
+       end if
+    class default
+       matches_array_1d_64 = .false.
+    end select
+
+  end function matches_array_1d_64
+
+
+  logical function matches_array_2d_64(this, expected_items, actual_value)
+    class(IsRelativelyNear_64), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j
+    type(IsRelativelyNear_64) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_2d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do j = 1, size(a%items,2)
+              do i = 1, size(a%items,1)
+                select type (e => expected_items(i,j))
+                type is (real(kind=REAL64))
+                   m = relatively_near(e, this%tolerance)
+                class default
+                   matches_array_2d_64 = .false.
+                   return
+                end select
+                if (.not. m%matches_safely(a%items(i,j))) then
+                   matches_array_2d_64 = .false.
+                   return
+                end if
+             end do
+          end do
+          matches_array_2d_64 = .true.
+       else
+          matches_array_2d_64 = .false.
+       end if
+    class default
+       matches_array_2d_64 = .false.
+    end select
+
+  end function matches_array_2d_64
+
+
+  logical function matches_array_3d_64(this, expected_items, actual_value)
+    class(IsRelativelyNear_64), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j, k
+    type(IsRelativelyNear_64) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_3d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do k = 1, size(a%items,3)
+             do j = 1, size(a%items,2)
+                 do i = 1, size(a%items,1)
+                   select type (e => expected_items(i,j,k))
+                   type is (real(kind=REAL64))
+                      m = relatively_near(e, this%tolerance)
+                   class default
+                      matches_array_3d_64 = .false.
+                      return
+                   end select
+                   if (.not. m%matches_safely(a%items(i,j,k))) then
+                      matches_array_3d_64 = .false.
+                      return
+                   end if
+                end do
+             end do
+          end do
+          matches_array_3d_64 = .true.
+       else
+          matches_array_3d_64 = .false.
+       end if
+    class default
+       matches_array_3d_64 = .false.
+    end select
+
+  end function matches_array_3d_64
+
+
+  logical function matches_array_4d_64(this, expected_items, actual_value)
+    class(IsRelativelyNear_64), intent(in) :: this
+    class(*), intent(in) :: expected_items(:,:,:,:)
+    class(*), intent(in) :: actual_value
+
+    integer :: i, j, k, l
+    type(IsRelativelyNear_64) :: m
+
+    _UNUSED_DUMMY(this)
+
+    select type (a => actual_value)
+    type is (ArrayWrapper_4d)
+       if (all(shape(a%items) == shape(expected_items))) then
+          do l = 1, size(a%items,4)
+             do k = 1, size(a%items,3)
+                do j = 1, size(a%items,2)
+                    do i = 1, size(a%items,1)
+                      select type (e => expected_items(i,j,k,l))
+                      type is (real(kind=REAL64))
+                         m = relatively_near(e, this%tolerance)
+                      class default
+                         matches_array_4d_64 = .false.
+                         return
+                      end select
+                      if (.not. m%matches_safely(a%items(i,j,k,l))) then
+                         matches_array_4d_64 = .false.
+                         return
+                      end if
+                   end do
+                end do
+             end do
+          end do
+          matches_array_4d_64 = .true.
+       else
+          matches_array_4d_64 = .false.
+       end if
+    class default
+       matches_array_4d_64 = .false.
+    end select
+
+  end function matches_array_4d_64
+
+
+  real(kind=REAL64) function delta_64(this, actual)
+    class(IsRelativelyNear_64), intent(in) :: this
+    real(kind=REAL64), intent(in) :: actual
+    delta_64 = abs(actual - this%value) / abs(this%value)
+  end function delta_64
+
+
+  subroutine describe_mismatch_safely_64(this, actual, description)
+    class(IsRelativelyNear_64), intent(in) :: this
+    class(*), intent(in) :: actual
+    class(MatcherDescription), intent(inout) :: description
+
+    real(kind=REAL64) :: d
+
+    select type (actual)
+    type is (real(kind=REAL32))
+       d = this%delta(real(actual, kind=REAL64))
+       call description%append_value(actual)
+       call description%append_text(" has a relative error of ")
+       call description%append_value(d)
+       call description%append_text(" which exceeds the tolerance by ")
+       call description%append_value(d - this%tolerance)
+    type is (real(kind=REAL64))
        d = this%delta(actual)
        call description%append_value(actual)
        call description%append_text(" has a relative error of ")
@@ -82,25 +744,37 @@ contains
        call description%append_value(d - this%tolerance)
     end select
 
-  end subroutine describe_mismatch_safely
+  end subroutine describe_mismatch_safely_64
 
-  logical function expects_type_of(this, actual) result(supported)
-    class(IsRelativelyNear), intent(in) :: this
+
+  logical function expects_type_of_64(this, actual) result(supported)
+    class(IsRelativelyNear_64), intent(in) :: this
     class(*), intent(in) :: actual
 
     _UNUSED_DUMMY(this)
+
     select type (actual)
-    type is (real)
+    type is (real(kind=REAL32))
        supported = .true.
+    type is (real(kind=REAL64))
+       supported = .true.
+    class is (ArrayWrapper_1d)
+       supported = allocated(this%array_value)
+    class is (ArrayWrapper_2d)
+       supported = allocated(this%array_value)
+    class is (ArrayWrapper_3d)
+       supported = allocated(this%array_value)
+    class is (ArrayWrapper_4d)
+       supported = allocated(this%array_value)
     class default
        supported = .false.
     end select
 
-  end function expects_type_of
+  end function expects_type_of_64
 
 
-  subroutine describe_to(this, description)
-    class(IsRelativelyNear), intent(in) :: this
+  subroutine describe_to_64(this, description)
+    class(IsRelativelyNear_64), intent(in) :: this
     class(MatcherDescription), intent(inout) :: description
 
     call description%append_text("a numeric value whose relative error from ")
@@ -108,6 +782,6 @@ contains
     call description%append_text(" is less than ")
     call description%append_value(this%tolerance)
 
-  end subroutine describe_to
+  end subroutine describe_to_64
 
 end module pf_IsRelativelyNear

--- a/src/funit/fhamcrest/IsRelativelyNear.F90
+++ b/src/funit/fhamcrest/IsRelativelyNear.F90
@@ -308,6 +308,8 @@ contains
              select type (av => a%items(i))
              type is (real(kind=REAL32))
                 a_val = av
+             type is (real(kind=REAL64))
+                a_val = real(av, kind=REAL32)
              class default
                 matches_array_1d_32 = .false.
                 return
@@ -351,6 +353,8 @@ contains
                 select type (av => a%items(i,j))
                 type is (real(kind=REAL32))
                    a_val = av
+                type is (real(kind=REAL64))
+                   a_val = real(av, kind=REAL32)
                 class default
                    matches_array_2d_32 = .false.
                    return
@@ -396,6 +400,8 @@ contains
                    select type (av => a%items(i,j,k))
                    type is (real(kind=REAL32))
                       a_val = av
+                   type is (real(kind=REAL64))
+                      a_val = real(av, kind=REAL32)
                    class default
                       matches_array_3d_32 = .false.
                       return
@@ -443,6 +449,8 @@ contains
                       select type (av => a%items(i,j,k,l))
                       type is (real(kind=REAL32))
                          a_val = av
+                      type is (real(kind=REAL64))
+                         a_val = real(av, kind=REAL32)
                       class default
                          matches_array_4d_32 = .false.
                          return
@@ -568,8 +576,6 @@ contains
     end if
 
     select type (actual_value)
-    type is (real(kind=REAL32))
-       matches_safely_64 = this%delta(real(actual_value, kind=REAL64)) <= this%tolerance
     type is (real(kind=REAL64))
        matches_safely_64 = this%delta(actual_value) <= this%tolerance
     end select
@@ -598,8 +604,6 @@ contains
                 return
              end select
              select type (av => a%items(i))
-             type is (real(kind=REAL32))
-                a_val = real(av, kind=REAL64)
              type is (real(kind=REAL64))
                 a_val = av
              class default
@@ -643,8 +647,6 @@ contains
                    return
                 end select
                 select type (av => a%items(i,j))
-                type is (real(kind=REAL32))
-                   a_val = real(av, kind=REAL64)
                 type is (real(kind=REAL64))
                    a_val = av
                 class default
@@ -690,8 +692,6 @@ contains
                       return
                    end select
                    select type (av => a%items(i,j,k))
-                   type is (real(kind=REAL32))
-                      a_val = real(av, kind=REAL64)
                    type is (real(kind=REAL64))
                       a_val = av
                    class default
@@ -739,8 +739,6 @@ contains
                          return
                       end select
                       select type (av => a%items(i,j,k,l))
-                      type is (real(kind=REAL32))
-                         a_val = real(av, kind=REAL64)
                       type is (real(kind=REAL64))
                          a_val = av
                       class default
@@ -781,13 +779,6 @@ contains
     real(kind=REAL64) :: d
 
     select type (actual)
-    type is (real(kind=REAL32))
-       d = this%delta(real(actual, kind=REAL64))
-       call description%append_value(actual)
-       call description%append_text(" has a relative error of ")
-       call description%append_value(d)
-       call description%append_text(" which exceeds the tolerance by ")
-       call description%append_value(d - this%tolerance)
     type is (real(kind=REAL64))
        d = this%delta(actual)
        call description%append_value(actual)
@@ -807,8 +798,6 @@ contains
     _UNUSED_DUMMY(this)
 
     select type (actual)
-    type is (real(kind=REAL32))
-       supported = .true.
     type is (real(kind=REAL64))
        supported = .true.
     class is (ArrayWrapper_1d)

--- a/src/funit/fhamcrest/IsRelativelyNear.F90
+++ b/src/funit/fhamcrest/IsRelativelyNear.F90
@@ -576,6 +576,8 @@ contains
     end if
 
     select type (actual_value)
+    type is (real(kind=REAL32))
+       matches_safely_64 = this%delta(real(actual_value, kind=REAL64)) <= this%tolerance
     type is (real(kind=REAL64))
        matches_safely_64 = this%delta(actual_value) <= this%tolerance
     end select
@@ -779,6 +781,13 @@ contains
     real(kind=REAL64) :: d
 
     select type (actual)
+    type is (real(kind=REAL32))
+       d = this%delta(real(actual, kind=REAL64))
+       call description%append_value(actual)
+       call description%append_text(" has a relative error of ")
+       call description%append_value(d)
+       call description%append_text(" which exceeds the tolerance by ")
+       call description%append_value(d - this%tolerance)
     type is (real(kind=REAL64))
        d = this%delta(actual)
        call description%append_value(actual)
@@ -798,6 +807,8 @@ contains
     _UNUSED_DUMMY(this)
 
     select type (actual)
+    type is (real(kind=REAL32))
+       supported = .true.
     type is (real(kind=REAL64))
        supported = .true.
     class is (ArrayWrapper_1d)

--- a/src/funit/fhamcrest/IsRelativelyNear.F90
+++ b/src/funit/fhamcrest/IsRelativelyNear.F90
@@ -291,23 +291,28 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, n_items
-    type(IsRelativelyNear_32) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL32) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_1d)
        n_items = size(expected_items)
        if (size(a%items) == n_items) then
-           do i = 1, n_items
+          do i = 1, n_items
              select type (e => expected_items(i))
              type is (real(kind=REAL32))
-                m = relatively_near(e, this%tolerance)
+                e_val = e
              class default
                 matches_array_1d_32 = .false.
                 return
              end select
-             if (.not. m%matches_safely(a%items(i))) then
+             select type (av => a%items(i))
+             type is (real(kind=REAL32))
+                a_val = av
+             class default
+                matches_array_1d_32 = .false.
+                return
+             end select
+             if (abs(a_val - e_val) / abs(e_val) > this%tolerance) then
                 matches_array_1d_32 = .false.
                 return
              end if
@@ -329,23 +334,28 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, j
-    type(IsRelativelyNear_32) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL32) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_2d)
        if (all(shape(a%items) == shape(expected_items))) then
           do j = 1, size(a%items,2)
-              do i = 1, size(a%items,1)
+             do i = 1, size(a%items,1)
                 select type (e => expected_items(i,j))
                 type is (real(kind=REAL32))
-                   m = relatively_near(e, this%tolerance)
+                   e_val = e
                 class default
                    matches_array_2d_32 = .false.
                    return
                 end select
-                if (.not. m%matches_safely(a%items(i,j))) then
+                select type (av => a%items(i,j))
+                type is (real(kind=REAL32))
+                   a_val = av
+                class default
+                   matches_array_2d_32 = .false.
+                   return
+                end select
+                if (abs(a_val - e_val) / abs(e_val) > this%tolerance) then
                    matches_array_2d_32 = .false.
                    return
                 end if
@@ -368,24 +378,29 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, j, k
-    type(IsRelativelyNear_32) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL32) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_3d)
        if (all(shape(a%items) == shape(expected_items))) then
           do k = 1, size(a%items,3)
              do j = 1, size(a%items,2)
-                 do i = 1, size(a%items,1)
+                do i = 1, size(a%items,1)
                    select type (e => expected_items(i,j,k))
                    type is (real(kind=REAL32))
-                      m = relatively_near(e, this%tolerance)
+                      e_val = e
                    class default
                       matches_array_3d_32 = .false.
                       return
                    end select
-                   if (.not. m%matches_safely(a%items(i,j,k))) then
+                   select type (av => a%items(i,j,k))
+                   type is (real(kind=REAL32))
+                      a_val = av
+                   class default
+                      matches_array_3d_32 = .false.
+                      return
+                   end select
+                   if (abs(a_val - e_val) / abs(e_val) > this%tolerance) then
                       matches_array_3d_32 = .false.
                       return
                    end if
@@ -409,9 +424,7 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, j, k, l
-    type(IsRelativelyNear_32) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL32) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_4d)
@@ -419,15 +432,22 @@ contains
           do l = 1, size(a%items,4)
              do k = 1, size(a%items,3)
                 do j = 1, size(a%items,2)
-                    do i = 1, size(a%items,1)
+                   do i = 1, size(a%items,1)
                       select type (e => expected_items(i,j,k,l))
                       type is (real(kind=REAL32))
-                         m = relatively_near(e, this%tolerance)
+                         e_val = e
                       class default
                          matches_array_4d_32 = .false.
                          return
                       end select
-                      if (.not. m%matches_safely(a%items(i,j,k,l))) then
+                      select type (av => a%items(i,j,k,l))
+                      type is (real(kind=REAL32))
+                         a_val = av
+                      class default
+                         matches_array_4d_32 = .false.
+                         return
+                      end select
+                      if (abs(a_val - e_val) / abs(e_val) > this%tolerance) then
                          matches_array_4d_32 = .false.
                          return
                       end if
@@ -510,10 +530,15 @@ contains
     class(IsRelativelyNear_32), intent(in) :: this
     class(MatcherDescription), intent(inout) :: description
 
-    call description%append_text("a numeric value whose relative error from ")
-    call description%append_value(this%value)
-    call description%append_text(" is less than ")
-    call description%append_value(this%tolerance)
+    if (allocated(this%array_value)) then
+       call description%append_text("an array where each element's relative error is less than ")
+       call description%append_value(this%tolerance)
+    else
+       call description%append_text("a numeric value whose relative error from ")
+       call description%append_value(this%value)
+       call description%append_text(" is less than ")
+       call description%append_value(this%tolerance)
+    end if
 
   end subroutine describe_to_32
 
@@ -558,23 +583,30 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, n_items
-    type(IsRelativelyNear_64) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL64) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_1d)
        n_items = size(expected_items)
        if (size(a%items) == n_items) then
-           do i = 1, n_items
+          do i = 1, n_items
              select type (e => expected_items(i))
              type is (real(kind=REAL64))
-                m = relatively_near(e, this%tolerance)
+                e_val = e
              class default
                 matches_array_1d_64 = .false.
                 return
              end select
-             if (.not. m%matches_safely(a%items(i))) then
+             select type (av => a%items(i))
+             type is (real(kind=REAL32))
+                a_val = real(av, kind=REAL64)
+             type is (real(kind=REAL64))
+                a_val = av
+             class default
+                matches_array_1d_64 = .false.
+                return
+             end select
+             if (abs(a_val - e_val) / abs(e_val) > this%tolerance) then
                 matches_array_1d_64 = .false.
                 return
              end if
@@ -596,23 +628,30 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, j
-    type(IsRelativelyNear_64) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL64) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_2d)
        if (all(shape(a%items) == shape(expected_items))) then
           do j = 1, size(a%items,2)
-              do i = 1, size(a%items,1)
+             do i = 1, size(a%items,1)
                 select type (e => expected_items(i,j))
                 type is (real(kind=REAL64))
-                   m = relatively_near(e, this%tolerance)
+                   e_val = e
                 class default
                    matches_array_2d_64 = .false.
                    return
                 end select
-                if (.not. m%matches_safely(a%items(i,j))) then
+                select type (av => a%items(i,j))
+                type is (real(kind=REAL32))
+                   a_val = real(av, kind=REAL64)
+                type is (real(kind=REAL64))
+                   a_val = av
+                class default
+                   matches_array_2d_64 = .false.
+                   return
+                end select
+                if (abs(a_val - e_val) / abs(e_val) > this%tolerance) then
                    matches_array_2d_64 = .false.
                    return
                 end if
@@ -635,24 +674,31 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, j, k
-    type(IsRelativelyNear_64) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL64) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_3d)
        if (all(shape(a%items) == shape(expected_items))) then
           do k = 1, size(a%items,3)
              do j = 1, size(a%items,2)
-                 do i = 1, size(a%items,1)
+                do i = 1, size(a%items,1)
                    select type (e => expected_items(i,j,k))
                    type is (real(kind=REAL64))
-                      m = relatively_near(e, this%tolerance)
+                      e_val = e
                    class default
                       matches_array_3d_64 = .false.
                       return
                    end select
-                   if (.not. m%matches_safely(a%items(i,j,k))) then
+                   select type (av => a%items(i,j,k))
+                   type is (real(kind=REAL32))
+                      a_val = real(av, kind=REAL64)
+                   type is (real(kind=REAL64))
+                      a_val = av
+                   class default
+                      matches_array_3d_64 = .false.
+                      return
+                   end select
+                   if (abs(a_val - e_val) / abs(e_val) > this%tolerance) then
                       matches_array_3d_64 = .false.
                       return
                    end if
@@ -676,9 +722,7 @@ contains
     class(*), intent(in) :: actual_value
 
     integer :: i, j, k, l
-    type(IsRelativelyNear_64) :: m
-
-    _UNUSED_DUMMY(this)
+    real(kind=REAL64) :: e_val, a_val
 
     select type (a => actual_value)
     type is (ArrayWrapper_4d)
@@ -686,15 +730,24 @@ contains
           do l = 1, size(a%items,4)
              do k = 1, size(a%items,3)
                 do j = 1, size(a%items,2)
-                    do i = 1, size(a%items,1)
+                   do i = 1, size(a%items,1)
                       select type (e => expected_items(i,j,k,l))
                       type is (real(kind=REAL64))
-                         m = relatively_near(e, this%tolerance)
+                         e_val = e
                       class default
                          matches_array_4d_64 = .false.
                          return
                       end select
-                      if (.not. m%matches_safely(a%items(i,j,k,l))) then
+                      select type (av => a%items(i,j,k,l))
+                      type is (real(kind=REAL32))
+                         a_val = real(av, kind=REAL64)
+                      type is (real(kind=REAL64))
+                         a_val = av
+                      class default
+                         matches_array_4d_64 = .false.
+                         return
+                      end select
+                      if (abs(a_val - e_val) / abs(e_val) > this%tolerance) then
                          matches_array_4d_64 = .false.
                          return
                       end if
@@ -777,10 +830,15 @@ contains
     class(IsRelativelyNear_64), intent(in) :: this
     class(MatcherDescription), intent(inout) :: description
 
-    call description%append_text("a numeric value whose relative error from ")
-    call description%append_value(this%value)
-    call description%append_text(" is less than ")
-    call description%append_value(this%tolerance)
+    if (allocated(this%array_value)) then
+       call description%append_text("an array where each element's relative error is less than ")
+       call description%append_value(this%tolerance)
+    else
+       call description%append_text("a numeric value whose relative error from ")
+       call description%append_value(this%value)
+       call description%append_text(" is less than ")
+       call description%append_value(this%tolerance)
+    end if
 
   end subroutine describe_to_64
 

--- a/src/funit/fhamcrest/MatcherAssert.F90
+++ b/src/funit/fhamcrest/MatcherAssert.F90
@@ -21,6 +21,9 @@ module pf_MatcherAssert
 
      module procedure :: assert_that_3d_no_reason
      module procedure :: assert_that_3d_reason
+
+     module procedure :: assert_that_4d_no_reason
+     module procedure :: assert_that_4d_reason
   end interface assert_that
 
 contains
@@ -119,5 +122,26 @@ contains
     call assert_that(reason, ArrayWrapper(actual), matcher, location)
 
   end subroutine assert_that_3d_reason
+
+  subroutine assert_that_4d_no_reason(actual, matcher, location)
+    use pf_StringDescription
+    class(*), intent(in) :: actual(:,:,:,:)
+    class(AbstractMatcher), intent(in) :: matcher
+    type (SourceLocation), optional, intent(in) :: location
+
+    call assert_that('', actual, matcher, location)
+
+  end subroutine assert_that_4d_no_reason
+
+  subroutine assert_that_4d_reason(reason, actual, matcher, location)
+    use pf_StringDescription
+    character(*), intent(in) :: reason
+    class(*), intent(in) :: actual(:,:,:,:)
+    class(AbstractMatcher), intent(in) :: matcher
+    type (SourceLocation), optional, intent(in) :: location
+
+    call assert_that(reason, ArrayWrapper(actual), matcher, location)
+
+  end subroutine assert_that_4d_reason
 
 end module pf_MatcherAssert

--- a/tests/fhamcrest/Test_IsEqual.pf
+++ b/tests/fhamcrest/Test_IsEqual.pf
@@ -381,11 +381,51 @@ contains
       @assert_that(int_2D, is(not(equal_to(complex32_array))))
       @assert_that(int_2D, is(not(equal_to(complex64_array))))
 
-      @assert_that(int32_array, is(not(equal_to(int_2D))))
-      @assert_that(int64_array, is(not(equal_to(int_2D))))
-      @assert_that(real32_array, is(not(equal_to(int_2D))))
-      @assert_that(real64_array, is(not(equal_to(int_2D))))
-      @assert_that(complex32_array, is(not(equal_to(int_2D))))
-      @assert_that(complex64_array, is(not(equal_to(int_2D))))
-   end subroutine test_is_equal_array_3d
+       @assert_that(int32_array, is(not(equal_to(int_2D))))
+       @assert_that(int64_array, is(not(equal_to(int_2D))))
+       @assert_that(real32_array, is(not(equal_to(int_2D))))
+       @assert_that(real64_array, is(not(equal_to(int_2D))))
+       @assert_that(complex32_array, is(not(equal_to(int_2D))))
+       @assert_that(complex64_array, is(not(equal_to(int_2D))))
+    end subroutine test_is_equal_array_3d
+
+   @test
+   subroutine test_is_equal_array_4d()
+      integer              :: int32_array(2,2,2,2)
+      integer(kind=INT64)  :: int64_array(2,2,2,2)
+      real(kind=REAL32)    :: real32_array(2,2,2,2)
+      real(kind=REAL64)    :: real64_array(2,2,2,2)
+      complex(kind=REAL32) :: complex32_array(2,2,2,2)
+      complex(kind=REAL64) :: complex64_array(2,2,2,2)
+
+      integer :: int_3D(2,2,2)
+      integer :: i
+
+      int32_array     = reshape([(i, i=1,16)], shape(int32_array))
+      int64_array     = int32_array
+      real32_array    = int32_array
+      real64_array    = int32_array
+      complex32_array = int32_array
+      complex64_array = int32_array
+
+      int_3D = reshape([1, 2, 3, 4, 5, 6, 7, 8], shape(int_3D))
+
+      @assert_that(int32_array, is(equal_to(int32_array)))
+      @assert_that(int64_array, is(equal_to(int64_array)))
+      @assert_that(real32_array, is(equal_to(real32_array)))
+      @assert_that(real64_array, is(equal_to(real64_array)))
+      @assert_that(complex32_array, is(equal_to(complex32_array)))
+      @assert_that(complex64_array, is(equal_to(complex64_array)))
+
+      !! rank mismatch
+      @assert_that(int_3D, is(not(equal_to(int32_array))))
+      @assert_that(int_3D, is(not(equal_to(int64_array))))
+      @assert_that(int_3D, is(not(equal_to(real32_array))))
+      @assert_that(int_3D, is(not(equal_to(real64_array))))
+
+      @assert_that(int32_array, is(not(equal_to(int_3D))))
+      @assert_that(int64_array, is(not(equal_to(int_3D))))
+      @assert_that(real32_array, is(not(equal_to(int_3D))))
+      @assert_that(real64_array, is(not(equal_to(int_3D))))
+   end subroutine test_is_equal_array_4d
 end module Test_IsEqual

--- a/tests/fhamcrest/Test_IsNear.pf
+++ b/tests/fhamcrest/Test_IsNear.pf
@@ -1,4 +1,5 @@
 module Test_IsNear
+  use iso_fortran_env, only: REAL32, REAL64
   use funit
   implicit none
 
@@ -14,44 +15,199 @@ contains
     call assert_that(2., is(near(2.1, 0.2)))
   end subroutine test_near_within_tolerance
 
-
   ! Cannot use literals in expected message, because (a) FP arithmetic
   ! may not match exact arithmetic and (b) the number of digits printed
-  ! may very by compiler.  
+  ! may vary by compiler.
   @test
   subroutine test_near_not_within_tolerance()
+    real :: tol, expected, actual, d
     character(:), allocatable :: error
-    call assert_that(2.2, is(near(2.0, 0.1)))
+    expected = 2.0
+    actual   = 2.2
+    tol      = 0.1
+    d        = abs(actual - expected)
+    call assert_that(actual, is(near(expected, tol)))
     error = new_line('a') &
-         & // 'Expected: is a numeric value within <' // str(0.1) // '> of <' // str(2.0) // '>' &
+         & // 'Expected: is a numeric value within <' // str32(tol) // '> of <' // str32(expected) // '>' &
          & // new_line('a') &
-         & // '     but: <' // str(2.2) // '> differed by <' // str(2.2-2.0) &
-         & // '> which exceeds the tolerance by <' // str(abs(2.2-2.0) - 0.1) // '>'
+         & // '     but: <' // str32(actual) // '> differed by <' // str32(d) &
+         & // '> which exceeds the tolerance by <' // str32(d - tol) // '>'
     @assertExceptionRaised(error)
   end subroutine test_near_not_within_tolerance
 
-  function str(x)
-    character(:), allocatable :: str
-    real, intent(in) :: x
-
-    character(32) :: buffer
-
-    write(buffer,'(g0)') x
-    str = trim(buffer)
-  end function str
-  
-
   @test
   subroutine test_wrong_type()
+    real :: tol, expected
     character(:), allocatable :: error
-
-    call assert_that(2, is(near(2.0, 0.1)))
+    expected = 2.0
+    tol      = 0.1
+    call assert_that(2, is(near(expected, tol)))
     error = new_line('a') &
-         & // 'Expected: is a numeric value within <' // str(0.1) // '> of <' // str(2.0) // '>' &
+         & // 'Expected: is a numeric value within <' // str32(tol) // '> of <' // str32(expected) // '>' &
          & // new_line('a') &
          & // '     but: was an integer (<2>)'
     @assertExceptionRaised(error)
-
   end subroutine test_wrong_type
+
+  ! --- double precision scalar ---
+
+  @test
+  subroutine test_near_double_self()
+    call assert_that(2.d0, is(near(2.d0, 0.d0)))
+  end subroutine test_near_double_self
+
+  @test
+  subroutine test_near_double_within_tolerance()
+    call assert_that(2.d0, is(near(2.1d0, 0.2d0)))
+  end subroutine test_near_double_within_tolerance
+
+  @test
+  subroutine test_near_double_not_within_tolerance()
+    call assert_that(2.2d0, is(near(2.0d0, 0.1d0)))
+    @assertExceptionRaised()
+  end subroutine test_near_double_not_within_tolerance
+
+  ! --- REAL64 scalar ---
+
+  @test
+  subroutine test_near_real64_self()
+    real(kind=REAL64) :: x
+    x = 7.0_REAL64
+    call assert_that(x, is(near(x, 0.0_REAL64)))
+  end subroutine test_near_real64_self
+
+  @test
+  subroutine test_near_real64_within_tolerance()
+    real(kind=REAL64) :: x
+    x = 7.0_REAL64
+    call assert_that(x, is(near(x + 1.e-8_REAL64, 1.e-7_REAL64)))
+  end subroutine test_near_real64_within_tolerance
+
+  @test
+  subroutine test_near_real64_not_within_tolerance()
+    real(kind=REAL64) :: x
+    x = 7.0_REAL64
+    call assert_that(x + 1.0_REAL64, is(near(x, 1.e-10_REAL64)))
+    @assertExceptionRaised()
+  end subroutine test_near_real64_not_within_tolerance
+
+  ! --- actual kind differs from expected kind ---
+
+  @test
+  subroutine test_near_actual_single_expected_double()
+    ! actual is default real, expected/tolerance are double — still within tolerance
+    real :: actual
+    actual = 2.0
+    call assert_that(actual, is(near(2.0_REAL64, 1.e-5_REAL64)))
+  end subroutine test_near_actual_single_expected_double
+
+  ! --- array rank 1 (default real) ---
+
+  @test
+  subroutine test_near_real_array_1d()
+    real :: a(3)
+    a = [1., 2., 3.]
+    call assert_that(a, is(near(a, 0.0)))
+  end subroutine test_near_real_array_1d
+
+  @test
+  subroutine test_near_real_array_1d_within_tolerance()
+    real :: a(3), b(3)
+    a = [1., 2., 3.]
+    b = a + 1.e-5
+    call assert_that(b, is(near(a, 1.e-4)))
+  end subroutine test_near_real_array_1d_within_tolerance
+
+  @test
+  subroutine test_near_real_array_1d_not_within_tolerance()
+    real :: a(3), b(3)
+    a = [1., 2., 3.]
+    b = a + 1.0
+    call assert_that(b, is(near(a, 1.e-4)))
+    @assertExceptionRaised()
+  end subroutine test_near_real_array_1d_not_within_tolerance
+
+  ! --- array rank 1 (double precision) ---
+
+  @test
+  subroutine test_near_double_array_1d()
+    real(kind=REAL64) :: a(3)
+    a = [1.d0, 2.d0, 3.d0]
+    call assert_that(a, is(near(a, 0.d0)))
+  end subroutine test_near_double_array_1d
+
+  @test
+  subroutine test_near_double_array_1d_within_tolerance()
+    real(kind=REAL64) :: a(3), b(3)
+    a = [1.d0, 2.d0, 3.d0]
+    b = a + 1.d-8
+    call assert_that(b, is(near(a, 1.d-7)))
+  end subroutine test_near_double_array_1d_within_tolerance
+
+  @test
+  subroutine test_near_double_array_1d_not_within_tolerance()
+    real(kind=REAL64) :: a(3), b(3)
+    a = [1.d0, 2.d0, 3.d0]
+    b = a + 1.d0
+    call assert_that(b, is(near(a, 1.d-10)))
+    @assertExceptionRaised()
+  end subroutine test_near_double_array_1d_not_within_tolerance
+
+  ! --- actual kind differs from expected in array case ---
+
+  @test
+  subroutine test_near_double_array_actual_single()
+    ! expected double, actual single — should still match within tolerance
+    real(kind=REAL64) :: expected(3)
+    real :: actual(3)
+    expected = [1.d0, 2.d0, 3.d0]
+    actual   = real(expected)
+    call assert_that(actual, is(near(expected, 1.d-5)))
+  end subroutine test_near_double_array_actual_single
+
+  ! --- array rank 2 ---
+
+  @test
+  subroutine test_near_double_array_2d()
+    real(kind=REAL64) :: a(2,2)
+    a = reshape([1.d0, 2.d0, 3.d0, 4.d0], shape(a))
+    call assert_that(a, is(near(a, 0.d0)))
+  end subroutine test_near_double_array_2d
+
+  ! --- array rank 3 ---
+
+  @test
+  subroutine test_near_double_array_3d()
+    real(kind=REAL64) :: a(2,2,2)
+    a = reshape([1.d0, 2.d0, 3.d0, 4.d0, 5.d0, 6.d0, 7.d0, 8.d0], shape(a))
+    call assert_that(a, is(near(a, 0.d0)))
+  end subroutine test_near_double_array_3d
+
+  ! --- array rank 4 ---
+
+  @test
+  subroutine test_near_double_array_4d()
+    real(kind=REAL64) :: a(2,2,2,2)
+    integer :: i
+    a = reshape([(real(i, REAL64), i=1,16)], shape(a))
+    call assert_that(a, is(near(a, 0.d0)))
+  end subroutine test_near_double_array_4d
+
+  ! helpers
+  function str32(x)
+    character(:), allocatable :: str32
+    real, intent(in) :: x
+    character(32) :: buffer
+    write(buffer,'(g0)') x
+    str32 = trim(buffer)
+  end function str32
+
+  function str64(x)
+    character(:), allocatable :: str64
+    real(kind=REAL64), intent(in) :: x
+    character(32) :: buffer
+    write(buffer,'(g0)') x
+    str64 = trim(buffer)
+  end function str64
 
 end module Test_IsNear

--- a/tests/fhamcrest/Test_IsNear.pf
+++ b/tests/fhamcrest/Test_IsNear.pf
@@ -156,14 +156,14 @@ contains
   ! --- actual kind differs from expected in array case ---
 
   @test
-  subroutine test_near_double_array_actual_single()
-    ! expected double, actual single — should still match within tolerance
-    real(kind=REAL64) :: expected(3)
-    real :: actual(3)
-    expected = [1.d0, 2.d0, 3.d0]
-    actual   = real(expected)
-    call assert_that(actual, is(near(expected, 1.d-5)))
-  end subroutine test_near_double_array_actual_single
+  subroutine test_near_real_array_actual_double()
+    ! expected default real, actual double — test writer convenience
+    real :: expected(3)
+    real(kind=REAL64) :: actual(3)
+    expected = [1., 2., 3.]
+    actual   = real(expected, kind=REAL64)
+    call assert_that(actual, is(near(expected, 1.e-5)))
+  end subroutine test_near_real_array_actual_double
 
   ! --- array rank 2 ---
 

--- a/tests/fhamcrest/Test_IsRelativelyNear.pf
+++ b/tests/fhamcrest/Test_IsRelativelyNear.pf
@@ -133,13 +133,14 @@ contains
   ! --- actual kind differs from expected in array case ---
 
   @test
-  subroutine test_relatively_near_double_array_actual_single()
-    real(kind=REAL64) :: expected(3)
-    real :: actual(3)
-    expected = [1.d0, 2.d0, 3.d0]
-    actual   = real(expected) * (1.0 + 1.e-5)
-    call assert_that(actual, is(relatively_near(expected, 1.d-4)))
-  end subroutine test_relatively_near_double_array_actual_single
+  subroutine test_relatively_near_real_array_actual_double()
+    ! expected default real, actual double — test writer convenience
+    real :: expected(3)
+    real(kind=REAL64) :: actual(3)
+    expected = [1., 2., 3.]
+    actual   = real(expected, kind=REAL64) * (1.d0 + 1.d-8)
+    call assert_that(actual, is(relatively_near(expected, 1.e-4)))
+  end subroutine test_relatively_near_real_array_actual_double
 
   ! --- array rank 2 ---
 

--- a/tests/fhamcrest/Test_IsRelativelyNear.pf
+++ b/tests/fhamcrest/Test_IsRelativelyNear.pf
@@ -1,9 +1,9 @@
 module Test_IsRelativelyNear
+  use iso_fortran_env, only: REAL32, REAL64
   use funit
   implicit none
 
 contains
-
 
   @test
   subroutine test_relatively_near_self()
@@ -17,27 +17,173 @@ contains
 
   @test
   subroutine test_not_relatively_near()
+    real :: expected, actual, tol, d
     character(:), allocatable :: error
-    call assert_that(30., is(relatively_near(10., 1.0)))
-
+    expected = 10.
+    actual   = 30.
+    tol      = 1.0
+    d        = abs(actual - expected) / abs(expected)
+    call assert_that(actual, is(relatively_near(expected, tol)))
     error = new_line('a') &
          & // 'Expected: is a numeric value whose relative error from <' &
-         & // str(10.) // '> is less than <' // str(1.0) // '>' &
+         & // str32(expected) // '> is less than <' // str32(tol) // '>' &
          & // new_line('a') &
-         & // '     but: <' // str(30.) // '> has a relative error of <' // str((30.-10.)/10.) &
-         & // '> which exceeds the tolerance by <' &
-         & // str((30.-10.)/10. - 1.0) // '>'
+         & // '     but: <' // str32(actual) // '> has a relative error of <' &
+         & // str32(d) // '> which exceeds the tolerance by <' &
+         & // str32(d - tol) // '>'
     @assertExceptionRaised(error)
   end subroutine test_not_relatively_near
-  
-  function str(x)
-    character(:), allocatable :: str
+
+  ! --- double precision scalar ---
+
+  @test
+  subroutine test_relatively_near_double_self()
+    call assert_that(2.d0, is(relatively_near(2.d0, 0.d0)))
+  end subroutine test_relatively_near_double_self
+
+  @test
+  subroutine test_relatively_near_double()
+    call assert_that(9.d0, is(relatively_near(10.d0, 0.2d0)))
+  end subroutine test_relatively_near_double
+
+  @test
+  subroutine test_not_relatively_near_double()
+    call assert_that(30.d0, is(relatively_near(10.d0, 1.0d0)))
+    @assertExceptionRaised()
+  end subroutine test_not_relatively_near_double
+
+  ! --- REAL64 scalar ---
+
+  @test
+  subroutine test_relatively_near_real64()
+    real(kind=REAL64) :: x
+    x = 7.0_REAL64
+    call assert_that(x * (1.0_REAL64 + 1.e-8_REAL64), is(relatively_near(x, 1.e-7_REAL64)))
+  end subroutine test_relatively_near_real64
+
+  @test
+  subroutine test_not_relatively_near_real64()
+    real(kind=REAL64) :: x
+    x = 7.0_REAL64
+    call assert_that(x * 2.0_REAL64, is(relatively_near(x, 1.e-10_REAL64)))
+    @assertExceptionRaised()
+  end subroutine test_not_relatively_near_real64
+
+  ! --- actual kind differs from expected kind ---
+
+  @test
+  subroutine test_relatively_near_actual_single_expected_double()
+    real :: actual
+    actual = 9.0
+    call assert_that(actual, is(relatively_near(10.0_REAL64, 0.2_REAL64)))
+  end subroutine test_relatively_near_actual_single_expected_double
+
+  ! --- array rank 1 (default real) ---
+
+  @test
+  subroutine test_relatively_near_real_array_1d()
+    real :: a(3)
+    a = [1., 2., 3.]
+    call assert_that(a, is(relatively_near(a, 0.0)))
+  end subroutine test_relatively_near_real_array_1d
+
+  @test
+  subroutine test_relatively_near_real_array_1d_within_tolerance()
+    real :: a(3), b(3)
+    a = [1., 2., 3.]
+    b = a * (1.0 + 1.e-5)
+    call assert_that(b, is(relatively_near(a, 1.e-4)))
+  end subroutine test_relatively_near_real_array_1d_within_tolerance
+
+  @test
+  subroutine test_relatively_near_real_array_1d_not_within_tolerance()
+    real :: a(3), b(3)
+    a = [1., 2., 3.]
+    b = a * 2.0
+    call assert_that(b, is(relatively_near(a, 1.e-4)))
+    @assertExceptionRaised()
+  end subroutine test_relatively_near_real_array_1d_not_within_tolerance
+
+  ! --- array rank 1 (double precision) ---
+
+  @test
+  subroutine test_relatively_near_double_array_1d()
+    real(kind=REAL64) :: a(3)
+    a = [1.d0, 2.d0, 3.d0]
+    call assert_that(a, is(relatively_near(a, 0.d0)))
+  end subroutine test_relatively_near_double_array_1d
+
+  @test
+  subroutine test_relatively_near_double_array_1d_within_tolerance()
+    real(kind=REAL64) :: a(3), b(3)
+    a = [1.d0, 2.d0, 3.d0]
+    b = a * (1.d0 + 1.d-8)
+    call assert_that(b, is(relatively_near(a, 1.d-7)))
+  end subroutine test_relatively_near_double_array_1d_within_tolerance
+
+  @test
+  subroutine test_relatively_near_double_array_1d_not_within_tolerance()
+    real(kind=REAL64) :: a(3), b(3)
+    a = [1.d0, 2.d0, 3.d0]
+    b = a * 2.d0
+    call assert_that(b, is(relatively_near(a, 1.d-10)))
+    @assertExceptionRaised()
+  end subroutine test_relatively_near_double_array_1d_not_within_tolerance
+
+  ! --- actual kind differs from expected in array case ---
+
+  @test
+  subroutine test_relatively_near_double_array_actual_single()
+    real(kind=REAL64) :: expected(3)
+    real :: actual(3)
+    expected = [1.d0, 2.d0, 3.d0]
+    actual   = real(expected) * (1.0 + 1.e-5)
+    call assert_that(actual, is(relatively_near(expected, 1.d-4)))
+  end subroutine test_relatively_near_double_array_actual_single
+
+  ! --- array rank 2 ---
+
+  @test
+  subroutine test_relatively_near_double_array_2d()
+    real(kind=REAL64) :: a(2,2)
+    a = reshape([1.d0, 2.d0, 3.d0, 4.d0], shape(a))
+    call assert_that(a, is(relatively_near(a, 0.d0)))
+  end subroutine test_relatively_near_double_array_2d
+
+  ! --- array rank 3 ---
+
+  @test
+  subroutine test_relatively_near_double_array_3d()
+    real(kind=REAL64) :: a(2,2,2)
+    a = reshape([1.d0, 2.d0, 3.d0, 4.d0, 5.d0, 6.d0, 7.d0, 8.d0], shape(a))
+    call assert_that(a, is(relatively_near(a, 0.d0)))
+  end subroutine test_relatively_near_double_array_3d
+
+  ! --- array rank 4 ---
+
+  @test
+  subroutine test_relatively_near_double_array_4d()
+    real(kind=REAL64) :: a(2,2,2,2)
+    integer :: i
+    a = reshape([(real(i, REAL64), i=1,16)], shape(a))
+    call assert_that(a, is(relatively_near(a, 0.d0)))
+  end subroutine test_relatively_near_double_array_4d
+
+  ! helpers
+  function str32(x)
+    character(:), allocatable :: str32
     real, intent(in) :: x
-
     character(32) :: buffer
-
     write(buffer,'(g0)') x
-    str = trim(buffer)
-  end function str
-  
+    str32 = trim(buffer)
+  end function str32
+
+  function str64(x)
+    character(:), allocatable :: str64
+    real(kind=REAL64), intent(in) :: x
+    character(32) :: buffer
+    write(buffer,'(g0)') x
+    str64 = trim(buffer)
+  end function str64
+
 end module Test_IsRelativelyNear


### PR DESCRIPTION
## Summary

- Add `IsNear_32`/`IsNear_64` and `IsRelativelyNear_32`/`IsRelativelyNear_64` typed matcher types so tolerance precision matches the expected value's precision
- Extend `near()` and `relatively_near()` constructors to accept REAL64 scalars and real arrays of ranks 1-4 for both 32- and 64-bit variants
- Extend `equal_to()` and `assert_that()` to support rank-4 arrays
- Fix `expects_type_of` in both matchers to return .true. for ArrayWrapper_Nd actual values, so array matching correctly dispatches through `matches_safely`

## Root cause fixed

`expects_type_of_32/64` previously only handled scalar real types. When `assert_that` wraps an array actual in `ArrayWrapper_Nd`, `TypeSafeMatcher%matches` calls `expects_type_of` first — which returned .false. for any array wrapper, preventing `matches_safely` (which has correct array dispatch) from ever being called.

## Files changed

- `src/funit/fhamcrest/IsNear.F90` — rewritten with two typed matcher types and full array support
- `src/funit/fhamcrest/IsRelativelyNear.F90` — same
- `src/funit/fhamcrest/IsEqual.F90` — rank-4 support added
- `src/funit/fhamcrest/MatcherAssert.F90` — rank-4 `assert_that` overloads added
- `tests/fhamcrest/Test_IsNear.pf` — REAL64 scalar, mixed-kind, and array rank 1-4 tests
- `tests/fhamcrest/Test_IsRelativelyNear.pf` — same coverage
- `tests/fhamcrest/Test_IsEqual.pf` — rank-4 tests added