### PR TITLE
Skip command_line_filtering/shuffle_integration tests on Windows

### DIFF
--- a/tests/funit-core/CMakeLists.txt
+++ b/tests/funit-core/CMakeLists.txt
@@ -131,6 +131,12 @@ set_property (TEST old_tests
     PROPERTY FAIL_REGULAR_EXPRESSION "Encountered 1 or more failures/errors during testing"
     )
 
+# Command-line filtering and shuffle integration tests drive their
+# executables through a bash script; CreateProcess() cannot launch a
+# script directly on Windows (no shebang support), so skip them there,
+# as with Test_RegexFilter.pf above.
+if (NOT WIN32)
+
 # Command-line filtering tests
 add_pfunit_ctest (filter_cmdline_tests.x
   TEST_SOURCES FilterCommandLineTests.pf
@@ -162,6 +168,8 @@ add_test(NAME shuffle_integration
 set_tests_properties(shuffle_integration PROPERTIES
   DEPENDS shuffle_int_tests.x
 )
+
+endif ()
 
 
 


### PR DESCRIPTION
Fixes #568.

## Problem

`command_line_filtering` and `shuffle_integration` register their CTest entries with `add_test(COMMAND <path>/test_*.sh ...)`, invoking the `.sh` script directly. On Windows, `CreateProcess()` cannot launch a shell script this way (no shebang support), so both tests fail with `BAD_COMMAND` / "inappropriate file type or format" regardless of the actual filtering/shuffle logic being tested.

## Fix

Wrapped both test blocks in `tests/funit-core/CMakeLists.txt` with `if (NOT WIN32)`, the same pattern already used just above them to exclude `Test_RegexFilter.pf` on Windows.

## Testing

Reproduced and verified on Windows (MinGW gfortran 16.1.0) by building pFUnit standalone with its own test suite enabled (`ENABLE_TESTS` default when built as the top-level project):

- Before the fix: `ctest -R "command_line_filtering|shuffle_integration"` reproduced the exact failure from #568 — both tests `Not Run (BAD_COMMAND)` with "inappropriate file type or format".
- After the fix: `filter_cmdline_tests.x`/`shuffle_int_tests.x` are no longer built at all on Windows, and the two CTest entries no longer appear in the test list.
- Ran the full suite after the change: 29 tests execute with no new failures introduced by this change (18 pre-existing, unrelated failures remain in the vendored gFTL `test_derived_*` tests, tracked separately in [Goddard-Fortran-Ecosystem/gFTL#184](https://github.com/Goddard-Fortran-Ecosystem/gFTL/issues/184)).

---

Drafted with Claude's assistance.
- Reproduced the exact `BAD_COMMAND` failure from #568 on Windows before writing the fix, to confirm the root cause matched what the issue described.
- Rebuilt and reran the full CTest suite after the fix to confirm the two target tests are cleanly skipped and no other tests regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)