### PR TITLE
Update CI and prepare for 4.18 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,30 +80,23 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
 
-      # On macOS, use Homebrew's OpenMPI which is patched for platform compatibility.
-      # On Linux, build from source and cache the result.
-      - name: Install MPI (macOS via Homebrew)
-        if: runner.os == 'macOS'
-        run: brew install open-mpi
-
-      - name: Cache MPI (Linux)
+      - name: Cache MPI
         id: cache-mpi
-        if: runner.os == 'Linux'
         uses: actions/cache@v5
         with:
           path: ~/local/openmpi
           key: mpi-${{ matrix.os }}-openmpi-5.0.10
 
-      - name: Build MPI (Linux)
-        if: runner.os == 'Linux' && steps.cache-mpi.outputs.cache-hit != 'true'
+      - name: Build MPI
+        if: steps.cache-mpi.outputs.cache-hit != 'true'
         run: |
           sh ${GITHUB_WORKSPACE}/tools/ci-install-mpi.sh openmpi 5.0.10
 
-      - name: Set MPI Environment (Linux)
-        if: runner.os == 'Linux'
+      - name: Set MPI Environment
         run: |
           echo "${HOME}/local/openmpi/bin" >> $GITHUB_PATH
           echo "LD_LIBRARY_PATH=${HOME}/local/openmpi/lib" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=${HOME}/local/openmpi/lib" >> $GITHUB_ENV
 
       - name: MPI Versions
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-15, macos-26]
         compiler: [gfortran-12, gfortran-13, gfortran-14, gfortran-15]
         # gfortran-11 is only on ubuntu-22.04
         # gfortran-13 and -14 and -15 are not on ubuntu-22.04
         # gfortran-12 is not on macos
-        # gfortran-15 is only on macos
+        # gfortran-15 is only on macos (and ubuntu-24.04+ does not have it)
         include:
           - os: ubuntu-22.04
             compiler: gfortran-11
@@ -38,9 +38,9 @@ jobs:
             compiler: gfortran-15
           - os: ubuntu-24.04
             compiler: gfortran-15
-          - os: macos-14
-            compiler: gfortran-12
           - os: macos-15
+            compiler: gfortran-12
+          - os: macos-26
             compiler: gfortran-12
 
       # fail-fast if set to 'true' here is good for production, but when
@@ -76,23 +76,30 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
 
-      - name: Cache MPI
+      # On macOS, use Homebrew's OpenMPI which is patched for platform compatibility.
+      # On Linux, build from source and cache the result.
+      - name: Install MPI (macOS via Homebrew)
+        if: runner.os == 'macOS'
+        run: brew install open-mpi
+
+      - name: Cache MPI (Linux)
         id: cache-mpi
+        if: runner.os == 'Linux'
         uses: actions/cache@v5
         with:
           path: ~/local/openmpi
           key: mpi-${{ matrix.os }}-openmpi-5.0.10
 
-      - name: Build MPI
-        if: steps.cache-mpi.outputs.cache-hit != 'true'
+      - name: Build MPI (Linux)
+        if: runner.os == 'Linux' && steps.cache-mpi.outputs.cache-hit != 'true'
         run: |
           sh ${GITHUB_WORKSPACE}/tools/ci-install-mpi.sh openmpi 5.0.10
 
-      - name: Set MPI Environment
+      - name: Set MPI Environment (Linux)
+        if: runner.os == 'Linux'
         run: |
           echo "${HOME}/local/openmpi/bin" >> $GITHUB_PATH
           echo "LD_LIBRARY_PATH=${HOME}/local/openmpi/lib" >> $GITHUB_ENV
-          echo "DYLD_LIBRARY_PATH=${HOME}/local/openmpi/lib" >> $GITHUB_ENV
 
       - name: MPI Versions
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,10 @@ on:
   # Allow us to trigger it manually
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   GNU:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,13 +22,11 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         compiler: [gfortran-12, gfortran-13, gfortran-14, gfortran-15]
-        # gfortran-10 and -11 are only on ubuntu-22.04
+        # gfortran-11 is only on ubuntu-22.04
         # gfortran-13 and -14 and -15 are not on ubuntu-22.04
         # gfortran-12 is not on macos
         # gfortran-15 is only on macos
         include:
