### PR TITLE
Escape backslashes when generating CTestCustom.cmake on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,11 @@ if (ENABLE_TESTS)
   # are EXCLUDE_FROM_ALL
   # From https://stackoverflow.com/questions/733475/cmake-ctest-make-test-doesnt-build-tests/56448477#56448477
   build_command(CTEST_CUSTOM_PRE_TEST TARGET build-tests)
+  # build_command() returns native (backslash) paths on Windows; ESCAPE_QUOTES
+  # below only escapes embedded quotes, not backslashes, so double them first
+  # or a path like C:\Users\... produces an invalid \U escape once written
+  # into the quoted string below.
+  string(REPLACE "\\" "\\\\" CTEST_CUSTOM_PRE_TEST "${CTEST_CUSTOM_PRE_TEST}")
   string(CONFIGURE \"@CTEST_CUSTOM_PRE_TEST@\" CTEST_CUSTOM_PRE_TEST_QUOTED ESCAPE_QUOTES)
   file(WRITE "${CMAKE_BINARY_DIR}/CTestCustom.cmake" "set(CTEST_CUSTOM_PRE_TEST ${CTEST_CUSTOM_PRE_TEST_QUOTED})" "\n")
 endif()


### PR DESCRIPTION
Fixes #567.

## Problem

The top-level `CMakeLists.txt` generates `CTestCustom.cmake` by running the result of `build_command()` through `string(CONFIGURE ... ESCAPE_QUOTES)` and writing it into a double-quoted `set(...)` string. `ESCAPE_QUOTES` only escapes embedded double quotes, not backslashes. On Windows, `build_command()` returns a native path (e.g. `C:\Users\...\cmake.exe`), so the generated file ends up with raw, unescaped backslashes inside a double-quoted CMake string. When CTest later parses that file, sequences like `\U` (from `...\Users\...`) are interpreted as invalid escape sequences, and `ctest` fails immediately with a CMake parse error before any test runs — not a cosmetic issue, a full functional regression on Windows.

## Fix

Added a `string(REPLACE "\\" "\\\\" ...)` step to double the backslashes in the `build_command()` output before it goes through the existing quote-escaping and gets written out.

## Testing

Verified on Windows (MinGW gfortran 16.1.0):

- Before the fix: `ctest` failed immediately with `CMake Error ... Invalid character escape '\U'` when parsing the generated `CTestCustom.cmake` — reproducing the exact error from #567. No tests could run.
- After the fix: `CTestCustom.cmake` now contains a correctly escaped path (`C:\Users\...`), and `ctest` runs to completion (33/33 tests execute). Remaining failures are pre-existing and unrelated to this change: `command_line_filtering`/`shuffle_integration` (tracked separately in #568/#569) and the vendored gFTL `test_derived_*` fixture-file issue ([Goddard-Fortran-Ecosystem/gFTL#184](https://github.com/Goddard-Fortran-Ecosystem/gFTL/issues/184)).

---

Drafted with Claude's assistance.
- Reproduced the exact parse failure from #567 on Windows before writing the fix, to confirm the root cause matched.
- Rebuilt and reran `ctest` after the fix to confirm it now parses `CTestCustom.cmake` correctly and runs the full suite, with no new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)