### PR TITLE
Define _WIN32 via CMake WIN32 so FUnit.F90's preprocessor guard matches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,15 @@ if (MINGW)
   set(SKIP_ROBUST YES)
 endif ()
 
+# gfortran does not predefine the _WIN32 preprocessor macro on any platform
+# (unlike MSVC/Intel), but Fortran sources such as FUnit.F90 use #ifndef
+# _WIN32 guards that need to agree with CMake's own WIN32-gated source
+# exclusions (e.g. src/funit/core/CMakeLists.txt). Define it explicitly so
+# both stay consistent regardless of compiler.
+if (WIN32)
+  add_compile_definitions(_WIN32)
+endif ()
+
 
 if (NOT SKIP_MPI)
   find_package (MPI QUIET COMPONENTS Fortran)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Define `_WIN32` via CMake's `WIN32` variable so `FUnit.F90`'s `#ifndef _WIN32` guard around `pf_RegexFilter` agrees with `core/CMakeLists.txt`'s CMake-driven exclusion of `RegexFilter.F90` on Windows, fixing a standalone Windows/gfortran build failure (issue #566)
+
 ## [4.20.0] - 2026-09-10
 
 ### Fixed


### PR DESCRIPTION
## Summary

Fixes the standalone Windows/gfortran build failure described in #566.

## Problem

`src/funit/FUnit.F90` guards `use pf_RegexFilter` (and the later `RegexFilter(...)` call) with `#ifndef _WIN32`, assuming `_WIN32` is predefined by the compiler on Windows. gfortran never predefines `_WIN32` on any platform, so that guard compiles the `use` statement in on Windows too. Meanwhile `src/funit/core/CMakeLists.txt` separately excludes `RegexFilter.F90` (and its dependencies) from the Windows source list via CMake's own `if(NOT WIN32)`. The two checks disagree, so the module `FUnit.F90` needs is never built, and the build fails with a missing `.mod` file.

## Fix

Added a small block to the top-level `CMakeLists.txt`, right after the existing MinGW-skip block, that defines `_WIN32` project-wide whenever CMake's own `WIN32` is true:

```cmake
if (WIN32)
  add_compile_definitions(_WIN32)
endif ()
```

This keeps the Fortran preprocessor guard and the CMake-side source exclusion consistent regardless of which Windows Fortran compiler is used, without touching the solver/test logic itself. Also added a `ChangeLog.md` entry under `[Unreleased]`.

## Testing

Verified locally with a full clean build (`rm -rf build && cmake -S . -B build -G Ninja ... && cmake --build build`) using gfortran on Windows 11: all 1457/1457 build steps succeeded, including `FUnit.F90.obj` and the final `libfunit.a` link, with no `-D_WIN32` workaround flag needed on the `cmake` command line. Confirmed `-D_WIN32` is present in the generated `build.ninja` `DEFINES` for the relevant targets. Reverting the fix reproduces the original error from #566 exactly. pFUnit's own test suite (398 tests across `funit_tests.x`, `new_tests.x`, `filter_cmdline_tests.x`, `fhamcrest_tests.x`) passes with the fix applied.

Also ran the full CI matrix on this change via a fork PR before opening this one: all 15 jobs passed (Flang, Intel Fortran, Nvidia-build-only, 5x Ubuntu/gfortran, 6x macOS/gfortran) - https://github.com/djkees/pFUnit/actions/runs/34508645644

Opened as a draft since this repository limits non-write-access contributors to 2 open PRs at a time; will mark ready once #569/#570 clear.

---

Drafted with Claude's assistance.

- Root cause identified by reading `FUnit.F90` and `core/CMakeLists.txt` directly, not assumed.
- Fix verified by rebuilding from a clean `build/` directory, reproducing the original failure by reverting the change, running pFUnit's own test suite, and running the fork's full CI build matrix - all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)