-          - os: ubuntu-22.04
-            compiler: gfortran-10
           - os: ubuntu-22.04
             compiler: gfortran-11
         exclude:
@@ -83,12 +81,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/local/openmpi
-          key: mpi-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}
+          key: mpi-${{ matrix.os }}-openmpi-5.0.10
 
       - name: Build MPI
         if: steps.cache-mpi.outputs.cache-hit != 'true'
         run: |
-          sh ${GITHUB_WORKSPACE}/tools/ci-install-mpi.sh openmpi 5.0.2
+          sh ${GITHUB_WORKSPACE}/tools/ci-install-mpi.sh openmpi 5.0.10
 
       - name: Set MPI Environment
         run: |
@@ -117,7 +115,7 @@ jobs:
         run: ctest --test-dir build --parallel 1 --output-on-failure --repeat until-pass:4
 
       - name: Archive log files on failure
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: logfiles-${{ matrix.compiler }}-${{ matrix.os }}
@@ -186,7 +184,7 @@ jobs:
         run: ctest --test-dir build --parallel 1 --output-on-failure --repeat until-pass:4
 
       - name: Archive log files on failure
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: logfiles-Intel
@@ -290,7 +288,7 @@ jobs:
 
       - name: Archive log files on failure
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: logfiles-Nvidia
           path: |
@@ -345,7 +343,7 @@ jobs:
         run: ctest --test-dir build --parallel 1 --output-on-failure --repeat until-pass:4
 
       - name: Archive log files on failure
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: logfiles-Flang

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,10 +201,10 @@ jobs:
     runs-on: ubuntu-24.04
     # Turned off for now because NVHPC image is too large for free
     # GitHub Actions runners, but leaving here for when we can run it again
-    if: false
+    if: true
     env:
       FC: nvfortran
-      NVHPC_IMAGE: nvcr.io/nvidia/nvhpc:26.1-devel-cuda13.1-ubuntu24.04
+      NVHPC_IMAGE: nvcr.io/nvidia/nvhpc:26.3-devel-cuda13.1-ubuntu24.04
 
     steps:
       # Reclaim lots of space

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -10,13 +10,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           path: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
           submodules: recursive
 
       - name: Checkout git-archive-all.sh
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           repository: fabacab/git-archive-all.sh
           path: git-archive-all.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project (PFUNIT
-  VERSION 4.17.1
+  VERSION 4.18.0
   LANGUAGES Fortran C)
 
 cmake_policy(SET CMP0077 NEW)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated CI workflow to use OpenMPI 5.0.10 (previously 5.0.2) on Linux
-- On macOS, switched from building OpenMPI from source to using Homebrew's `open-mpi` package for better platform compatibility
+- Updated CI workflow to use OpenMPI 5.0.10 (previously 5.0.2) on all platforms
 - Simplified CI MPI cache key to be per-OS only (previously per-OS and per-compiler), reducing redundant cache entries
 - Added `concurrency` group to CI workflow to cancel in-progress runs when a new commit is pushed to the same PR
 - Removed `macos-14` (Sonoma) from the CI runner matrix; it is deprecated upstream and two OS releases behind

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated CI workflow to use OpenMPI 5.0.10 (previously 5.0.2)
+- Updated CI workflow to use OpenMPI 5.0.10 (previously 5.0.2) on Linux
+- On macOS, switched from building OpenMPI from source to using Homebrew's `open-mpi` package for better platform compatibility
 - Simplified CI MPI cache key to be per-OS only (previously per-OS and per-compiler), reducing redundant cache entries
 - Removed gfortran-10 from the GNU CI compiler matrix
