### PR TITLE
Flang bug workaround (occurring in parameterised tests)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.18.2] - 2026-05-28
+
+- Workaround for Flang regression (issue #554)
+  - Avoids an issue in Flang where intrinsic assignment of TestVector loses nested polymorphic allocatable components (e.g. testParameter) after a certain nesting depth. This pathway for Flang instead explicitly
+  loops through and uses a `push_back` to correctly preserves all allocatable components.
+
 ## [4.18.1] - 2026-05-05
 
 ### Fixed

--- a/src/funit/core/TestSuite.F90
+++ b/src/funit/core/TestSuite.F90
@@ -87,6 +87,8 @@ contains
       ! polymorphic allocatable components (e.g. testParameter) at depth >= 3.
       ! Use explicit push_back instead, which uses allocate(item, source=t) per
       ! element and correctly preserves all allocatable components.
+      ! Ends up being equivalent to:
+      !       this%tests = b%tests
       do i = 1, b%tests%size()
          t => b%tests%at(i)
          call this%tests%push_back(t)

--- a/src/funit/core/TestSuite.F90
+++ b/src/funit/core/TestSuite.F90
@@ -79,8 +79,10 @@ contains
       class (TestSuite), intent(out) :: this
       type (TestSuite), intent(in) :: b
 
+#ifdef __flang__
       class (Test), pointer :: t
       integer :: i
+#endif
 
       this%name = b%name
 #ifdef __flang__

--- a/src/funit/core/TestSuite.F90
+++ b/src/funit/core/TestSuite.F90
@@ -83,16 +83,18 @@ contains
       integer :: i
 
       this%name = b%name
+#ifdef __flang__
       ! Workaround for Flang bug: intrinsic assignment of TestVector loses nested
       ! polymorphic allocatable components (e.g. testParameter) at depth >= 3.
       ! Use explicit push_back instead, which uses allocate(item, source=t) per
       ! element and correctly preserves all allocatable components.
-      ! Ends up being equivalent to:
-      !       this%tests = b%tests
       do i = 1, b%tests%size()
          t => b%tests%at(i)
          call this%tests%push_back(t)
       end do
+#else
+      this%tests = b%tests
+#endif
       this%shuffle_enabled = b%shuffle_enabled
       this%shuffle_seed = b%shuffle_seed
 

--- a/src/funit/core/TestSuite.F90
+++ b/src/funit/core/TestSuite.F90
@@ -79,8 +79,18 @@ contains
       class (TestSuite), intent(out) :: this
       type (TestSuite), intent(in) :: b
 
+      class (Test), pointer :: t
+      integer :: i
+
       this%name = b%name
-      this%tests = b%tests
+      ! Workaround for Flang bug: intrinsic assignment of TestVector loses nested
+      ! polymorphic allocatable components (e.g. testParameter) at depth >= 3.
+      ! Use explicit push_back instead, which uses allocate(item, source=t) per
+      ! element and correctly preserves all allocatable components.
+      do i = 1, b%tests%size()
+         t => b%tests%at(i)
+         call this%tests%push_back(t)
+      end do
       this%shuffle_enabled = b%shuffle_enabled
       this%shuffle_seed = b%shuffle_seed
 

--- a/tests/funit-core/CMakeLists.txt
+++ b/tests/funit-core/CMakeLists.txt
@@ -46,7 +46,8 @@ set(pf_tests
   Test_NameFilter.pf
   Test_RegularExpression.pf
   Test_TestMethod_before.pf
-  Test_Long_Subroutine_Name.pf)
+  Test_Long_Subroutine_Name.pf
+  Test_ParameterizedAssert.pf)
 
 # Add regex filter tests for non-Windows platforms
 if(NOT WIN32)

--- a/tests/funit-core/Test_ParameterizedAssert.pf
+++ b/tests/funit-core/Test_ParameterizedAssert.pf
@@ -1,0 +1,46 @@
+module Test_ParameterizedAssert
+  ! Simple test to check that parameterized tests are working
+  ! correctly.
+  use FUnit
+  implicit none
+
+  @suite(name='ParameterizedAssert_suite')
+
+  @testParameter
+  type, extends(AbstractTestParameter) :: TestParametersType
+    integer :: dummy
+  contains
+    procedure :: toString
+  end type TestParametersType
+
+  @testCase(constructor=test_case_constructor)
+  type, extends(ParameterizedTestCase) :: TestCaseType
+    type(TestParametersType) :: param
+  end type TestCaseType
+
+contains
+
+  function test_case_constructor(param)
+    type(TestCaseType) :: test_case_constructor
+    type(TestParametersType), intent(in) :: param
+    test_case_constructor%param = param
+  end function test_case_constructor
+
+  function get_parameters_simple() result(params)
+    type(TestParametersType), allocatable :: params(:)
+    params = [ TestParametersType(0) ]
+  end function get_parameters_simple
+
+  function toString(this) result(string)
+    class(TestParametersType), intent(in) :: this
+    character(:), allocatable :: string
+    string = 'simple'
+  end function toString
+
+  @test(testParameters={get_parameters_simple()})
+  subroutine test_sanity(this)
+    class(TestCaseType), intent(inout) :: this
+    @assertEqual(1, 1)
+  end subroutine test_sanity
+
+end module Test_ParameterizedAssert

--- a/tests/funit-core/Test_ParameterizedAssert.pf
+++ b/tests/funit-core/Test_ParameterizedAssert.pf
@@ -40,7 +40,7 @@ contains
   @test(testParameters={get_parameters_simple()})
   subroutine test_sanity(this)
     class(TestCaseType), intent(inout) :: this
-    @assertEqual(1, 1)
+    @assertEqual(1, 1) ! basic check
   end subroutine test_sanity
 
 end module Test_ParameterizedAssert

--- a/tests/funit-core/Test_ParameterizedAssert.pf
+++ b/tests/funit-core/Test_ParameterizedAssert.pf
@@ -40,7 +40,7 @@ contains
   @test(testParameters={get_parameters_simple()})
   subroutine test_sanity(this)
     class(TestCaseType), intent(inout) :: this
-    @assertEqual(1, 1) ! basic check
+    @assertEqual(1, 1)
   end subroutine test_sanity
 
 end module Test_ParameterizedAssert

--- a/tests/funit-core/testSuites.inc
+++ b/tests/funit-core/testSuites.inc
@@ -20,4 +20,5 @@
    ADD_TEST_SUITE(NameFilter_suite)
    ADD_TEST_SUITE(RegularExpression_suite)
    ADD_TEST_SUITE(TestMethod_before)
+   ADD_TEST_SUITE(ParameterizedAssert_suite)
    


### PR DESCRIPTION
When using flang to build and compile pFUnit tests, a bug is hit for parameterised tests causing a segfault (https://github.com/Goddard-Fortran-Ecosystem/pFUnit/issues/554). The problem seems to be due to chains of polymorphic allocatables which eventual lose the allocation descriptor leaving a nested allocatable looking unallocated, which then pops up a segfault here. My work around is, when copying tests in [TestSuite.f90](https://github.com/Goddard-Fortran-Ecosystem/pFUnit/blob/main/src/funit/core/TestSuite.F90#L78-L83), to use a loop and explicitly copy across the tests:
https://github.com/Cambridge-ICCS/pFUnit/commit/184fdcad41af4bcf1b03d824d62042991e92f38b instead; this is equivalent to previous code but avoids the flang bug.