### PR TITLE
Fix --tap option crash; document --xml in README

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,9 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Avoids an issue in Flang where intrinsic assignment of TestVector loses nested polymorphic allocatable components (e.g. testParameter) after a certain nesting depth. This pathway for Flang instead explicitly
   loops through and uses a `push_back` to correctly preserves all allocatable components.
 - Fix `--tap`/`-t` option crashing with memory allocation failure in fArgParse (issue #556)
-  - The option was registered as `action='store'` with an integer default, causing a type mismatch crash when no filename argument followed the flag
-  - Split into two arguments: `-t`/`--tap` (boolean, no filename required) and `--tap-file <file>` (optional filename, defaults to `tap_output.tap`)
-  - Either flag enables TAP output; `--tap-file` alone implies `--tap`
+  - The option was registered as `action='store'` with an integer default, causing a type mismatch crash
+  - Replaced with `action='store_true'` boolean flag; TAP output is always written to `tap_output.tap`
 
 ### Added
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Document `-x`/`--xml` and `-t`/`--tap`/`--tap-file` flags in README command line options
+- Document `-x`/`--xml` and `-t`/`--tap` flags in README command line options
 
 ## [4.18.1] - 2026-05-05
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workaround for Flang regression (issue #554)
   - Avoids an issue in Flang where intrinsic assignment of TestVector loses nested polymorphic allocatable components (e.g. testParameter) after a certain nesting depth. This pathway for Flang instead explicitly
   loops through and uses a `push_back` to correctly preserves all allocatable components.
+- Fix `--tap`/`-t` option crashing with memory allocation failure in fArgParse (issue #556)
+  - The option was registered as `action='store'` with an integer default, causing a type mismatch crash when no filename argument followed the flag
+  - Split into two arguments: `-t`/`--tap` (boolean, no filename required) and `--tap-file <file>` (optional filename, defaults to `tap_output.tap`)
+  - Either flag enables TAP output; `--tap-file` alone implies `--tap`
+
+### Added
+
+- Document `-x`/`--xml` and `-t`/`--tap`/`--tap-file` flags in README command line options
 
 ## [4.18.1] - 2026-05-05
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ the pFUnit preprocessor.
     -o or --output <outputfile>     Direct pFUnit messages to a file.
     -r or --runner <runner>         Specify a non default test runner. (Advanced)
     -s or -skip  <n>                Used internally.
+    -t or --tap                     Write results in TAP format to tap_output.tap.
+    --tap-file <tapfile>            Write TAP results to <tapfile> (implies --tap).
     -x or --xml                     Print results in JUnit-compatible XML format.
 
 #### Filtering Tests

--- a/README.md
+++ b/README.md
@@ -271,7 +271,6 @@ the pFUnit preprocessor.
     -r or --runner <runner>         Specify a non default test runner. (Advanced)
     -s or -skip  <n>                Used internally.
     -t or --tap                     Write results in TAP format to tap_output.tap.
-    --tap-file <tapfile>            Write TAP results to <tapfile> (implies --tap).
     -x or --xml                     Print results in JUnit-compatible XML format.
 
 #### Filtering Tests

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ the pFUnit preprocessor.
     -o or --output <outputfile>     Direct pFUnit messages to a file.
     -r or --runner <runner>         Specify a non default test runner. (Advanced)
     -s or -skip  <n>                Used internally.
+    -x or --xml                     Print results in JUnit-compatible XML format.
 
 #### Filtering Tests
 

--- a/src/funit/FUnit.F90
+++ b/src/funit/FUnit.F90
@@ -113,9 +113,9 @@ contains
          use_tap = .false.
          option => options%at('use_tap')
          if (associated(option)) call cast(option, use_tap)
-         ! --tap-file alone also implies TAP output
+         ! --tapfile alone also implies TAP output
          tap_file = 'tap_output.tap'
-         option => options%at('tap_file')
+         option => options%at('tapfile')
          if (associated(option)) then
             call cast(option, tap_file)
             write(error_unit,'(a,a,a)') 'DEBUG: tap_file=[',tap_file,']'
@@ -404,8 +404,8 @@ contains
          call parser%add_argument('-t', '--tap', action='store_true', &
               & dest='use_tap', &
               & help='add a TAP listener (writes to tap_output.tap by default)')
-         call parser%add_argument('--tap-file', type='string', &
-              & dest='tap_file', action='store', &
+         call parser%add_argument('--tapfile', type='string', &
+              & dest='tapfile', action='store', &
               & help='filename for TAP output (default: tap_output.tap; implies --tap)')
 
       call parser%add_argument('-x', '--xml', action='store_true', &

--- a/src/funit/FUnit.F90
+++ b/src/funit/FUnit.F90
@@ -34,7 +34,7 @@ contains
 
    end function run
 
-   logical function generic_run(load_tests, context) result(status)
+    logical function generic_run(load_tests, context) result(status)
       use fArgParse
       use pf_StringUtilities
       use pf_AbstractPrinter
@@ -42,6 +42,7 @@ contains
       use pf_Test
       use pf_TestVector
       use pf_GlobFilter
+      use iso_fortran_env, only: error_unit
 #ifndef _WIN32
       use pf_RegexFilter
 #endif
@@ -117,6 +118,7 @@ contains
          option => options%at('tap_file')
          if (associated(option)) then
             call cast(option, tap_file)
+            write(error_unit,'(a,a,a)') 'DEBUG: tap_file=[',tap_file,']'
             if (tap_file /= '') use_tap = .true.
          end if
          if (use_tap) call runner%add_listener(TapListener(tap_file))

--- a/src/funit/FUnit.F90
+++ b/src/funit/FUnit.F90
@@ -113,12 +113,11 @@ contains
          option => options%at('use_tap')
          if (associated(option)) call cast(option, use_tap)
          ! --tap-file alone also implies TAP output
+         tap_file = 'tap_output.tap'
          option => options%at('tap_file')
          if (associated(option)) then
             call cast(option, tap_file)
-            use_tap = .true.
-         else
-            tap_file = 'tap_output.tap'
+            if (tap_file /= '') use_tap = .true.
          end if
          if (use_tap) call runner%add_listener(TapListener(tap_file))
       end block

--- a/src/funit/FUnit.F90
+++ b/src/funit/FUnit.F90
@@ -107,13 +107,21 @@ contains
          if (debug) call runner%add_listener(DebugListener(unit))
       end if
 
-      option => options%at('tap_file')
-      if (associated(option)) then
-         call cast(option, tap_file)
-         if (tap_file /= '') then
-            call runner%add_listener(TapListener(tap_file))
+      block
+         logical :: use_tap
+         use_tap = .false.
+         option => options%at('use_tap')
+         if (associated(option)) call cast(option, use_tap)
+         ! --tap-file alone also implies TAP output
+         option => options%at('tap_file')
+         if (associated(option)) then
+            call cast(option, tap_file)
+            use_tap = .true.
+         else
+            tap_file = 'tap_output.tap'
          end if
-      end if
+         if (use_tap) call runner%add_listener(TapListener(tap_file))
+      end block
 
 
 
@@ -392,9 +400,12 @@ contains
               & dest='n_skip', action='store', default=0, &
               & help='skip the first n_skip tests; only used with RemoteRunner')
 
-         call parser%add_argument('-t', '--tap', type='string', &
-              & dest='tap_file', action='store', default=0, &
-              & help='add a TAP listener and send results to file name')
+         call parser%add_argument('-t', '--tap', action='store_true', &
+              & dest='use_tap', &
+              & help='add a TAP listener (writes to tap_output.tap by default)')
+         call parser%add_argument('--tap-file', type='string', &
+              & dest='tap_file', action='store', default='tap_output.tap', &
+              & help='filename for TAP output (default: tap_output.tap; implies --tap)')
 
       call parser%add_argument('-x', '--xml', action='store_true', &
            & help='print results with XmlPrinter')

--- a/src/funit/FUnit.F90
+++ b/src/funit/FUnit.F90
@@ -404,7 +404,7 @@ contains
               & dest='use_tap', &
               & help='add a TAP listener (writes to tap_output.tap by default)')
          call parser%add_argument('--tap-file', type='string', &
-              & dest='tap_file', action='store', default='tap_output.tap', &
+              & dest='tap_file', action='store', &
               & help='filename for TAP output (default: tap_output.tap; implies --tap)')
 
       call parser%add_argument('-x', '--xml', action='store_true', &

--- a/src/funit/FUnit.F90
+++ b/src/funit/FUnit.F90
@@ -42,7 +42,6 @@ contains
       use pf_Test
       use pf_TestVector
       use pf_GlobFilter
-      use iso_fortran_env, only: error_unit
 #ifndef _WIN32
       use pf_RegexFilter
 #endif
@@ -63,7 +62,6 @@ contains
       integer :: n_skip
       character(:), allocatable :: ofile
       character(:), allocatable :: runner_class
-      character(:), allocatable :: tap_file
       class(AbstractPrinter), allocatable :: printer
 
       call set_command_line_options()
@@ -113,15 +111,7 @@ contains
          use_tap = .false.
          option => options%at('use_tap')
          if (associated(option)) call cast(option, use_tap)
-         ! --tapfile alone also implies TAP output
-         tap_file = 'tap_output.tap'
-         option => options%at('tapfile')
-         if (associated(option)) then
-            call cast(option, tap_file)
-            write(error_unit,'(a,a,a)') 'DEBUG: tap_file=[',tap_file,']'
-            if (tap_file /= '') use_tap = .true.
-         end if
-         if (use_tap) call runner%add_listener(TapListener(tap_file))
+         if (use_tap) call runner%add_listener(TapListener('tap_output.tap'))
       end block
 
 
@@ -403,10 +393,7 @@ contains
 
          call parser%add_argument('-t', '--tap', action='store_true', &
               & dest='use_tap', &
-              & help='add a TAP listener (writes to tap_output.tap by default)')
-         call parser%add_argument('--tapfile', type='string', &
-              & dest='tapfile', action='store', &
-              & help='filename for TAP output (default: tap_output.tap; implies --tap)')
+              & help='add a TAP listener; results written to tap_output.tap')
 
       call parser%add_argument('-x', '--xml', action='store_true', &
            & help='print results with XmlPrinter')


### PR DESCRIPTION
## Problem

The `-t`/`--tap` command line option crashed with a fatal memory allocation failure (and later segfault) in fArgParse when called with or without a filename argument. The root cause was that the option was registered as `action='store'` (expecting a string value on the command line) with `default=0` (an integer), causing a type mismatch crash in fArgParse's string handling.

Fixes #556

## Fix

Replace the `store` string option with a simple `store_true` boolean flag. TAP output is always written to `tap_output.tap` in the current directory.

**Before:**
```fortran
call parser%add_argument('-t', '--tap', type='string', &
     & dest='tap_file', action='store', default=0, &
     & help='add a TAP listener and send results to file name')
```

**After:**
```fortran
call parser%add_argument('-t', '--tap', action='store_true', &
     & dest='use_tap', &
     & help='add a TAP listener; results written to tap_output.tap')
```

**Usage:**
```sh
./tests.x --tap    # writes TAP results to tap_output.tap
```

Note: a filename argument was attempted (`--tap-file`/`--tapfile`) but fArgParse `store` string options appear broken with NVHPC — the value is never returned from `options%at()`. Keeping it simple with a fixed output filename for now.

## Also

Added missing `-x`/`--xml` and `-t`/`--tap` flags to the README command line options table.