+- Removed `macos-14` (Sonoma) from the CI runner matrix; it is deprecated upstream and two OS releases behind
+- Added `macos-26` (macOS Tahoe) to the GNU CI runner matrix
 - Updated `actions/upload-artifact` from v6 to v7 in `main.yml`
 - Updated `actions/checkout` from v2 to v6 in `release-tarball.yml`
 - Updated `README.md`: removed stale `pFUnit 4.0` title, updated LICENSE description to Apache-2.0 (as of v4.17.0), fixed `ChangeLog` reference to `ChangeLog.md`, removed non-existent `VERSION` file entry, removed Python 2.7 references

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.18.0] - 2026-04-24
+
+### Changed
+
+- Updated CI workflow to use OpenMPI 5.0.10 (previously 5.0.2)
+- Simplified CI MPI cache key to be per-OS only (previously per-OS and per-compiler), reducing redundant cache entries
+- Removed gfortran-10 from the GNU CI compiler matrix
+- Updated `actions/upload-artifact` from v6 to v7 in `main.yml`
+- Updated `actions/checkout` from v2 to v6 in `release-tarball.yml`
+- Updated `README.md`: removed stale `pFUnit 4.0` title, updated LICENSE description to Apache-2.0 (as of v4.17.0), fixed `ChangeLog` reference to `ChangeLog.md`, removed non-existent `VERSION` file entry, removed Python 2.7 references
+
 ### Added
 
 - Extended `near()` and `relatively_near()` Hamcrest matchers to support `REAL64` and array ranks 1–4 (issue #542)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated CI workflow to use OpenMPI 5.0.10 (previously 5.0.2) on Linux
 - On macOS, switched from building OpenMPI from source to using Homebrew's `open-mpi` package for better platform compatibility
 - Simplified CI MPI cache key to be per-OS only (previously per-OS and per-compiler), reducing redundant cache entries
-- Removed gfortran-10 from the GNU CI compiler matrix
+- Added `concurrency` group to CI workflow to cancel in-progress runs when a new commit is pushed to the same PR
 - Removed `macos-14` (Sonoma) from the CI runner matrix; it is deprecated upstream and two OS releases behind
 - Added `macos-26` (macOS Tahoe) to the GNU CI runner matrix
 - Updated `actions/upload-artifact` from v6 to v7 in `main.yml`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pFUnit 4.0
+# pFUnit
 
 pFUnit is a unit testing framework enabling JUnit-like testing of
 serial and MPI-parallel software written in Fortran.  Limited support
@@ -42,17 +42,14 @@ comprehensive, and earlier compilers may work for some user code.
   - NAG v7.2
   - GFortran v12+
 - CMake v3.24+
-- Python v2.7* or v3.x
+- Python v3.x
 - make (or ninja or ...)
 - Optional
   - MPI (tested with OpenMPI and Intel MPI)
   - OpenMP
   
 Doxygen was used to generate documention for pFUnit 3, but is not being
-maintained.   My intent instead is to leverage the GitHub wiki to better
-maintain features.
-
-**Note that support for Python 2.7 my soon disappear.**
+maintained.
 
 
 ## Obtaining pFUnit
@@ -103,18 +100,15 @@ files.
 - `COPYRIGHT` - Contains information pertaining to the use and
   distribution of pFUnit.
   
-- `ChangeLog` - history of changes
+- `ChangeLog.md` - history of changes
 
 - `Examples` - Contains examples of how to use pFUnit once it is
   installed.   These are deprecated.  Users should instead go to the
   [pFUnit-demos](https://github.com/Goddard-Fortran-Ecosystem/pFUnit_demos) repository.
 
-- `LICENSE` - The NASA Open Source Agreement for GSC-15,137-1 F-UNIT,
-  also known as pFUnit.
+- `LICENSE` - Apache-2.0 license (as of v4.17.0). (The original NASA Open Source Agreement is retained as `LICENSE-NOSA` for historical reference.)
 
 - `README.md` - This file.
-
-- `VERSION` - Contains a string describing the current version of the framework.
 
 - `bin` - Executables used to construct and perform unit tests.
 


### PR DESCRIPTION
This PR prepares pFUnit for 4.18 release and also updates the CI (with suggestions by claude)

A couple changes:

1. Removing the `gfortran-10` test in CI. It was consistently failing with ICEs and we don't "officially" support gcc 10 anyway.
2. Add `macos-26` tests and removing `macos-14` tests. GitHub will soon remove the `macos-14` images. 