### PR TITLE
Fix #548: workaround GCC 16.1.0 regression in TestResult%getName()

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround GCC 16.1.0 regression in `TestResult%getName()` (issue #548)
+  - GCC 16.1.0 incorrectly copies only padding spaces (or garbage for
+    polymorphic dispatch) when assigning a `character(len=N)` component to a
+    `character(:), allocatable` function result variable
+  - Fixed by using `trim(this%name)` in the assignment, which avoids the
+    compiler bug and is also semantically correct
+  - A standalone reproducer and GCC Bugzilla report have been filed for the
+    upstream compiler bug
+
 ## [4.18.0] - 2026-04-24
 
 ### Changed

--- a/src/funit/core/TestResult.F90
+++ b/src/funit/core/TestResult.F90
@@ -312,7 +312,9 @@ contains
    function getName(this) result(name)
       class (TestResult), intent(in) :: this
       character(:), allocatable :: name
-      name = this%name
+      ! Use trim() to avoid a GCC 16 bug where assigning a fixed-length
+      ! character variable to an allocatable result copies only padding spaces.
+      name = trim(this%name)
    end function getName
 
    subroutine setName(this, name)


### PR DESCRIPTION
## Summary

- Fixes #548: `old_tests` failure with GCC 16.1.0
- GCC 16.1.0 has a regression where assigning a `character(len=N)` variable to a `character(:), allocatable` function result produces spaces instead of the actual string content
- `TestResult%getName()` follows exactly this pattern, causing the suite name written to XML output to be corrupted
- Fix: use `trim(this%name)` instead of `this%name` in the assignment — this avoids the compiler bug and is also semantically correct (no need to preserve trailing padding spaces)

## Root cause

The GCC 16.1.0 regression can be reduced to this minimal case:

```fortran
program test
  implicit none
  character(len=64) :: fixed
  character(:), allocatable :: got
  fixed = 'hello world'
  got = getName(fixed)
  if (trim(got) == 'hello world') then
    print *, 'PASS'
  else
    print *, 'FAIL: got=[', trim(got), ']'
  end if
contains
  function getName(fixed) result(name)
    character(len=64), intent(in) :: fixed
    character(:), allocatable :: name
    name = fixed   ! BUG: produces spaces under GCC 16.1.0
  end function
end program
```

GCC 15.2.0 prints `PASS`; GCC 16.1.0 prints `FAIL` with a 64-character string of spaces.
The allocatable is allocated to the correct length but the content is not copied.
A GCC Bugzilla report has been filed for the upstream compiler bug:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=125117

## Fix

```fortran
name = trim(this%name)
```

## Testing

Verified that `ctest -R old_tests` passes with GCC 16.1.0 after this fix.
