### PR TITLE
Support ifx and ifort on Windows by branching debug and compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project (PFUNIT
-  VERSION 4.19.0
+  VERSION 4.20.0
   LANGUAGES Fortran C)
 
 cmake_policy(SET CMP0077 NEW)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,12 +5,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.20.0] - 2026-09-10
+
 ### Fixed
 
 - Support `ifx` and `ifort` compilers on Windows by branching debug and compiler flags
 
 ### Changed
 
+- Update submodule (fArgParse v1.12.0)
 - Update CI to match build matrix of GFE
 - Separate scheduled CI from pull-request CI
 - Update GitHub Actions to current major versions

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Support `ifx` and `ifort` compilers on Windows by branching debug and compiler flags
+
 ### Changed
 
 - Update CI to match build matrix of GFE

--- a/cmake/Intel.cmake
+++ b/cmake/Intel.cmake
@@ -3,19 +3,23 @@
 if(WIN32)
   set(no_optimize "-Od")
   set(check_all "-check:all")
+  set(debug_info "-Zi")
+  set(disable_warning_for_long_names "-Qdiag-disable:5462")
+  set(cpp "-fpp")
 else()
   set(no_optimize "-O0")
   set(check_all "-check all")
+  set(debug_info "-g")
+  set(disable_warning_for_long_names "-diag-disable 5462")
+  set(cpp "-cpp")
 endif()
 
 
-set(disable_warning_for_long_names "-diag-disable 5462")
 set(traceback "-traceback")
-set(cpp "-cpp")
 
 
 set(common_flags "${cpp} ${disable_warning_for_long_names}")
-set(CMAKE_Fortran_FLAGS_DEBUG  "-O0 -g ${common_flags} ${traceback} ${no_optimize} ${check_all}")
+set(CMAKE_Fortran_FLAGS_DEBUG  "${no_optimize} ${debug_info} ${common_flags} ${traceback} ${check_all}")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3 ${common_flags}")
 
 add_compile_definitions(_INTEL)

--- a/cmake/IntelLLVM.cmake
+++ b/cmake/IntelLLVM.cmake
@@ -3,19 +3,23 @@
 if(WIN32)
   set(no_optimize "-Od")
   set(check_all "-check:all")
+  set(debug_info "-Zi")
+  set(disable_warning_for_long_names "-Qdiag-disable:5462")
+  set(cpp "-fpp")
 else()
   set(no_optimize "-O0")
   set(check_all "-check all,nouninit")
+  set(debug_info "-g")
+  set(disable_warning_for_long_names "-diag-disable 5462")
+  set(cpp "-cpp")
 endif()
   
 
-set(disable_warning_for_long_names "-diag-disable 5462")
 set(traceback "-traceback")
-set(cpp "-cpp")
 
 
 set(common_flags "${cpp} ${disable_warning_for_long_names}")
-set(CMAKE_Fortran_FLAGS_DEBUG  "-O0 -g ${common_flags} ${traceback} ${no_optimize} ${check_all}")
+set(CMAKE_Fortran_FLAGS_DEBUG  "${no_optimize} ${debug_info} ${common_flags} ${traceback} ${check_all}")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3 ${common_flags}")
 
 add_definitions(-D_INTEL)


### PR DESCRIPTION
Cross-references: Goddard-Fortran-Ecosystem/yaFyaml#95, Goddard-Fortran-Ecosystem/fArgParse#168

### Summary

In `pFUnit`, `CMAKE_Fortran_FLAGS_DEBUG` hardcoded `-O0 -g`. On Windows with `ifx`/`ifort`, `-g` causes `option '/g' is ambiguous`, failing Debug builds. Additionally, the hardcoded `-O0` conflicted with `-Od` on Windows, and Windows variants for warning flags and preprocessor switches were missing.

This PR introduces platform-conditional flags:
- `debug_info`: `-Zi` on Windows, `-g` elsewhere
- `no_optimize`: `-Od` on Windows, `-O0` elsewhere
- `disable_warning_for_long_names`: `-Qdiag-disable:5462` on Windows, `-diag-disable 5462` elsewhere
- `cpp`: `-fpp` on Windows, `-cpp` elsewhere
- Deduplicates the redundant second `-O0` previously passed on Linux in Debug mode.

> **Important:** Linux flags do not change at all (aside from removing the harmless duplicate `-O0`).

### Compiler Flags Comparison

#### Linux (`ifx` / `ifort`)
* **Debug (`CMAKE_Fortran_FLAGS_DEBUG`):**
  `-O0 -g -cpp -diag-disable 5462 -traceback -check all,nouninit`
  *(Unchanged from before, with previous duplicate `-O0` removed)*
* **Release (`CMAKE_Fortran_FLAGS_RELEASE`):**
  `-O3 -cpp -diag-disable 5462`
  *(Unchanged from before)*

#### Windows (`ifx` / `ifort`)
* **Debug (`CMAKE_Fortran_FLAGS_DEBUG`):**
  `-Od -Zi -fpp -Qdiag-disable:5462 -traceback -check:all`
* **Release (`CMAKE_Fortran_FLAGS_RELEASE`):**
  `-O3 -fpp -Qdiag-disable:5462`

*(For classic `Intel.cmake`, `-check all` is used on Linux and `-check:all` on Windows).*