### PR TITLE
Add Windows CI workflow and fix script test execution on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,143 @@
+name: Windows CI Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "**.md"
+      - "**.MD"
+      - "LICENCE"
+      - "COPYRIGHT"
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Windows-GNU:
+    name: Windows / gfortran
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Set all directories as git safe
+        run: |
+          git config --global --add safe.directory '*'
+
+      - name: Install m4
+        run: choco install gnuwin32-m4 -y
+
+      - name: Set up Fortran (MinGW gfortran)
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: gcc
+
+      - name: Versions
+        run: |
+          gfortran --version
+          gcc --version
+          ninja --version
+          cmake --version
+
+      - name: Configure pFUnit
+        run: |
+          cmake -B build -G "Ninja" \
+            -DCMAKE_Fortran_COMPILER=gfortran \
+            -DCMAKE_C_COMPILER=gcc \
+            -DSKIP_MPI=YES \
+            -DSKIP_OPENMP=ON \
+            -DSKIP_ROBUST=YES \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/install"
+
+      - name: Build pFUnit
+        run: cmake --build build --parallel 4
+
+      - name: Build Tests target
+        run: |
+          cmake --build build --parallel 4 --target build-tests
+          cmake --build build --parallel 4 --target tests || true
+
+      - name: Run Ctest
+        run: ctest --test-dir build --parallel 4 --output-on-failure --repeat until-pass:4
+
+      - name: Archive log files on failure
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: logfiles-Windows-GNU
+          path: |
+            build/**/*.log
+
+  Windows-Intel:
+    name: Windows / ifx
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Set all directories as git safe
+        run: |
+          git config --global --add safe.directory '*'
+
+      - name: Install m4
+        run: choco install gnuwin32-m4 -y
+
+      - name: Set up Intel Fortran (ifx)
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: intel
+          version: "2025.3.2"
+
+      - name: Set up MSVC toolchain
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Versions
+        run: |
+          ifx --version
+          cl
+          ninja --version
+          cmake --version
+
+      - name: Configure pFUnit
+        run: |
+          cmake -B build -G "Ninja" \
+            -DCMAKE_Fortran_COMPILER=ifx \
+            -DCMAKE_C_COMPILER=cl \
+            -DSKIP_MPI=YES \
+            -DSKIP_OPENMP=ON \
+            -DSKIP_ROBUST=YES \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/install"
+
+      - name: Build pFUnit
+        run: cmake --build build --parallel 4
+
+      - name: Build Tests target
+        run: |
+          cmake --build build --parallel 4 --target build-tests
+          cmake --build build --parallel 4 --target tests || true
+
+      - name: Run Ctest
+        run: ctest --test-dir build --parallel 4 --output-on-failure --repeat until-pass:4
+
+      - name: Archive log files on failure
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: logfiles-Windows-Intel
+          path: |
+            build/**/*.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project (PFUNIT
-  VERSION 4.20.0
+  VERSION 4.20.1
   LANGUAGES Fortran C)
 
 cmake_policy(SET CMP0077 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,10 @@ if (MINGW)
   set(SKIP_ROBUST YES)
 endif ()
 
+if (WIN32)
+  add_compile_definitions(_WIN32)
+endif()
+
 
 if (NOT SKIP_MPI)
   find_package (MPI QUIET COMPONENTS Fortran)
@@ -173,6 +177,8 @@ if (ENABLE_TESTS)
   # are EXCLUDE_FROM_ALL
   # From https://stackoverflow.com/questions/733475/cmake-ctest-make-test-doesnt-build-tests/56448477#56448477
   build_command(CTEST_CUSTOM_PRE_TEST TARGET build-tests)
+  # Ensure forward slashes so Windows paths do not break CTestCustom.cmake syntax with unescaped backslashes
+  string(REPLACE "\\" "/" CTEST_CUSTOM_PRE_TEST "${CTEST_CUSTOM_PRE_TEST}")
   string(CONFIGURE \"@CTEST_CUSTOM_PRE_TEST@\" CTEST_CUSTOM_PRE_TEST_QUOTED ESCAPE_QUOTES)
   file(WRITE "${CMAKE_BINARY_DIR}/CTestCustom.cmake" "set(CTEST_CUSTOM_PRE_TEST ${CTEST_CUSTOM_PRE_TEST_QUOTED})" "\n")
 endif()

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Windows CI workflow for MinGW `gfortran` and Intel `ifx` (issue #568)
+
+### Fixed
+
+- Fix execution of `command_line_filtering` and `shuffle_integration` tests on Windows (issue #568)
+- Fix CMake syntax error in `CTestCustom.cmake` on Windows caused by unescaped backslashes in `build_command()` output
+
 ## [4.20.0] - 2026-09-10
 
 ### Fixed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.20.1] - 2026-09-11
+
 ### Added
 
 - Windows CI workflow for MinGW `gfortran` and Intel `ifx` (issue #568)

--- a/tests/funit-core/CMakeLists.txt
+++ b/tests/funit-core/CMakeLists.txt
@@ -138,14 +138,20 @@ add_pfunit_ctest (filter_cmdline_tests.x
 )
 add_dependencies(build-tests filter_cmdline_tests.x)
 
-add_test(NAME command_line_filtering
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_command_line_filtering.sh 
-          ${CMAKE_CURRENT_BINARY_DIR}/filter_cmdline_tests.x
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-)
-set_tests_properties(command_line_filtering PROPERTIES
-  DEPENDS filter_cmdline_tests.x
-)
+find_program(BASH_PROGRAM NAMES bash)
+
+if (BASH_PROGRAM)
+  add_test(NAME command_line_filtering
+    COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test_command_line_filtering.sh 
+            $<TARGET_FILE:filter_cmdline_tests.x>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+  set_tests_properties(command_line_filtering PROPERTIES
+    DEPENDS filter_cmdline_tests.x
+  )
+else()
+  message(STATUS "bash not found - skipping command_line_filtering test")
+endif()
 
 # Shuffle integration tests
 add_pfunit_ctest (shuffle_int_tests.x
@@ -154,14 +160,18 @@ add_pfunit_ctest (shuffle_int_tests.x
 )
 add_dependencies(build-tests shuffle_int_tests.x)
 
-add_test(NAME shuffle_integration
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_shuffle.sh
-          ${CMAKE_CURRENT_BINARY_DIR}/shuffle_int_tests.x
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-)
-set_tests_properties(shuffle_integration PROPERTIES
-  DEPENDS shuffle_int_tests.x
-)
+if (BASH_PROGRAM)
+  add_test(NAME shuffle_integration
+    COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test_shuffle.sh
+            $<TARGET_FILE:shuffle_int_tests.x>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+  set_tests_properties(shuffle_integration PROPERTIES
+    DEPENDS shuffle_int_tests.x
+  )
+else()
+  message(STATUS "bash not found - skipping shuffle_integration test")
+endif()
 
 
 

--- a/tests/funit-core/test_command_line_filtering.sh
+++ b/tests/funit-core/test_command_line_filtering.sh
@@ -5,8 +5,15 @@
 set -e  # Exit on error
 
 TEST_EXE="$1"
-if [ -z "$TEST_EXE" ] || [ ! -x "$TEST_EXE" ]; then
-    echo "ERROR: Test executable not provided or not executable: $TEST_EXE"
+if [ -z "$TEST_EXE" ]; then
+    echo "ERROR: Test executable not provided"
+    exit 1
+fi
+if [ ! -f "$TEST_EXE" ] && [ -f "${TEST_EXE}.exe" ]; then
+    TEST_EXE="${TEST_EXE}.exe"
+fi
+if [ ! -f "$TEST_EXE" ]; then
+    echo "ERROR: Test executable not found: $TEST_EXE"
     exit 1
 fi
 

--- a/tests/funit-core/test_command_line_filtering.sh
+++ b/tests/funit-core/test_command_line_filtering.sh
@@ -80,7 +80,7 @@ test_filter "Filter test_* exclude test_alpha_* (glob)" 2 -f "FilterCommandLineT
 test_filter "Exclude slow* and other* (glob)" 4 -e "FilterCommandLineTests_suite.*slow*" "FilterCommandLineTests_suite.*other*"
 
 # Unix-specific regex tests
-if [ "$(uname)" != "MINGW"* ] && [ "$(uname)" != "MSYS"* ]; then
+if [[ "$(uname)" != MINGW* && "$(uname)" != MSYS* ]]; then
     echo ""
     echo "Running Unix/Linux/macOS-specific regex tests..."
     

--- a/tests/funit-core/test_shuffle.sh
+++ b/tests/funit-core/test_shuffle.sh
@@ -4,8 +4,15 @@
 set -e  # Exit on error
 
 TEST_EXE="$1"
-if [ -z "$TEST_EXE" ] || [ ! -x "$TEST_EXE" ]; then
-    echo "ERROR: Test executable not provided or not executable: $TEST_EXE"
+if [ -z "$TEST_EXE" ]; then
+    echo "ERROR: Test executable not provided"
+    exit 1
+fi
+if [ ! -f "$TEST_EXE" ] && [ -f "${TEST_EXE}.exe" ]; then
+    TEST_EXE="${TEST_EXE}.exe"
+fi
+if [ ! -f "$TEST_EXE" ]; then
+    echo "ERROR: Test executable not found: $TEST_EXE"
     exit 1
 fi
 


### PR DESCRIPTION
## Description

Closes #568.

This PR adds a dedicated Windows CI workflow (`windows.yml`) testing `windows-latest` with MinGW `gfortran` and Intel `ifx`, and fixes test execution issues on Windows:

- **Fix test execution on Windows**: Tests `command_line_filtering` and `shuffle_integration` previously failed on Windows with `BAD_COMMAND` because `add_test` called the `.sh` scripts directly, which cannot be launched via Windows `CreateProcess`.
  - Used `find_program(BASH_PROGRAM NAMES bash)` and invoked tests via `${BASH_PROGRAM}`.
  - Used generator expression `$<TARGET_FILE:...>` so that `.exe` extension is included automatically on Windows.
  - Added executable path fallback in `test_command_line_filtering.sh` and `test_shuffle.sh` to inspect `${TEST_EXE}.exe` if `${TEST_EXE}` does not exist.
- **Fix `CTestCustom.cmake` syntax error on Windows**:
  - Sanitized backslashes in `CTEST_CUSTOM_PRE_TEST` with `string(REPLACE "\\" "/" ...)` so paths with spaces and Windows backslashes (e.g. `C:\Program Files\...`) do not trigger CMake syntax errors (`Invalid character escape '\P'`).
- **Define `_WIN32` on Windows**:
  - Added `add_compile_definitions(_WIN32)` when `WIN32` is true so that preprocessing macros are consistently active across both MinGW and Intel on Windows.
- **Add `.github/workflows/windows.yml`**:
  - Sets up `Windows-GNU` (MinGW gfortran via `fortran-lang/setup-fortran@v1`) and `Windows-Intel` (Intel ifx via `fortran-lang/setup-fortran@v1` + `ilammy/msvc-dev-cmd@v1`).
  - Installs `gnuwin32-m4` via Chocolatey.
  - Builds and tests without MPI (`-DSKIP_MPI=YES`).
