### PR TITLE
Fix #543: suppress anyExceptions() guard after @assertExceptionRaised

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended `equal_to()` Hamcrest matcher and `assert_that()` to support rank-4 arrays
 
 ### Fixed
+- `@assertExceptionRaised` no longer short-circuits after catching one exception (issue #543)
+  - Previously, the generated code emitted `if (anyExceptions()) return` after every
+    `@assertExceptionRaised`, preventing successive calls from catching additional exceptions
+  - Multiple exceptions can now each be caught with successive `@assertExceptionRaised` directives
 - Allow for larger integer value comparisons greater than 20 digits (issue #540)
   - Previously, a large but valid `_int64` based integer would fail to be written
     to a string because of being hard coded to only be allocated 20 characters

--- a/bin/funit/pFUnitParser.py
+++ b/bin/funit/pFUnitParser.py
@@ -412,7 +412,11 @@ class AtAssert(Action):
             parser.outputFile, parser.fileName, parser.currentLineNumber
         )
         parser.outputFile.write(" )\n")
-        parser.outputFile.write("  if (anyExceptions()) return\n")
+        # For assertExceptionRaised, do NOT check anyExceptions() after the call.
+        # Multiple exceptions may have been raised and the user should be able to
+        # catch each one with successive @assertExceptionRaised directives.
+        if match.group(1).lower() != "exceptionraised":
+            parser.outputFile.write("  if (anyExceptions()) return\n")
         parser.outputFile.write(
             cppSetLineAndFile(parser.currentLineNumber + 1, parser.fileName)
         )

--- a/bin/funit/tests/test_parser_assertions.py
+++ b/bin/funit/tests/test_parser_assertions.py
@@ -378,5 +378,29 @@ class TestParserAssertions(unittest.TestCase):
         self.assertTrue("#line 9 'foo.pfunit'\n", parser.outLines[7])
 
 
+    def testAssertExceptionRaisedNoAnyExceptionsCheck(self):
+        """assertExceptionRaised should NOT emit 'if (anyExceptions()) return'.
+        Multiple exceptions may be raised and the user should be able to catch
+        each one with successive @assertExceptionRaised directives."""
+        parser = MockParser([" \n"])
+        atAssert = AtAssert(parser)
+
+        self.assertTrue(atAssert.match("@assertExceptionRaised()"))
+        self.assertTrue(atAssert.match("@assertExceptionRaised('some message')"))
+
+        parser.fileName = "foo.pfunit"
+        parser.currentLineNumber = 8
+        atAssert.apply("   @assertExceptionRaised('msg_x')\n")
+        self.assertEqual('#line 8 "foo.pfunit"\n', parser.outLines[0])
+        self.assertEqual("  call assertExceptionRaised('msg_x', &\n", parser.outLines[1])
+        self.assertEqual(" & location=SourceLocation( &\n", parser.outLines[2])
+        self.assertEqual(" & 'foo.pfunit', &\n", parser.outLines[3])
+        self.assertEqual(" & 8)", parser.outLines[4])
+        self.assertEqual(" )\n", parser.outLines[5])
+        # No 'if (anyExceptions()) return' should be emitted
+        self.assertEqual('#line 9 "foo.pfunit"\n', parser.outLines[6])
+        self.assertEqual(6, len(parser.outLines) - 1)  # only 7 lines total (0-6)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/funit-core/CMakeLists.txt
+++ b/tests/funit-core/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(other_shared PUBLIC funit)
 
 set(pf_tests
   Test_ExceptionList.pf
+  Test_AssertExceptionRaised.pf
   Test_DisableTest.pf
   Test_AssertString.pf
   Test_Assert_Integer.pf

--- a/tests/funit-core/Test_AssertExceptionRaised.pf
+++ b/tests/funit-core/Test_AssertExceptionRaised.pf
@@ -1,0 +1,39 @@
+module Test_AssertExceptionRaised
+   use FUnit
+
+   @suite(name='AssertExceptionRaised_suite')
+
+contains
+
+   ! Verify that two successive @assertExceptionRaised directives can each
+   ! catch their own exception when two exceptions have been raised.
+   ! Prior to fix for GH-543, the first @assertExceptionRaised would emit
+   ! 'if (anyExceptions()) return', short-circuiting before the second
+   ! exception could be caught.
+   @test
+   subroutine test_catch_two_exceptions()
+      call throw('msg_x')
+      call throw('msg_y')
+
+      @assertExceptionRaised('msg_x')
+      @assertExceptionRaised('msg_y')
+
+   end subroutine test_catch_two_exceptions
+
+
+   ! Sanity check: a single @assertExceptionRaised still works as before.
+   @test
+   subroutine test_catch_single_exception()
+      call throw('some error')
+      @assertExceptionRaised('some error')
+   end subroutine test_catch_single_exception
+
+
+   ! Verify that @assertExceptionRaised() (no message) clears any exception.
+   @test
+   subroutine test_catch_any_exception()
+      call throw('anything')
+      @assertExceptionRaised()
+   end subroutine test_catch_any_exception
+
+end module Test_AssertExceptionRaised

--- a/tests/funit-core/testSuites.inc
+++ b/tests/funit-core/testSuites.inc
@@ -12,6 +12,7 @@
    ADD_TEST_SUITE(Disable_suite)
    ADD_TEST_SUITE(TapListener_suite)
    ADD_TEST_SUITE(ExceptionList_suite)
+   ADD_TEST_SUITE(AssertExceptionRaised_suite)
    ADD_TEST_SUITE(GlobPattern_suite)
    ADD_TEST_SUITE(LiteralPattern_suite)
    ADD_TEST_SUITE(DotPattern_suite)


### PR DESCRIPTION
## Summary

Fixes #543.

`@assertExceptionRaised` previously emitted `if (anyExceptions()) return` after every call, which short-circuited execution before successive `@assertExceptionRaised` directives could catch additional exceptions. This meant that when two exceptions were raised, only the first could be caught:

```fortran
call throw('msg_x')
call throw('msg_y')
@assertExceptionRaised('msg_x')  ! would return here if any exceptions remain
@assertExceptionRaised('msg_y')  ! never reached
```

## Fix

The `anyExceptions()` guard is now suppressed for `@assertExceptionRaised` directives only, allowing multiple successive calls to each catch their own exception.

## Changes

- `bin/funit/pFUnitParser.py`: skip emitting `if (anyExceptions()) return` when the directive is `assertExceptionRaised`
- `bin/funit/tests/test_parser_assertions.py`: add parser test verifying the guard is not emitted
- `tests/funit-core/Test_AssertExceptionRaised.pf`: new Fortran test suite including a two-exception catch test
- `tests/funit-core/CMakeLists.txt`, `testSuites.inc`: wire in new test suite
- `ChangeLog.md`: document the fix